### PR TITLE
Improve shared business-rules and add concession/permit validation

### DIFF
--- a/packages/business-rules-lib/src/index.js
+++ b/packages/business-rules-lib/src/index.js
@@ -1,6 +1,7 @@
 import * as contactValidation from './validators/contact.js'
 import * as permissionValidation from './validators/permission.js'
 
+export * from './util/ages.js'
 export const validation = {
   contact: contactValidation,
   permission: permissionValidation

--- a/packages/business-rules-lib/src/util/__tests__/ages.spec.js
+++ b/packages/business-rules-lib/src/util/__tests__/ages.spec.js
@@ -1,0 +1,23 @@
+import { isMinor, isJunior, isSenior, MINOR_MAX_AGE, JUNIOR_MAX_AGE, SENIOR_MIN_AGE } from '../ages.js'
+
+describe('age determination', () => {
+  describe('isMinor', () => {
+    it(`allows ages less than or equal to ${MINOR_MAX_AGE}`, async () => {
+      expect(isMinor(MINOR_MAX_AGE)).toBeTruthy()
+    })
+  })
+  describe('isJunior', () => {
+    it(`allows ages less than or equal to ${JUNIOR_MAX_AGE} but greater than ${MINOR_MAX_AGE}`, async () => {
+      expect(isJunior(JUNIOR_MAX_AGE)).toBeTruthy()
+      expect(isJunior(MINOR_MAX_AGE + 1)).toBeTruthy()
+      expect(isJunior(MINOR_MAX_AGE)).toBeFalsy()
+    })
+  })
+
+  describe('isSenior', () => {
+    it(`allows ages greater than or equal to ${SENIOR_MIN_AGE}`, async () => {
+      expect(isSenior(SENIOR_MIN_AGE)).toBeTruthy()
+      expect(isSenior(SENIOR_MIN_AGE - 1)).toBeFalsy()
+    })
+  })
+})

--- a/packages/business-rules-lib/src/util/ages.js
+++ b/packages/business-rules-lib/src/util/ages.js
@@ -1,0 +1,27 @@
+/** The maximum age at which an angler is considered to be a minor (free licence) */
+export const MINOR_MAX_AGE = 12
+/** The maximum age at which an angler is entitled to a junior concession */
+export const JUNIOR_MAX_AGE = 16
+/** The minimum age at which an angler becomes entitled to a senior concession */
+export const SENIOR_MIN_AGE = 65
+
+/**
+ * Determine if the provided age is classified as a minor
+ * @param {number} age The age to be tested
+ * @returns {boolean} true if the given age should be classified as a minor
+ */
+export const isMinor = age => age <= MINOR_MAX_AGE
+
+/**
+ * Determine if the provided age is classified as a junior
+ * @param {number} age The age to be tested
+ * @returns {boolean} true if the given age should be classified as a junior
+ */
+export const isJunior = age => age > MINOR_MAX_AGE && age <= JUNIOR_MAX_AGE
+
+/**
+ * Determine if the provided age is classified as a senior
+ * @param {number} age The age to be tested
+ * @returns {boolean} true if the given age should be classified as a senior
+ */
+export const isSenior = age => age >= SENIOR_MIN_AGE

--- a/packages/business-rules-lib/src/validators/__tests__/contact.spec.js
+++ b/packages/business-rules-lib/src/validators/__tests__/contact.spec.js
@@ -27,7 +27,7 @@ describe('contact validators', () => {
       await expect(contactValidation.birthDateValidator.validateAsync('1-111-19')).rejects.toThrow('"value" must be in [YYYY-MM-DD] format')
     })
 
-    it("throws if given tommorows's date", async () => {
+    it("throws if given tommorow's date", async () => {
       await expect(
         contactValidation.birthDateValidator.validateAsync(
           moment()
@@ -50,34 +50,103 @@ describe('contact validators', () => {
   })
 
   describe('firstNameValidator', () => {
-    it('allows and trims premises', async () => {
-      await expect(contactValidation.firstNameValidator.validateAsync(' John ')).resolves.toEqual('JOHN')
+    describe('converts to title case', () => {
+      each([
+        [' mIchael-hArrY ', 'Michael-Harry'],
+        [' érmintrùdé ', 'Érmintrùdé']
+      ]).it('converts %s to %s', async (name, expected) => {
+        await expect(contactValidation.firstNameValidator.validateAsync(name)).resolves.toEqual(expected)
+      })
     })
 
-    it('throws on empty premises', async () => {
+    describe('allows specific punctuation characters', () => {
+      each("'-".split('')).it('allows the %s character', async c => {
+        await expect(contactValidation.firstNameValidator.validateAsync(`Test${c}`)).resolves.toEqual(`Test${c}`)
+      })
+    })
+
+    describe('does not allow banned characters', () => {
+      each('!@£$%^&()+*/{}[];":;|\\?<>§±`~0123456789'.split('')).it('does not allow the %s character', async c => {
+        await expect(contactValidation.firstNameValidator.validateAsync(c)).rejects.toThrow('contains forbidden characters')
+      })
+    })
+
+    it('allows and trims forenames', async () => {
+      await expect(contactValidation.firstNameValidator.validateAsync(' John ')).resolves.toEqual('John')
+    })
+
+    it('throws on empty forenames', async () => {
       await expect(contactValidation.firstNameValidator.validateAsync('')).rejects.toThrow('"value" is not allowed to be empty')
     })
 
-    it('throws where the name is over 100 characters', async () => {
+    it('throws where the name exceeds the maximum allowed length', async () => {
       await expect(contactValidation.firstNameValidator.validateAsync('A'.repeat(101))).rejects.toThrow(
         '"value" length must be less than or equal to 100 characters long'
       )
     })
 
-    it('throws where the name a single character', async () => {
+    it('throws where the name is a single character', async () => {
       await expect(contactValidation.firstNameValidator.validateAsync('A')).rejects.toThrow(
         '"value" length must be at least 2 characters long'
       )
     })
 
-    it('It allows a range of unicode characters from plane 1', async () => {
-      const internationStr = 'Æçéñøķť'
-      await expect(contactValidation.firstNameValidator.validateAsync(internationStr)).resolves.toEqual('ÆÇÉÑØĶŤ')
+    it('allows a range of unicode characters from plane 1', async () => {
+      const internationStr = 'ÆÇÉÑØĶŤ'
+      await expect(contactValidation.firstNameValidator.validateAsync(internationStr)).resolves.toEqual('Æçéñøķť')
+    })
+  })
+
+  describe('lastNameValidator', () => {
+    describe('converts to title case', () => {
+      each([
+        [' SMITH-JONES ', 'Smith-Jones'],
+        ['smith-jones', 'Smith-Jones'],
+        ['smythé', 'Smythé'],
+        ["O'DELL", "O'Dell"],
+        ['mcdonald', 'McDonald'],
+        ['macdonald', 'Macdonald'],
+        ['macy', 'Macy'],
+        ['van doorn', 'van Doorn'],
+        ['de vries', 'de Vries'],
+        ['van der waals', 'van der Waals'],
+        ['van den heuvel', 'van den Heuvel']
+      ]).it('converts %s to %s', async (name, expected) => {
+        await expect(contactValidation.lastNameValidator.validateAsync(name)).resolves.toEqual(expected)
+      })
     })
 
-    it('It does not allow numbers', async () => {
-      const nbrStr = '123'
-      await expect(contactValidation.firstNameValidator.validateAsync(nbrStr)).rejects.toThrow('contains forbidden characters')
+    describe('allows specific punctuation characters', () => {
+      each("'-".split('')).it('allows the %s character', async c => {
+        await expect(contactValidation.lastNameValidator.validateAsync(`Test${c}`)).resolves.toEqual(`Test${c}`)
+      })
+    })
+
+    describe('does not allow banned characters', () => {
+      each('!@£$%^&()+*/{}[];":;|\\?<>§±`~0123456789'.split('')).it('does not allow the %s character', async c => {
+        await expect(contactValidation.lastNameValidator.validateAsync(c)).rejects.toThrow('contains forbidden characters')
+      })
+    })
+
+    it('throws on empty last names', async () => {
+      await expect(contactValidation.lastNameValidator.validateAsync('')).rejects.toThrow('"value" is not allowed to be empty')
+    })
+
+    it('throws where the name exceeds the maximum allowed length', async () => {
+      await expect(contactValidation.lastNameValidator.validateAsync('A'.repeat(101))).rejects.toThrow(
+        '"value" length must be less than or equal to 100 characters long'
+      )
+    })
+
+    it('throws where the name is a single character', async () => {
+      await expect(contactValidation.lastNameValidator.validateAsync('A')).rejects.toThrow(
+        '"value" length must be at least 2 characters long'
+      )
+    })
+
+    it('allows a range of unicode characters from plane 1', async () => {
+      const internationStr = 'ÆÇÉÑØĶŤ'
+      await expect(contactValidation.lastNameValidator.validateAsync(internationStr)).resolves.toEqual('Æçéñøķť')
     })
   })
 
@@ -113,64 +182,80 @@ describe('contact validators', () => {
 
   describe('premisesValidator', () => {
     it('allows and trims premises', async () => {
-      await expect(contactValidation.premisesValidator.validateAsync(' 15 Rose Cottage ')).resolves.toEqual('15 ROSE COTTAGE')
+      await expect(contactValidation.premisesValidator.validateAsync(' 15 ROSE COTTAGE ')).resolves.toEqual('15 Rose Cottage')
     })
 
     it('throws on empty premises', async () => {
       await expect(contactValidation.premisesValidator.validateAsync('')).rejects.toThrow('"value" is not allowed to be empty')
     })
 
-    it('throws where the premises is over 50 characters', async () => {
-      await expect(contactValidation.premisesValidator.validateAsync('A'.repeat(51))).rejects.toThrow(
-        '"value" length must be less than or equal to 50 characters long'
+    it('throws where the premises exceeds the maximum allowed length', async () => {
+      await expect(contactValidation.premisesValidator.validateAsync('A'.repeat(101))).rejects.toThrow(
+        '"value" length must be less than or equal to 100 characters long'
       )
     })
   })
 
   describe('streetValidator', () => {
     it('allows and trims street', async () => {
-      await expect(contactValidation.streetValidator.validateAsync(' Bond Street ')).resolves.toEqual('BOND STREET')
+      await expect(contactValidation.streetValidator.validateAsync(' BOND STREET ')).resolves.toEqual('Bond Street')
     })
 
     it('allows empty street', async () => {
       await expect(contactValidation.streetValidator.validateAsync('')).resolves.toBeFalsy()
     })
 
-    it('throws where the street is over 50 characters', async () => {
-      await expect(contactValidation.streetValidator.validateAsync('A'.repeat(51))).rejects.toThrow(
-        '"value" length must be less than or equal to 50 characters long'
+    it('throws where the street exceeds the maximum allowed length', async () => {
+      await expect(contactValidation.streetValidator.validateAsync('A'.repeat(101))).rejects.toThrow(
+        '"value" length must be less than or equal to 100 characters long'
       )
     })
   })
 
   describe('localityValidator', () => {
     it('allows and trims locality', async () => {
-      await expect(contactValidation.localityValidator.validateAsync(' Mayfair ')).resolves.toEqual('MAYFAIR')
+      await expect(contactValidation.localityValidator.validateAsync(' MAYFAIR ')).resolves.toEqual('Mayfair')
     })
 
     it('allows empty locality', async () => {
       await expect(contactValidation.localityValidator.validateAsync('')).resolves.toBeFalsy()
     })
 
-    it('throws where the locality is over 50 characters', async () => {
-      await expect(contactValidation.localityValidator.validateAsync('A'.repeat(51))).rejects.toThrow(
-        '"value" length must be less than or equal to 50 characters long'
+    it('throws where the locality exceeds the maximum allowed length', async () => {
+      await expect(contactValidation.localityValidator.validateAsync('A'.repeat(101))).rejects.toThrow(
+        '"value" length must be less than or equal to 100 characters long'
       )
     })
   })
 
   describe('townValidator', () => {
+    describe('converts to title case', () => {
+      each([
+        ['lOndon', 'London'],
+        ['newcastle upon tyne', 'Newcastle upon Tyne'],
+        ['wotton-under-edge', 'Wotton-under-Edge'],
+        ['barrow-in-ferness', 'Barrow-in-Ferness'],
+        ['stoke-on-trent', 'Stoke-on-Trent'],
+        ['sutton cum lound', 'Sutton cum Lound'],
+        ['wells-next-the-sea', 'Wells-next-the-Sea'],
+        ['chapel-en-le-frith', 'Chapel-en-le-Frith'],
+        ['puddleby-on-the-marsh', 'Puddleby-on-the-Marsh']
+      ]).it('converts %s to %s', async (name, expected) => {
+        await expect(contactValidation.townValidator.validateAsync(name)).resolves.toEqual(expected)
+      })
+    })
+
     it('allows and trims town', async () => {
-      await expect(contactValidation.townValidator.validateAsync(' london ')).resolves.toEqual('LONDON')
+      await expect(contactValidation.townValidator.validateAsync(' LONDON ')).resolves.toEqual('London')
     })
 
     it('throws on empty town', async () => {
       await expect(contactValidation.townValidator.validateAsync('')).rejects.toThrow('"value" is not allowed to be empty')
     })
 
-    it('throws where the town is over 50 characters', async () => {
-      await expect(contactValidation.townValidator.validateAsync('A'.repeat(51))).rejects.toThrow(
-        '"value" length must be less than or equal to 50 characters long'
+    it('throws where the town exceeds the maximum allowed length', async () => {
+      await expect(contactValidation.townValidator.validateAsync('A'.repeat(101))).rejects.toThrow(
+        '"value" length must be less than or equal to 100 characters long'
       )
     })
   })

--- a/packages/business-rules-lib/src/validators/__tests__/contact.spec.js
+++ b/packages/business-rules-lib/src/validators/__tests__/contact.spec.js
@@ -239,7 +239,8 @@ describe('contact validators', () => {
         ['sutton cum lound', 'Sutton cum Lound'],
         ['wells-next-the-sea', 'Wells-next-the-Sea'],
         ['chapel-en-le-frith', 'Chapel-en-le-Frith'],
-        ['puddleby-on-the-marsh', 'Puddleby-on-the-Marsh']
+        ['puddleby-on-the-marsh', 'Puddleby-on-the-Marsh'],
+        ['weston-super-mare', 'Weston-super-Mare']
       ]).it('converts %s to %s', async (name, expected) => {
         await expect(contactValidation.townValidator.validateAsync(name)).resolves.toEqual(expected)
       })

--- a/packages/business-rules-lib/src/validators/contact.js
+++ b/packages/business-rules-lib/src/validators/contact.js
@@ -117,7 +117,7 @@ export const localityValidator = Joi.string()
 export const townValidator = Joi.string()
   .trim()
   .max(100)
-  .external(toTitleCase(['under', 'upon', 'in', 'on', 'cum', 'next', 'the', 'en', 'le']))
+  .external(toTitleCase(['under', 'upon', 'in', 'on', 'cum', 'next', 'the', 'en', 'le', 'super']))
   .required()
   .example('Exampleton')
 

--- a/packages/dynamics-lib/src/entities/__tests__/recurring-payment-instruction.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/recurring-payment-instruction.entity.spec.js
@@ -10,15 +10,13 @@ describe('recurring payment entity', () => {
     const instruction = RecurringPaymentInstruction.fromResponse(
       {
         '@odata.etag': 'W/"53585154"',
-        defra_recurringpaymentinstructionid: 'bfb24adf-2e83-ea11-a811-000d3a649213',
-        defra_name: '18569ba8-094e-4e8c-9911-bfedd5ccc17a'
+        defra_recurringpaymentinstructionid: 'bfb24adf-2e83-ea11-a811-000d3a649213'
       },
       optionSetData
     )
 
     const expectedFields = {
-      id: 'bfb24adf-2e83-ea11-a811-000d3a649213',
-      referenceNumber: '18569ba8-094e-4e8c-9911-bfedd5ccc17a'
+      id: 'bfb24adf-2e83-ea11-a811-000d3a649213'
     }
 
     expect(instruction).toBeInstanceOf(RecurringPaymentInstruction)
@@ -33,7 +31,6 @@ describe('recurring payment entity', () => {
     const recurringPayment = new RecurringPayment()
 
     const instruction = new RecurringPaymentInstruction()
-    instruction.referenceNumber = 'Test Reference Number'
     instruction.bindToContact(contact)
     instruction.bindToPermit(permit)
     instruction.bindToRecurringPayment(recurringPayment)
@@ -41,7 +38,6 @@ describe('recurring payment entity', () => {
     const dynamicsEntity = instruction.toRequestBody()
     expect(dynamicsEntity).toMatchObject(
       expect.objectContaining({
-        defra_name: 'Test Reference Number',
         'defra_Contact@odata.bind': `$${contact.uniqueContentId}`,
         'defra_Permit@odata.bind': `$${permit.uniqueContentId}`,
         'defra_RecurringPayment@odata.bind': `$${recurringPayment.uniqueContentId}`

--- a/packages/dynamics-lib/src/entities/recurring-payment-instruction.entity.js
+++ b/packages/dynamics-lib/src/entities/recurring-payment-instruction.entity.js
@@ -11,8 +11,7 @@ export class RecurringPaymentInstruction extends BaseEntity {
     dynamicsCollection: 'defra_recurringpaymentinstructions',
     defaultFilter: 'statecode eq 0',
     mappings: {
-      id: { field: 'defra_recurringpaymentinstructionid', type: 'string' },
-      referenceNumber: { field: 'defra_name', type: 'string' }
+      id: { field: 'defra_recurringpaymentinstructionid', type: 'string' }
     }
   })
 
@@ -22,18 +21,6 @@ export class RecurringPaymentInstruction extends BaseEntity {
    */
   static get definition () {
     return RecurringPaymentInstruction._definition
-  }
-
-  /**
-   * The reference number associated with the recurring payment instruction
-   * @type {string}
-   */
-  get referenceNumber () {
-    return super._getState('referenceNumber')
-  }
-
-  set referenceNumber (referenceNumber) {
-    super._setState('referenceNumber', referenceNumber)
   }
 
   /**

--- a/packages/gafl-webapp-service/package.json
+++ b/packages/gafl-webapp-service/package.json
@@ -44,7 +44,6 @@
     "@hapi/joi": "^17.1.1",
     "@hapi/joi-date": "^2.0.1",
     "@hapi/vision": "^6.0.0",
-    "camelcase": "^6.0.0",
     "debug": "^4.1.1",
     "find": "^0.3.0",
     "govuk-frontend": "^3.6.0",

--- a/packages/gafl-webapp-service/src/pages/contact/address/entry/__tests__/address-entry-spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/entry/__tests__/address-entry-spec.js
@@ -36,7 +36,7 @@ describe('The manual address entry page', () => {
 
   it('redirects back to itself on posting too long premises', async () => {
     const addr = Object.assign({}, goodAddress)
-    addr.premises = 'A'.repeat(51)
+    addr.premises = 'A'.repeat(101)
     const data = await injectWithCookie('POST', ADDRESS_ENTRY.uri, addr)
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(ADDRESS_ENTRY.uri)
@@ -44,7 +44,7 @@ describe('The manual address entry page', () => {
 
   it('redirects back to itself on posting too long street', async () => {
     const addr = Object.assign({}, goodAddress)
-    addr.street = 'A'.repeat(51)
+    addr.street = 'A'.repeat(101)
     const data = await injectWithCookie('POST', ADDRESS_ENTRY.uri, addr)
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(ADDRESS_ENTRY.uri)
@@ -52,7 +52,7 @@ describe('The manual address entry page', () => {
 
   it('redirects back to itself on posting too long locality', async () => {
     const addr = Object.assign({}, goodAddress)
-    addr.locality = 'A'.repeat(51)
+    addr.locality = 'A'.repeat(101)
     const data = await injectWithCookie('POST', ADDRESS_ENTRY.uri, addr)
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(ADDRESS_ENTRY.uri)
@@ -68,7 +68,7 @@ describe('The manual address entry page', () => {
 
   it('redirects back to itself on posting too long town', async () => {
     const addr = Object.assign({}, goodAddress)
-    addr.town = 'A'.repeat(51)
+    addr.town = 'A'.repeat(101)
     const data = await injectWithCookie('POST', ADDRESS_ENTRY.uri, addr)
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(ADDRESS_ENTRY.uri)
@@ -100,9 +100,9 @@ describe('The manual address entry page', () => {
   it('The contact information has been set in the transaction', async () => {
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
     expect(JSON.parse(payload).permissions[0].licensee).toEqual({
-      premises: '14 HOWECROFT COURT',
-      street: 'EASTMEAD LANE',
-      town: 'BRISTOL',
+      premises: '14 Howecroft Court',
+      street: 'Eastmead Lane',
+      town: 'Bristol',
       postcode: 'BS9 1HJ',
       countryCode: 'GB'
     })
@@ -120,9 +120,9 @@ describe('The manual address entry page', () => {
   it('The contact information has been set in the transaction', async () => {
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
     expect(JSON.parse(payload).permissions[0].licensee).toEqual({
-      premises: '14 HOWECROFT COURT',
-      street: 'EASTMEAD LANE',
-      town: 'BRISTOL',
+      premises: '14 Howecroft Court',
+      street: 'Eastmead Lane',
+      town: 'Bristol',
       postcode: 'not checked',
       countryCode: 'FR'
     })

--- a/packages/gafl-webapp-service/src/pages/contact/address/lookup/__tests__/address-lookup.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/lookup/__tests__/address-lookup.spec.js
@@ -42,7 +42,7 @@ describe('The address lookup page', () => {
   })
 
   it('redirects back to itself on posting a too long premises', async () => {
-    const data = await injectWithCookie('POST', ADDRESS_LOOKUP.uri, { premises: 'a'.repeat(51), postcode: 'BS9 1HJ' })
+    const data = await injectWithCookie('POST', ADDRESS_LOOKUP.uri, { premises: 'a'.repeat(101), postcode: 'BS9 1HJ' })
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(ADDRESS_LOOKUP.uri)
   })

--- a/packages/gafl-webapp-service/src/pages/contact/date-of-birth/__tests__/date-of-birth.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/date-of-birth/__tests__/date-of-birth.spec.js
@@ -12,22 +12,23 @@ import {
   LICENCE_SUMMARY,
   BENEFIT_CHECK
 } from '../../../../constants.js'
+import { MINOR_MAX_AGE, JUNIOR_MAX_AGE, SENIOR_MIN_AGE } from '@defra-fish/business-rules-lib'
 
 beforeAll(d => start(d))
 beforeAll(d => initialize(d))
 afterAll(d => stop(d))
 
-const dob13Today = moment().add(-13, 'years')
-const dob13Tomorrow = moment()
-  .add(-13, 'years')
+const dobJuniorToday = moment().subtract(MINOR_MAX_AGE + 1, 'years')
+const dobJuniorTomorrow = moment()
+  .subtract(MINOR_MAX_AGE + 1, 'years')
   .add(1, 'day')
-const dob16Today = moment().add(-16, 'years')
-const dob16Tomorrow = moment()
-  .add(-16, 'years')
+const dobAdultToday = moment().subtract(JUNIOR_MAX_AGE + 1, 'years')
+const dobAdultTomorrow = moment()
+  .subtract(JUNIOR_MAX_AGE + 1, 'years')
   .add(1, 'day')
-const dob65Today = moment().add(-65, 'years')
-const dob65Tomorrow = moment()
-  .add(-65, 'years')
+const dobSeniorToday = moment().add(-SENIOR_MIN_AGE, 'years')
+const dobSeniorTomorrow = moment()
+  .add(-SENIOR_MIN_AGE, 'years')
   .add(1, 'day')
 
 const dobHelper = d => ({
@@ -80,86 +81,86 @@ describe('The date of birth page', () => {
   /*
    * These tests are for licences starting today
    */
-  it(`my licence starts immediately after payment, my date of birth is ${dob13Tomorrow.format(
+  it(`my licence starts immediately after payment, my date of birth is ${dobJuniorTomorrow.format(
     'YYYY-MM-DD'
   )} and I do not require a fishing licence`, async () => {
     await postRedirectGet(LICENCE_TO_START.uri, { 'licence-to-start': 'after-payment' })
-    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob13Tomorrow))
+    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobJuniorTomorrow))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(NO_LICENCE_REQUIRED.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
-    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dob13Tomorrow.format('YYYY-MM-DD'))
+    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dobJuniorTomorrow.format('YYYY-MM-DD'))
     expect(JSON.parse(payload).permissions[0].licensee.noLicenceRequired).toBeTruthy()
   })
 
-  it(`my licence starts immediately after payment, my date of birth is ${dob13Today.format(
+  it(`my licence starts immediately after payment, my date of birth is ${dobJuniorToday.format(
     'YYYY-MM-DD'
   )} and I require a junior 12 month fishing licence`, async () => {
     await postRedirectGet(LICENCE_TO_START.uri, { 'licence-to-start': 'after-payment' })
     await postRedirectGet(LICENCE_LENGTH.uri, { 'licence-length': '1D' })
-    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob13Today))
+    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobJuniorToday))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(JUNIOR_LICENCE.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
-    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dob13Today.format('YYYY-MM-DD'))
+    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dobJuniorToday.format('YYYY-MM-DD'))
     expect(JSON.parse(payload).permissions[0].licensee.noLicenceRequired).not.toBeTruthy()
     expect(concessionHelper.hasJunior(JSON.parse(payload).permissions[0].licensee)).toBeTruthy()
     expect(JSON.parse(payload).permissions[0].licenceLength).toBe('12M')
   })
 
-  it(`my licence starts immediately after payment, my date of birth is ${dob16Tomorrow.format(
+  it(`my licence starts immediately after payment, my date of birth is ${dobAdultTomorrow.format(
     'YYYY-MM-DD'
   )} and I require a 12 month fishing licence and with a junior concession`, async () => {
     await postRedirectGet(LICENCE_TO_START.uri, { 'licence-to-start': 'after-payment' })
-    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob16Tomorrow))
+    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobAdultTomorrow))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(JUNIOR_LICENCE.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
-    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dob16Tomorrow.format('YYYY-MM-DD'))
+    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dobAdultTomorrow.format('YYYY-MM-DD'))
     expect(concessionHelper.hasJunior(JSON.parse(payload).permissions[0].licensee)).toBeTruthy()
     expect(JSON.parse(payload).permissions[0].licensee.noLicenceRequired).not.toBeTruthy()
   })
 
-  it(`my licence starts immediately after payment, my date of birth is ${dob16Today.format(
+  it(`my licence starts immediately after payment, my date of birth is ${dobAdultToday.format(
     'YYYY-MM-DD'
   )} and I require an adult fishing licence`, async () => {
     await postRedirectGet(LICENCE_TO_START.uri, { 'licence-to-start': 'after-payment' })
     await postRedirectGet(LICENCE_LENGTH.uri, { 'licence-length': '1D' })
-    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob16Today))
+    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobAdultToday))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(LICENCE_SUMMARY.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
-    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dob16Today.format('YYYY-MM-DD'))
+    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dobAdultToday.format('YYYY-MM-DD'))
     expect(JSON.parse(payload).permissions[0].licensee.noLicenceRequired).not.toBeTruthy()
     expect(JSON.parse(payload).permissions[0].licensee.concessions.length).toBe(0)
     expect(JSON.parse(payload).permissions[0].licenceLength).toBe('1D')
   })
 
-  it(`my licence starts immediately after payment, my date of birth is ${dob65Tomorrow.format(
+  it(`my licence starts immediately after payment, my date of birth is ${dobSeniorTomorrow.format(
     'YYYY-MM-DD'
   )} and I require an adult fishing licence`, async () => {
     await postRedirectGet(LICENCE_TO_START.uri, { 'licence-to-start': 'after-payment' })
     await postRedirectGet(LICENCE_LENGTH.uri, { 'licence-length': '1D' })
-    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob65Tomorrow))
+    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobSeniorTomorrow))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(LICENCE_SUMMARY.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
-    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dob65Tomorrow.format('YYYY-MM-DD'))
+    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dobSeniorTomorrow.format('YYYY-MM-DD'))
     expect(JSON.parse(payload).permissions[0].licensee.noLicenceRequired).not.toBeTruthy()
     expect(JSON.parse(payload).permissions[0].licensee.concessions.length).toBe(0)
     expect(JSON.parse(payload).permissions[0].licenceLength).toBe('1D')
   })
 
-  it(`my licence starts immediately after payment, my date of birth is ${dob65Today.format(
+  it(`my licence starts immediately after payment, my date of birth is ${dobSeniorToday.format(
     'YYYY-MM-DD'
   )} and I am entitled to a senior concession`, async () => {
     await postRedirectGet(LICENCE_TO_START.uri, { 'licence-to-start': 'after-payment' })
     await postRedirectGet(LICENCE_LENGTH.uri, { 'licence-length': '1D' })
-    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob65Today))
+    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobSeniorToday))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(LICENCE_SUMMARY.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
-    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dob65Today.format('YYYY-MM-DD'))
+    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dobSeniorToday.format('YYYY-MM-DD'))
     expect(JSON.parse(payload).permissions[0].licensee.noLicenceRequired).not.toBeTruthy()
     expect(concessionHelper.hasSenior(JSON.parse(payload).permissions[0].licensee)).toBeTruthy()
     expect(JSON.parse(payload).permissions[0].licenceLength).toBe('1D')
@@ -169,45 +170,45 @@ describe('The date of birth page', () => {
    * These tests are for licences starting tomorrow
    */
 
-  it(`my licence starts tomorrow, my date of birth is ${dob13Tomorrow.format(
+  it(`my licence starts tomorrow, my date of birth is ${dobJuniorTomorrow.format(
     'YYYY-MM-DD'
   )} and I require a fishing licence with a junior concession`, async () => {
     const fdate = moment().add(1, 'days')
     await postRedirectGet(LICENCE_START_DATE.uri, startDateHelper(fdate))
-    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob13Tomorrow))
+    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobJuniorTomorrow))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(JUNIOR_LICENCE.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
-    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dob13Tomorrow.format('YYYY-MM-DD'))
+    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dobJuniorTomorrow.format('YYYY-MM-DD'))
     expect(JSON.parse(payload).permissions[0].licensee.noLicenceRequired).not.toBeTruthy()
     expect(concessionHelper.hasJunior(JSON.parse(payload).permissions[0].licensee)).toBeTruthy()
   })
 
-  it(`my licence starts tomorrow, my date of birth is ${dob16Tomorrow.format(
+  it(`my licence starts tomorrow, my date of birth is ${dobAdultTomorrow.format(
     'YYYY-MM-DD'
   )} and I require a 12 month adult fishing licence`, async () => {
     const fdate = moment().add(1, 'days')
     await injectWithCookie('POST', LICENCE_START_DATE.uri, startDateHelper(fdate))
-    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob16Tomorrow))
+    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobAdultTomorrow))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(BENEFIT_CHECK.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
-    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dob16Tomorrow.format('YYYY-MM-DD'))
+    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dobAdultTomorrow.format('YYYY-MM-DD'))
     expect(JSON.parse(payload).permissions[0].licensee.concessions.length).toBe(0)
     expect(JSON.parse(payload).permissions[0].licensee.noLicenceRequired).not.toBeTruthy()
   })
 
-  it(`my licence starts tomorrow, my date of birth is ${dob65Tomorrow.format(
+  it(`my licence starts tomorrow, my date of birth is ${dobSeniorTomorrow.format(
     'YYYY-MM-DD'
   )} and I am entitled to a senior concession`, async () => {
     const fdate = moment().add(1, 'days')
     await injectWithCookie('POST', LICENCE_START_DATE.uri, startDateHelper(fdate))
     await postRedirectGet(LICENCE_LENGTH.uri, { 'licence-length': '1D' })
-    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob65Tomorrow))
+    const data = await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobSeniorTomorrow))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(LICENCE_SUMMARY.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
-    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dob65Tomorrow.format('YYYY-MM-DD'))
+    expect(JSON.parse(payload).permissions[0].licensee.birthDate).toBe(dobSeniorTomorrow.format('YYYY-MM-DD'))
     expect(JSON.parse(payload).permissions[0].licensee.noLicenceRequired).not.toBeTruthy()
     expect(concessionHelper.hasSenior(JSON.parse(payload).permissions[0].licensee)).toBeTruthy()
     expect(JSON.parse(payload).permissions[0].licenceLength).toBe('1D')

--- a/packages/gafl-webapp-service/src/pages/contact/name/__tests__/name.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/name/__tests__/name.spec.js
@@ -73,14 +73,14 @@ describe('The name page', () => {
 
   it('Check character substitutions are made on a successful submission', async () => {
     const data = await injectWithCookie('POST', NAME.uri, {
-      'last-name': 'Willis',
-      'first-name': 'Graham  Michael'
+      'last-name': 'WILLIS',
+      'first-name': 'GRAHAM    MICHAEL'
     })
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(CONTROLLER.uri)
     await injectWithCookie('GET', CONTROLLER.uri)
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
 
-    expect(JSON.parse(payload).permissions[0].licensee).toEqual({ firstName: 'GRAHAM MICHAEL', lastName: 'WILLIS' })
+    expect(JSON.parse(payload).permissions[0].licensee).toEqual({ firstName: 'Graham Michael', lastName: 'Willis' })
   })
 })

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-start-date/__tests__/licence-start-date.spec.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-start-date/__tests__/licence-start-date.spec.js
@@ -4,13 +4,14 @@ import * as concessionHelper from '../../../../processors/concession-helper.js'
 import { start, stop, initialize, injectWithCookie, postRedirectGet } from '../../../../__mocks__/test-utils.js'
 
 import moment from 'moment'
+import { MINOR_MAX_AGE, SENIOR_MIN_AGE } from '@defra-fish/business-rules-lib'
 
 beforeAll(d => start(d))
 beforeAll(d => initialize(d))
 afterAll(d => stop(d))
 
-const dob13Today = moment().add(-13, 'years')
-const dob65Today = moment().add(-65, 'years')
+const dobJuniorToday = moment().subtract(MINOR_MAX_AGE + 1, 'years')
+const dobSeniorToday = moment().subtract(SENIOR_MIN_AGE, 'years')
 
 const dobHelper = d => ({
   'date-of-birth-day': d.date().toString(),
@@ -105,7 +106,7 @@ describe('The licence start date page', () => {
   })
 
   it('setting licence start date removes any junior concession', async () => {
-    await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob13Today))
+    await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobJuniorToday))
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
     expect(concessionHelper.hasJunior(JSON.parse(payload).permissions[0].licensee)).toBeTruthy()
     const fdate = moment().add(5, 'days')
@@ -122,7 +123,7 @@ describe('The licence start date page', () => {
   })
 
   it('setting licence start date removes any senior concession', async () => {
-    await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob65Today))
+    await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobSeniorToday))
     const { payload } = await injectWithCookie('GET', '/buy/transaction')
     expect(concessionHelper.hasSenior(JSON.parse(payload).permissions[0].licensee)).toBeTruthy()
 

--- a/packages/gafl-webapp-service/src/pages/summary/licence-summary/__tests__/licence-summary.spec.js
+++ b/packages/gafl-webapp-service/src/pages/summary/licence-summary/__tests__/licence-summary.spec.js
@@ -20,6 +20,7 @@ import {
   NAME
 } from '../../../../constants.js'
 import moment from 'moment'
+import { JUNIOR_MAX_AGE } from '@defra-fish/business-rules-lib'
 
 jest.mock('node-fetch')
 const fetch = require('node-fetch')
@@ -35,8 +36,7 @@ const dobHelper = d => ({
   'date-of-birth-month': (d.month() + 1).toString(),
   'date-of-birth-year': d.year()
 })
-
-const dob16Today = moment().add(-16, 'years')
+const dobAdultToday = moment().subtract(JUNIOR_MAX_AGE + 1, 'years')
 
 beforeAll(d => start(d))
 beforeAll(d => initialize(d))
@@ -79,7 +79,7 @@ describe('The licence summary page', () => {
   })
 
   it('responds with summary page if all necessary pages have been completed', async () => {
-    await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dob16Today))
+    await postRedirectGet(DATE_OF_BIRTH.uri, dobHelper(dobAdultToday))
 
     // Mock the response from the API
     doMockPermits()

--- a/packages/sales-api-service/src/schema/__tests__/transaction.schema.spec.js
+++ b/packages/sales-api-service/src/schema/__tests__/transaction.schema.spec.js
@@ -2,18 +2,11 @@ import { createTransactionSchema, createTransactionResponseSchema } from '../tra
 import { mockTransactionPayload, mockTransactionRecord } from '../../../__mocks__/test-data.js'
 
 jest.mock('../validators/index.js', () => ({
-  createOptionSetValidator: optionSetName => {
-    return async value => undefined
-  },
-  createEntityIdValidator: (entityType, negate = false) => {
-    return async value => undefined
-  },
-  createAlternateKeyValidator: (entityType, alternateKeyProperty, negate = false) => {
-    return async value => undefined
-  },
-  createReferenceDataEntityValidator: entityType => {
-    return async value => undefined
-  }
+  createOptionSetValidator: () => async () => undefined,
+  createEntityIdValidator: () => async () => undefined,
+  createAlternateKeyValidator: () => async () => undefined,
+  createReferenceDataEntityValidator: () => async () => undefined,
+  createPermitConcessionValidator: () => async () => undefined
 }))
 
 describe('createTransactionSchema', () => {

--- a/packages/sales-api-service/src/schema/contact.schema.js
+++ b/packages/sales-api-service/src/schema/contact.schema.js
@@ -10,37 +10,15 @@ export const contactSchema = Joi.object({
     .optional()
     .description('the contact identifier of an existing contact record to be updated')
     .example('1329a866-d175-ea11-a811-000d3a64905b'),
-  firstName: Joi.string()
-    .trim()
-    .min(2)
-    .required()
-    .example('Fester'),
-  lastName: Joi.string()
-    .trim()
-    .min(2)
-    .required()
-    .example('Tester'),
+  firstName: validation.contact.firstNameValidator,
+  lastName: validation.contact.lastNameValidator,
   birthDate: validation.contact.birthDateValidator,
   email: validation.contact.emailValidator,
   mobilePhone: validation.contact.mobilePhoneValidator,
-  premises: Joi.string()
-    .trim()
-    .min(1)
-    .required()
-    .example('Example House'),
-  street: Joi.string()
-    .trim()
-    .min(1)
-    .example('Example Street'),
-  locality: Joi.string()
-    .trim()
-    .min(1)
-    .example('Near Sample'),
-  town: Joi.string()
-    .trim()
-    .min(1)
-    .required()
-    .example('Exampleton'),
+  premises: validation.contact.premisesValidator,
+  street: validation.contact.streetValidator,
+  locality: validation.contact.localityValidator,
+  town: validation.contact.townValidator,
   postcode: Joi.alternatives().conditional('country', {
     is: 'United Kingdom',
     then: validation.contact.ukPostcodeValidator,

--- a/packages/sales-api-service/src/schema/permission.schema.js
+++ b/packages/sales-api-service/src/schema/permission.schema.js
@@ -1,7 +1,7 @@
 import Joi from '@hapi/joi'
 import { contactSchema } from './contact.schema.js'
 import { concessionProofSchema } from './concession-proof.schema.js'
-import { createReferenceDataEntityValidator, createAlternateKeyValidator } from './validators/index.js'
+import { createReferenceDataEntityValidator, createAlternateKeyValidator, createPermitConcessionValidator } from './validators/index.js'
 import { Permit, Permission } from '@defra-fish/dynamics-lib'
 import { validation } from '@defra-fish/business-rules-lib'
 
@@ -24,7 +24,9 @@ export const createPermissionSchema = Joi.object({
     .required()
     .description('An ISO8601 compatible date string defining when the permission commences')
     .example(new Date().toISOString())
-}).label('create-permission-request')
+})
+  .external(createPermitConcessionValidator())
+  .label('create-permission-request')
 
 export const createPermissionResponseSchema = createPermissionSchema
   .append({

--- a/packages/sales-api-service/src/server/routes/__tests__/transactions.spec.js
+++ b/packages/sales-api-service/src/server/routes/__tests__/transactions.spec.js
@@ -11,7 +11,8 @@ jest.mock('../../../schema/validators/index.js', () => ({
   createOptionSetValidator: () => async () => undefined,
   createEntityIdValidator: () => async () => undefined,
   createAlternateKeyValidator: () => async () => undefined,
-  createReferenceDataEntityValidator: () => async () => undefined
+  createReferenceDataEntityValidator: () => async () => undefined,
+  createPermitConcessionValidator: () => async () => undefined
 }))
 
 let server = null

--- a/packages/sales-api-service/src/services/__tests__/permissions.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/permissions.service.spec.js
@@ -7,6 +7,7 @@ import {
   MOCK_1DAY_FULL_PERMIT,
   MOCK_CONCESSION
 } from '../../../__mocks__/test-data.js'
+import { JUNIOR_MAX_AGE, SENIOR_MIN_AGE } from '@defra-fish/business-rules-lib'
 
 jest.mock('../reference-data.service.js', () => ({
   ...jest.requireActual('../reference-data.service.js'),
@@ -39,7 +40,7 @@ describe('permissions service', () => {
             firstName: 'Fester',
             lastName: 'Tester',
             birthDate: moment(now)
-              .subtract(16, 'years')
+              .subtract(JUNIOR_MAX_AGE, 'years')
               .format('YYYY-MM-DD')
           }
         },
@@ -65,7 +66,7 @@ describe('permissions service', () => {
             firstName: 'Fester',
             lastName: 'Tester',
             birthDate: moment(now)
-              .subtract(15, 'years')
+              .subtract(JUNIOR_MAX_AGE - 1, 'years')
               .format('YYYY-MM-DD')
           }
         },
@@ -91,7 +92,7 @@ describe('permissions service', () => {
             firstName: 'Fester',
             lastName: 'Tester',
             birthDate: moment(now)
-              .subtract(65, 'years')
+              .subtract(SENIOR_MIN_AGE, 'years')
               .format('YYYY-MM-DD')
           }
         },

--- a/packages/sales-api-service/src/services/permissions.service.js
+++ b/packages/sales-api-service/src/services/permissions.service.js
@@ -1,4 +1,5 @@
 import { Permit } from '@defra-fish/dynamics-lib'
+import { isJunior, isSenior } from '@defra-fish/business-rules-lib'
 import { getGlobalOptionSetValue, getReferenceDataForEntityAndId } from './reference-data.service.js'
 import moment from 'moment'
 import cryptoRandomString from 'crypto-random-string'
@@ -56,9 +57,9 @@ function getAgeCategory (birthDate, issueDate) {
   let category = 'F' // Uncategorised
 
   const diff = issue.diff(dob, 'years', true)
-  if (diff <= 16) {
+  if (isJunior(diff)) {
     category = 'J'
-  } else if (diff >= 65) {
+  } else if (isSenior(diff)) {
     category = 'S'
   }
   return category

--- a/packages/sales-api-service/src/services/reference-data.service.js
+++ b/packages/sales-api-service/src/services/reference-data.service.js
@@ -13,6 +13,13 @@ export async function getReferenceData () {
   return retrieveMultipleAsMap(...ENTITY_TYPES).cached()
 }
 
+/**
+ * Retrieve all reference data records for the given entity type
+ *
+ * @template T
+ * @param {typeof T} entityType
+ * @returns {Promise<Array<T>>}
+ */
 export async function getReferenceDataForEntity (entityType) {
   const data = await getReferenceData()
   return data[entityType.definition.localCollection]

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -62,8 +62,6 @@ export async function processQueue ({ id }) {
 
     if (recurringPayment) {
       const paymentInstruction = new RecurringPaymentInstruction()
-      // TODO: Discuss with Graham/Jai - this feels like it is obsolete
-      paymentInstruction.referenceNumber = transactionRecord.recurringPayment.referenceNumber
       paymentInstruction.bindToContact(contact)
       paymentInstruction.bindToPermit(permit)
       paymentInstruction.bindToRecurringPayment(recurringPayment)


### PR DESCRIPTION
**Move age determinators into business-rules-lib**
- Add shared age-category determinator methods
- Refactor sales-api and frontend webapp to use these

**Remove referenceNumber/defra_name from RecurringPaymentInstruction**
- Not required


**Add concession/permit validation and improve shared validation:**
- Add validator API to check:
  - any concessionId provided is valid for its corresponding permitId
  - a concession is present where required by a given permitId
- Update API to use shared validators wherever possible
- Align shared validation rules max length rules with Dynamics
- Use title-case for user data as per current service
