### PR TITLE
Add support to authenticate users for easy renewals

### DIFF
--- a/packages/business-rules-lib/src/validators/__tests__/contact.spec.js
+++ b/packages/business-rules-lib/src/validators/__tests__/contact.spec.js
@@ -180,9 +180,34 @@ describe('contact validators', () => {
     each([
       ['ba21nw', 'BA2 1NW'],
       [' AB12    3CD ', 'AB12 3CD'],
-      ['AB123CD', 'AB12 3CD']
+      ['AB123CD ', 'AB12 3CD']
     ]).it('formats the UK postcode %s successfully as %s', async (postcode, replacedValue) => {
       await expect(contactValidation.createUKPostcodeValidator(Joi).validateAsync(postcode)).resolves.toEqual(replacedValue)
+    })
+
+    it('expects a minimum of 1 character', async () => {
+      await expect(contactValidation.createUKPostcodeValidator(Joi).validateAsync('')).rejects.toThrow('"value" is not allowed to be empty')
+    })
+    it('expects a maximum of 12 characters', async () => {
+      await expect(contactValidation.createUKPostcodeValidator(Joi).validateAsync('0123456789ABC')).rejects.toThrow(
+        '"value" length must be less than or equal to 12 characters long'
+      )
+    })
+    it('expects postcodes to conform to the pattern used in the UK', async () => {
+      await expect(contactValidation.createUKPostcodeValidator(Joi).validateAsync('0123456789')).rejects.toThrow(
+        /fails to match the required pattern/
+      )
+    })
+  })
+
+  describe('overseasPostcodeValidator', () => {
+    it('converts to uppercase and trims', async () => {
+      await expect(contactValidation.createOverseasPostcodeValidator(Joi).validateAsync('a ')).resolves.toEqual('A')
+    })
+    it('expects a minimum of 1 character', async () => {
+      await expect(contactValidation.createOverseasPostcodeValidator(Joi).validateAsync('')).rejects.toThrow(
+        '"value" is not allowed to be empty'
+      )
     })
   })
 

--- a/packages/business-rules-lib/src/validators/contact.js
+++ b/packages/business-rules-lib/src/validators/contact.js
@@ -204,6 +204,19 @@ export const createUKPostcodeValidator = joi =>
     .uppercase()
     .example('AB12 3CD')
 
+/**
+ * Create a validator to check/format overseas postcodes
+ * @param {Joi.Root} joi the joi validator used by the consuming project
+ * @returns {Joi.StringSchema}
+ */
+export const createOverseasPostcodeValidator = joi =>
+  joi
+    .string()
+    .trim()
+    .min(1)
+    .uppercase()
+    .required()
+
 const regexApostrophe = /\u2019/g
 const regexHyphen = /\u2014/g
 const regexMultiSpace = /\u0020{2,}/g

--- a/packages/business-rules-lib/src/validators/permission.js
+++ b/packages/business-rules-lib/src/validators/permission.js
@@ -5,4 +5,4 @@ export const createPermissionNumberValidator = joi =>
     .pattern(/^\d{8}-\d[A-Z]{2}\d[A-Z]{3}-[A-HJ-NP-Z0-9]{6}$/)
     .required()
     .description('The permission reference number')
-    .example('00310321-2DC3FAS-F4A315')
+    .example('17030621-3WC3FFT-U6HLG9')

--- a/packages/dynamics-lib/package-lock.json
+++ b/packages/dynamics-lib/package-lock.json
@@ -449,6 +449,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",

--- a/packages/dynamics-lib/package.json
+++ b/packages/dynamics-lib/package.json
@@ -40,6 +40,7 @@
     "dot-prop": "^5.2.0",
     "dynamics-web-api": "^1.6.3",
     "moment": "^2.25.3",
+    "pluralize": "^8.0.0",
     "uuid": "^8.0.0"
   }
 }

--- a/packages/dynamics-lib/src/__mocks__/TestEntity.js
+++ b/packages/dynamics-lib/src/__mocks__/TestEntity.js
@@ -2,7 +2,7 @@ import { BaseEntity, EntityDefinition } from '../entities/base.entity'
 
 export default class TestEntity extends BaseEntity {
   static _definition = new EntityDefinition({
-    localCollection: 'test',
+    localName: 'entityTest',
     dynamicsCollection: 'test',
     defaultFilter: 'statecode eq 0',
     mappings: {
@@ -40,7 +40,11 @@ export default class TestEntity extends BaseEntity {
         ref: 'test_globaloption'
       }
     },
-    alternateKey: 'strval'
+    alternateKey: 'strval',
+    relationships: {
+      parentTestEntity: { property: 'parent_test_entity', entity: TestEntity, parent: true },
+      childTestEntity: { property: 'child_test_entity', entity: TestEntity }
+    }
   })
 
   /**

--- a/packages/dynamics-lib/src/client/__tests__/util.spec.js
+++ b/packages/dynamics-lib/src/client/__tests__/util.spec.js
@@ -1,0 +1,9 @@
+import { escapeODataStringValue } from '../util.js'
+
+describe('util', () => {
+  describe('escapeODataStringValue', () => {
+    it('escapes all illegal characters used in a string value of an ODATA $filter clause', async () => {
+      expect(escapeODataStringValue("test%+/?#&'test%+/?#&'test")).toEqual("test%25%2B%2F%3F%23%26''test%25%2B%2F%3F%23%26''test")
+    })
+  })
+})

--- a/packages/dynamics-lib/src/client/util.js
+++ b/packages/dynamics-lib/src/client/util.js
@@ -1,0 +1,17 @@
+const stringSubstitutions = {
+  '%': '%25',
+  '+': '%2B',
+  '/': '%2F',
+  '?': '%3F',
+  '#': '%23',
+  '&': '%26',
+  "'": "''"
+}
+const escapeODataStringValueRegex = new RegExp(`[${Object.keys(stringSubstitutions).join('')}]`, 'g')
+
+/**
+ * Sanitise a string value used in an ODATA query
+ * @param {string|number|boolean} value the value to be sanitised
+ * @returns {string} the sanitised string
+ */
+export const escapeODataStringValue = value => String(value).replace(escapeODataStringValueRegex, char => stringSubstitutions[char])

--- a/packages/dynamics-lib/src/entities/__tests__/base.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/base.entity.spec.js
@@ -130,32 +130,49 @@ describe('BaseEntity', () => {
 })
 
 describe('EntityDefinition', () => {
-  it('exposes properties used by the entity manager', () => {
-    const definition = new EntityDefinition({
-      localCollection: 'test-local',
-      dynamicsCollection: 'test-remote',
-      defaultFilter: 'statecode eq 0',
-      mappings: {
-        id: {
-          field: 'idval',
-          type: 'string'
-        },
-        strVal: {
-          field: 'strval',
-          type: 'string'
-        }
+  const exampleDefinitionData = {
+    localName: 'example',
+    dynamicsCollection: 'example_remote',
+    defaultFilter: 'statecode eq 0',
+    mappings: {
+      id: {
+        field: 'idval',
+        type: 'string'
       },
-      alternateKey: 'strval'
-    })
+      strVal: {
+        field: 'strval',
+        type: 'string'
+      }
+    },
+    alternateKey: 'strval',
+    relationships: {
+      test: { property: 'relatedEntity', entity: TestEntity }
+    }
+  }
+
+  it('exposes properties used by the entity manager', () => {
+    const definition = new EntityDefinition(exampleDefinitionData)
     expect(definition.select).toStrictEqual(['idval', 'strval'])
-    expect(definition.localCollection).toStrictEqual('test-local')
-    expect(definition.dynamicsCollection).toStrictEqual('test-remote')
+    expect(definition.localName).toStrictEqual('example')
+    expect(definition.localCollection).toStrictEqual('examples')
+    expect(definition.dynamicsCollection).toStrictEqual('example_remote')
     expect(definition.defaultFilter).toStrictEqual('statecode eq 0')
     expect(definition.mappings).toBeInstanceOf(Object)
     expect(definition.alternateKey).toStrictEqual('strval')
+    expect(definition.relationships).toStrictEqual({ test: { property: 'relatedEntity', entity: TestEntity } })
+  })
+
+  it('requires a subclass of BaseEntity to be supplied in a relationship definition', () => {
+    class NotASubclassOfBaseEntity {}
+    expect(
+      () =>
+        new EntityDefinition(
+          Object.assign({}, exampleDefinitionData, { relationships: { test: { property: 'example', entity: NotASubclassOfBaseEntity } } })
+        )
+    ).toThrow('"relationships.test.entity" failed custom validation because Relationship entity must be a subclass of BaseEntity')
   })
 
   it('requires a valid entity definition', () => {
-    expect(() => new EntityDefinition({})).toThrow('"localCollection" is required')
+    expect(() => new EntityDefinition({})).toThrow('"localName" is required')
   })
 })

--- a/packages/dynamics-lib/src/entities/__tests__/concession-proof.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/concession-proof.entity.spec.js
@@ -44,8 +44,8 @@ describe('concession proof entity', () => {
     const concessionProof = new ConcessionProof()
     concessionProof.referenceNumber = 'TEST'
     concessionProof.proofType = optionSetData.defra_concessionproof.options['910400000']
-    concessionProof.bindToPermission(permission)
-    concessionProof.bindToConcession(concession)
+    concessionProof.bindToEntity(ConcessionProof.definition.relationships.permission, permission)
+    concessionProof.bindToEntity(ConcessionProof.definition.relationships.concession, concession)
 
     const dynamicsEntity = concessionProof.toRequestBody()
     expect(dynamicsEntity).toMatchObject(

--- a/packages/dynamics-lib/src/entities/__tests__/fulfilment-request.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/fulfilment-request.entity.spec.js
@@ -42,8 +42,8 @@ describe('fulfilment request entity', () => {
     fulfilmentRequest.requestTimestamp = '2020-04-14T11:14:27Z'
     fulfilmentRequest.notes = 'Some notes'
     fulfilmentRequest.status = optionSetData.defra_fulfilmentrequeststatus.options['910400001']
-    fulfilmentRequest.bindToPermission(permission)
-    fulfilmentRequest.bindToFulfilmentRequestFile(fulfilmentRequestFile)
+    fulfilmentRequest.bindToEntity(FulfilmentRequest.definition.relationships.permission, permission)
+    fulfilmentRequest.bindToEntity(FulfilmentRequest.definition.relationships.fulfilmentRequestFile, fulfilmentRequestFile)
 
     const dynamicsEntity = fulfilmentRequest.toRequestBody()
     expect(dynamicsEntity).toMatchObject(

--- a/packages/dynamics-lib/src/entities/__tests__/permission.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/permission.entity.spec.js
@@ -72,10 +72,10 @@ describe('permission entity', () => {
     permission.stagingId = '71ad9a25-2a03-406b-a0e3-f4ff37799374'
     permission.dataSource = optionSetData.defra_datasource.options['910400003']
 
-    permission.bindToContact(contact)
-    permission.bindToPermit(permit)
-    permission.bindToTransaction(transaction)
-    permission.bindToPoclFile(poclFile)
+    permission.bindToEntity(Permission.definition.relationships.licensee, contact)
+    permission.bindToEntity(Permission.definition.relationships.permit, permit)
+    permission.bindToEntity(Permission.definition.relationships.transaction, transaction)
+    permission.bindToEntity(Permission.definition.relationships.poclFile, poclFile)
 
     const dynamicsEntity = permission.toRequestBody()
     expect(dynamicsEntity).toMatchObject(

--- a/packages/dynamics-lib/src/entities/__tests__/permit.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/permit.entity.spec.js
@@ -30,7 +30,6 @@ describe('permit entity', () => {
     const expectedFields = {
       id: '9d1b34a0-0c66-e611-80dc-c4346bad0190',
       description: '2017-20 Coarse 1 day 2 Rod Licence (Full)',
-      permitId: '9d1b34a0-0c66-e611-80dc-c4346bad0190',
       permitType: expect.objectContaining({ id: 910400000, label: 'Rod Fishing Licence', description: 'Rod Fishing Licence' }),
       permitSubtype: expect.objectContaining({ id: 910400000, label: 'Salmon and sea trout', description: 'S' }),
       durationMagnitude: 1,

--- a/packages/dynamics-lib/src/entities/__tests__/pocl-staging-exception.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/pocl-staging-exception.entity.spec.js
@@ -1,5 +1,5 @@
 import { PoclStagingException } from '../pocl-staging-exception.entity.js'
-import { Permission, PoclFile, retrieveGlobalOptionSets } from '../..'
+import { Permission, retrieveGlobalOptionSets } from '../..'
 
 let optionSetData
 describe('pocl staging exception entity', () => {
@@ -48,9 +48,9 @@ describe('pocl staging exception entity', () => {
 
     // Test permission binding
     const permission = new Permission()
-    exception.bindToPermission(permission)
-    // Bind via alternate key
-    exception.bindToPoclFile(`/${PoclFile.definition.dynamicsCollection}(${PoclFile.definition.alternateKey}='filename.xml')`)
+    exception.bindToEntity(PoclStagingException.definition.relationships.permission, permission)
+    // Bind to the POCL file via alternate key
+    exception.bindToAlternateKey(PoclStagingException.definition.relationships.poclFile, 'filename.xml')
 
     const dynamicsEntity = exception.toRequestBody()
     expect(dynamicsEntity).toMatchObject(

--- a/packages/dynamics-lib/src/entities/__tests__/recurring-payment-instruction.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/recurring-payment-instruction.entity.spec.js
@@ -31,9 +31,9 @@ describe('recurring payment instruction entity', () => {
     const recurringPayment = new RecurringPayment()
 
     const instruction = new RecurringPaymentInstruction()
-    instruction.bindToContact(contact)
-    instruction.bindToPermit(permit)
-    instruction.bindToRecurringPayment(recurringPayment)
+    instruction.bindToEntity(RecurringPaymentInstruction.definition.relationships.licensee, contact)
+    instruction.bindToEntity(RecurringPaymentInstruction.definition.relationships.permit, permit)
+    instruction.bindToEntity(RecurringPaymentInstruction.definition.relationships.recurringPayment, recurringPayment)
 
     const dynamicsEntity = instruction.toRequestBody()
     expect(dynamicsEntity).toMatchObject(

--- a/packages/dynamics-lib/src/entities/__tests__/recurring-payment.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/recurring-payment.entity.spec.js
@@ -41,7 +41,7 @@ describe('recurring payment entity', () => {
     recurringPayment.mandate = 'Test mandate'
     recurringPayment.inceptionDay = 28
     recurringPayment.inceptionMonth = 2
-    recurringPayment.bindToContact(contact)
+    recurringPayment.bindToEntity(RecurringPayment.definition.relationships.payer, contact)
 
     const dynamicsEntity = recurringPayment.toRequestBody()
     expect(dynamicsEntity).toMatchObject(

--- a/packages/dynamics-lib/src/entities/__tests__/transaction-journal.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/transaction-journal.entity.spec.js
@@ -54,8 +54,8 @@ describe('transaction journal entity', () => {
     journal.timestamp = '2020-12-13T23:59:59Z'
     journal.type = optionSetData.defra_financialtransactiontype.options['910400000']
     journal.total = 123.45
-    journal.bindToTransactionCurrency(currency)
-    journal.bindToTransaction(transaction)
+    journal.bindToEntity(TransactionJournal.definition.relationships.transaction, transaction)
+    journal.bindToEntity(TransactionJournal.definition.relationships.transactionCurrency, currency)
 
     const dynamicsEntity = journal.toRequestBody()
     expect(dynamicsEntity).toMatchObject(

--- a/packages/dynamics-lib/src/entities/__tests__/transaction.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/transaction.entity.spec.js
@@ -60,8 +60,8 @@ describe('transaction entity', () => {
     transaction.paymentType = optionSetData.defra_paymenttype.options['910400000']
     transaction.source = optionSetData.defra_financialtransactionsource.options['910400000']
     transaction.total = 123.45
-    transaction.bindToTransactionCurrency(currency)
-    transaction.bindToPoclFile(poclFile)
+    transaction.bindToEntity(Transaction.definition.relationships.transactionCurrency, currency)
+    transaction.bindToEntity(Transaction.definition.relationships.poclFile, poclFile)
 
     const dynamicsEntity = transaction.toRequestBody()
     expect(dynamicsEntity).toMatchObject(

--- a/packages/dynamics-lib/src/entities/concession-proof.entity.js
+++ b/packages/dynamics-lib/src/entities/concession-proof.entity.js
@@ -1,4 +1,6 @@
 import { BaseEntity, EntityDefinition } from './base.entity.js'
+import { Concession } from './concession.entity.js'
+import { Permission } from './permission.entity.js'
 
 /**
  * Concession proofs entity
@@ -7,13 +9,17 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class ConcessionProof extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'concessionProofs',
+    localName: 'concessionProof',
     dynamicsCollection: 'defra_concessionproofs',
     defaultFilter: 'statecode eq 0',
     mappings: {
       id: { field: 'defra_concessionproofid', type: 'string' },
       referenceNumber: { field: 'defra_referencenumber', type: 'string' },
       proofType: { field: 'defra_concessionprooftype', type: 'optionset', ref: 'defra_concessionproof' }
+    },
+    relationships: {
+      permission: { property: 'defra_PermissionId', entity: Permission, parent: true },
+      concession: { property: 'defra_ConcessionNameId', entity: Concession, parent: true }
     }
   })
 
@@ -47,21 +53,5 @@ export class ConcessionProof extends BaseEntity {
 
   set proofType (proofType) {
     super._setState('proofType', proofType)
-  }
-
-  /**
-   * Associate the concession proof with a {@link Concession}
-   * @param {Concession} concession the {@link Concession} with which to create an association
-   */
-  bindToConcession (concession) {
-    super._bind('defra_ConcessionNameId@odata.bind', concession)
-  }
-
-  /**
-   * Associate the concession proof with a {@link Permission}
-   * @param {Permission} permission the {@link Permission} with which to create an association
-   */
-  bindToPermission (permission) {
-    super._bind('defra_PermissionId@odata.bind', permission)
   }
 }

--- a/packages/dynamics-lib/src/entities/concession.entity.js
+++ b/packages/dynamics-lib/src/entities/concession.entity.js
@@ -7,7 +7,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class Concession extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'concessions',
+    localName: 'concession',
     dynamicsCollection: 'defra_concessions',
     defaultFilter: 'statecode eq 0',
     mappings: {

--- a/packages/dynamics-lib/src/entities/contact.entity.js
+++ b/packages/dynamics-lib/src/entities/contact.entity.js
@@ -8,7 +8,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class Contact extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'contacts',
+    localName: 'contact',
     dynamicsCollection: 'contacts',
     defaultFilter: 'statecode eq 0',
     mappings: {

--- a/packages/dynamics-lib/src/entities/fulfilment-request-file.entity.js
+++ b/packages/dynamics-lib/src/entities/fulfilment-request-file.entity.js
@@ -7,7 +7,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class FulfilmentRequestFile extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'fulfilmentRequestFiles',
+    localName: 'fulfilmentRequestFile',
     dynamicsCollection: 'defra_fulfilmentrequestfiles',
     defaultFilter: 'statecode eq 0',
     mappings: {

--- a/packages/dynamics-lib/src/entities/fulfilment-request.entity.js
+++ b/packages/dynamics-lib/src/entities/fulfilment-request.entity.js
@@ -1,4 +1,6 @@
 import { BaseEntity, EntityDefinition } from './base.entity.js'
+import { Permission } from './permission.entity.js'
+import { FulfilmentRequestFile } from './fulfilment-request-file.entity.js'
 
 /**
  * Fulfilment requests entity
@@ -7,7 +9,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class FulfilmentRequest extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'fulfilmentRequests',
+    localName: 'fulfilmentRequest',
     dynamicsCollection: 'defra_fulfilmentrequests',
     defaultFilter: 'statecode eq 0',
     mappings: {
@@ -16,6 +18,10 @@ export class FulfilmentRequest extends BaseEntity {
       requestTimestamp: { field: 'defra_requesttimestamp', type: 'datetime' },
       notes: { field: 'defra_notes', type: 'string' },
       status: { field: 'defra_status', type: 'optionset', ref: 'defra_fulfilmentrequeststatus' }
+    },
+    relationships: {
+      permission: { property: 'defra_PermissionId', entity: Permission, parent: true },
+      fulfilmentRequestFile: { property: 'defra_FulfilmentRequestFileId', entity: FulfilmentRequestFile, parent: true }
     }
   })
 
@@ -73,21 +79,5 @@ export class FulfilmentRequest extends BaseEntity {
 
   set status (status) {
     super._setState('status', status)
-  }
-
-  /**
-   * Associate the fulfilment request with a {@link FulfilmentRequestFile}
-   * @param {FulfilmentRequestFile} fulfilmentRequestFile the {@link FulfilmentRequestFile} with which to create an association
-   */
-  bindToFulfilmentRequestFile (fulfilmentRequestFile) {
-    super._bind('defra_FulfilmentRequestFileId@odata.bind', fulfilmentRequestFile)
-  }
-
-  /**
-   * Associate the fulfilment request with a {@link Permission}
-   * @param {Permission} permission the {@link Permission} with which to create an association
-   */
-  bindToPermission (permission) {
-    super._bind('defra_PermissionId@odata.bind', permission)
   }
 }

--- a/packages/dynamics-lib/src/entities/permission.entity.js
+++ b/packages/dynamics-lib/src/entities/permission.entity.js
@@ -1,4 +1,9 @@
 import { BaseEntity, EntityDefinition } from './base.entity.js'
+import { Contact } from './contact.entity.js'
+import { Permit } from './permit.entity.js'
+import { ConcessionProof } from './concession-proof.entity.js'
+import { PoclFile } from './pocl-file.entity.js'
+import { Transaction } from './transaction.entity.js'
 
 /**
  * Permission entity
@@ -7,7 +12,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class Permission extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'permissions',
+    localName: 'permission',
     dynamicsCollection: 'defra_permissions',
     defaultFilter: 'statecode eq 0',
     mappings: {
@@ -18,6 +23,13 @@ export class Permission extends BaseEntity {
       endDate: { field: 'defra_enddate', type: 'datetime' },
       stagingId: { field: 'defra_stagingid', type: 'string' },
       dataSource: { field: 'defra_datasource', type: 'optionset', ref: 'defra_datasource' }
+    },
+    relationships: {
+      licensee: { property: 'defra_ContactId', entity: Contact, parent: true },
+      permit: { property: 'defra_PermitId', entity: Permit, parent: true },
+      transaction: { property: 'defra_Transaction', entity: Transaction, parent: true },
+      poclFile: { property: 'defra_POCLFileId', entity: PoclFile, parent: true },
+      concessionProofs: { property: 'defra_defra_permission_defra_concessionproof_PermissionId', entity: ConcessionProof }
     }
   })
 
@@ -99,37 +111,5 @@ export class Permission extends BaseEntity {
 
   set stagingId (stagingId) {
     super._setState('stagingId', stagingId)
-  }
-
-  /**
-   * Associate the permission with a {@link Permit}
-   * @param {Permit} permit the {@link Permit} with which to create an association
-   */
-  bindToPermit (permit) {
-    super._bind('defra_PermitId@odata.bind', permit)
-  }
-
-  /**
-   * Associate the permission with a {@link Contact}
-   * @param {Contact} contact the {@link Contact} with which to create an association
-   */
-  bindToContact (contact) {
-    super._bind('defra_ContactId@odata.bind', contact)
-  }
-
-  /**
-   * Associate the permission with a {@link Transaction}
-   * @param {Transaction} transaction the {@link Transaction} with which to create an association
-   */
-  bindToTransaction (transaction) {
-    super._bind('defra_Transaction@odata.bind', transaction)
-  }
-
-  /**
-   * Associate the permission with a {@link PoclFile}
-   * @param {PoclFile} poclFile the {@link PoclFile} with which to create an association
-   */
-  bindToPoclFile (poclFile) {
-    super._bind('defra_POCLFileId@odata.bind', poclFile)
   }
 }

--- a/packages/dynamics-lib/src/entities/permit-concession.entity.js
+++ b/packages/dynamics-lib/src/entities/permit-concession.entity.js
@@ -7,7 +7,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class PermitConcession extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'permitConcessions',
+    localName: 'permitConcession',
     dynamicsCollection: 'defra_defra_concession_defra_permitset',
     defaultFilter: undefined,
     mappings: {

--- a/packages/dynamics-lib/src/entities/permit.entity.js
+++ b/packages/dynamics-lib/src/entities/permit.entity.js
@@ -7,13 +7,12 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class Permit extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'permits',
+    localName: 'permit',
     dynamicsCollection: 'defra_permits',
     defaultFilter: 'statecode eq 0',
     mappings: {
       id: { field: 'defra_permitid', type: 'string' },
       description: { field: 'defra_name', type: 'string' },
-      permitId: { field: 'defra_permitid', type: 'string' },
       permitType: { field: 'defra_permittype', type: 'optionset', ref: 'defra_permittype' },
       permitSubtype: { field: 'defra_permitsubtype', type: 'optionset', ref: 'defra_permitsubtype' },
       durationMagnitude: { field: 'defra_durationnumericpart', type: 'integer' },
@@ -44,15 +43,6 @@ export class Permit extends BaseEntity {
    */
   get description () {
     return super._getState('description')
-  }
-
-  /**
-   * The id of the permit
-   * @type {string}
-   * @readonly
-   */
-  get permitId () {
-    return super._getState('permitId')
   }
 
   /**

--- a/packages/dynamics-lib/src/entities/pocl-file.entity.js
+++ b/packages/dynamics-lib/src/entities/pocl-file.entity.js
@@ -7,7 +7,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class PoclFile extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'poclFiles',
+    localName: 'poclFile',
     dynamicsCollection: 'defra_poclfiles',
     defaultFilter: 'statecode eq 0',
     mappings: {

--- a/packages/dynamics-lib/src/entities/pocl-staging-exception.entity.js
+++ b/packages/dynamics-lib/src/entities/pocl-staging-exception.entity.js
@@ -1,4 +1,6 @@
 import { BaseEntity, EntityDefinition } from './base.entity.js'
+import { PoclFile } from './pocl-file.entity.js'
+import { Permission } from './permission.entity.js'
 
 /**
  * pocl staging exception entity
@@ -7,7 +9,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class PoclStagingException extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'transactionFileErrors',
+    localName: 'transactionFileError',
     dynamicsCollection: 'defra_poclfiledataerrors',
     defaultFilter: 'statecode eq 0',
     mappings: {
@@ -18,6 +20,10 @@ export class PoclStagingException extends BaseEntity {
       notes: { field: 'defra_notes', type: 'string' },
       type: { field: 'defra_errortype', type: 'optionset', ref: 'defra_poclfiledataerrortype' },
       status: { field: 'defra_status', type: 'optionset', ref: 'defra_poclfiledataerrorstatus' }
+    },
+    relationships: {
+      permission: { property: 'defra_PermissionId', entity: Permission, parent: true },
+      poclFile: { property: 'defra_POCLFileId', entity: PoclFile, parent: true }
     }
   })
 
@@ -99,21 +105,5 @@ export class PoclStagingException extends BaseEntity {
 
   set status (status) {
     super._setState('status', status)
-  }
-
-  /**
-   * Associate the pocl staging exception with a {@link Permission}
-   * @param {Permission} permission the {@link Permission} with which to create an association
-   */
-  bindToPermission (permission) {
-    super._bind('defra_PermissionId@odata.bind', permission)
-  }
-
-  /**
-   * Associate the pocl staging exception with a {@link PoclFile}
-   * @param {PoclFile|string} poclFile the {@link PoclFile} with which to create an association
-   */
-  bindToPoclFile (poclFile) {
-    super._bind('defra_POCLFileId@odata.bind', poclFile)
   }
 }

--- a/packages/dynamics-lib/src/entities/recurring-payment-instruction.entity.js
+++ b/packages/dynamics-lib/src/entities/recurring-payment-instruction.entity.js
@@ -1,4 +1,7 @@
 import { BaseEntity, EntityDefinition } from './base.entity.js'
+import { Contact } from './contact.entity.js'
+import { Permit } from './permit.entity.js'
+import { RecurringPayment } from './recurring-payment.entity.js'
 
 /**
  * Recurring payment instruction entity
@@ -7,11 +10,16 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class RecurringPaymentInstruction extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'recurringPaymentInstructions',
+    localName: 'recurringPaymentInstruction',
     dynamicsCollection: 'defra_recurringpaymentinstructions',
     defaultFilter: 'statecode eq 0',
     mappings: {
       id: { field: 'defra_recurringpaymentinstructionid', type: 'string' }
+    },
+    relationships: {
+      recurringPayment: { property: 'defra_RecurringPayment', entity: RecurringPayment, parent: true },
+      licensee: { property: 'defra_Contact', entity: Contact, parent: true },
+      permit: { property: 'defra_Permit', entity: Permit, parent: true }
     }
   })
 
@@ -21,32 +29,5 @@ export class RecurringPaymentInstruction extends BaseEntity {
    */
   static get definition () {
     return RecurringPaymentInstruction._definition
-  }
-
-  /**
-   * Associate the recurring payment instruction with a {@link RecurringPayment}
-   *
-   * @param {RecurringPayment} recurringPayment the {@link RecurringPayment} with which to create an association
-   */
-  bindToRecurringPayment (recurringPayment) {
-    super._bind('defra_RecurringPayment@odata.bind', recurringPayment)
-  }
-
-  /**
-   * Associate the recurring payment instruction with a {@link Permit}
-   *
-   * @param {Permit} permit the {@link Permit} with which to create an association
-   */
-  bindToPermit (permit) {
-    super._bind('defra_Permit@odata.bind', permit)
-  }
-
-  /**
-   * Associate the recurring payment instruction with a {@link Contact}.  This is the contact details relating angler who will receive a new licence
-   *
-   * @param {Contact} contact the {@link Contact} with which to create an association
-   */
-  bindToContact (contact) {
-    super._bind('defra_Contact@odata.bind', contact)
   }
 }

--- a/packages/dynamics-lib/src/entities/recurring-payment.entity.js
+++ b/packages/dynamics-lib/src/entities/recurring-payment.entity.js
@@ -1,4 +1,5 @@
 import { BaseEntity, EntityDefinition } from './base.entity.js'
+import { Contact } from './contact.entity.js'
 
 /**
  * Recurring payment entity
@@ -7,7 +8,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class RecurringPayment extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'recurringPayments',
+    localName: 'recurringPayment',
     dynamicsCollection: 'defra_recurringpayments',
     defaultFilter: 'statecode eq 0',
     mappings: {
@@ -16,6 +17,9 @@ export class RecurringPayment extends BaseEntity {
       mandate: { field: 'defra_mandate', type: 'string' },
       inceptionDay: { field: 'defra_inceptionday', type: 'integer' },
       inceptionMonth: { field: 'defra_inceptionmonth', type: 'integer' }
+    },
+    relationships: {
+      payer: { property: 'defra_Contact', entity: Contact, parent: true }
     }
   })
 
@@ -75,14 +79,5 @@ export class RecurringPayment extends BaseEntity {
 
   set inceptionMonth (inceptionMonth) {
     super._setState('inceptionMonth', inceptionMonth)
-  }
-
-  /**
-   * Associate the recurring payment with a {@link Contact}.  This is the contact details relating to the person paying (not necessarily the angler)
-   *
-   * @param {Contact} contact the {@link Contact} with which to create an association
-   */
-  bindToContact (contact) {
-    super._bind('defra_Contact@odata.bind', contact)
   }
 }

--- a/packages/dynamics-lib/src/entities/staging-exception.entity.js
+++ b/packages/dynamics-lib/src/entities/staging-exception.entity.js
@@ -7,7 +7,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class StagingException extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'stagingExceptions',
+    localName: 'stagingException',
     dynamicsCollection: 'defra_crmstagingexceptions',
     defaultFilter: 'statecode eq 0',
     mappings: {

--- a/packages/dynamics-lib/src/entities/transaction-currency.entity.js
+++ b/packages/dynamics-lib/src/entities/transaction-currency.entity.js
@@ -7,7 +7,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class TransactionCurrency extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'transactionCurrencies',
+    localName: 'transactionCurrency',
     dynamicsCollection: 'transactioncurrencies',
     defaultFilter: 'statecode eq 0',
     mappings: {

--- a/packages/dynamics-lib/src/entities/transaction-journal.entity.js
+++ b/packages/dynamics-lib/src/entities/transaction-journal.entity.js
@@ -1,4 +1,6 @@
 import { BaseEntity, EntityDefinition } from './base.entity.js'
+import { TransactionCurrency } from './transaction-currency.entity.js'
+import { Transaction } from './transaction.entity.js'
 
 /**
  * Transaction Journal entity
@@ -7,7 +9,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class TransactionJournal extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'transactionJournals',
+    localName: 'transactionJournal',
     dynamicsCollection: 'defra_transactionjournals',
     defaultFilter: 'statecode eq 0',
     mappings: {
@@ -17,6 +19,10 @@ export class TransactionJournal extends BaseEntity {
       timestamp: { field: 'defra_timestamp', type: 'datetime' },
       type: { field: 'defra_transactiontype', type: 'optionset', ref: 'defra_financialtransactiontype' },
       total: { field: 'defra_total', type: 'decimal' }
+    },
+    relationships: {
+      transaction: { property: 'defra_Transaction', entity: Transaction, parent: true },
+      transactionCurrency: { property: 'transactioncurrencyid', entity: TransactionCurrency, parent: true }
     }
   })
 
@@ -86,21 +92,5 @@ export class TransactionJournal extends BaseEntity {
 
   set total (total) {
     super._setState('total', total)
-  }
-
-  /**
-   * Associate the transaction journal with a {@link TransactionCurrency}
-   * @param {TransactionCurrency} currency the {@link TransactionCurrency} with which to create an association
-   */
-  bindToTransactionCurrency (currency) {
-    super._bind('transactioncurrencyid@odata.bind', currency)
-  }
-
-  /**
-   * Associate the transaction journal with a {@link Transaction}
-   * @param {Transaction} transaction the {@link Transaction} with which to create an association
-   */
-  bindToTransaction (transaction) {
-    super._bind('defra_Transaction@odata.bind', transaction)
   }
 }

--- a/packages/dynamics-lib/src/entities/transaction.entity.js
+++ b/packages/dynamics-lib/src/entities/transaction.entity.js
@@ -1,4 +1,6 @@
 import { BaseEntity, EntityDefinition } from './base.entity.js'
+import { PoclFile } from './pocl-file.entity.js'
+import { TransactionCurrency } from './transaction-currency.entity.js'
 
 /**
  * Transaction entity
@@ -7,7 +9,7 @@ import { BaseEntity, EntityDefinition } from './base.entity.js'
 export class Transaction extends BaseEntity {
   /** @type {EntityDefinition} */
   static _definition = new EntityDefinition({
-    localCollection: 'transactions',
+    localName: 'transaction',
     dynamicsCollection: 'defra_transactions',
     defaultFilter: 'statecode eq 0',
     mappings: {
@@ -19,6 +21,10 @@ export class Transaction extends BaseEntity {
       paymentType: { field: 'defra_paymenttype', type: 'optionset', ref: 'defra_paymenttype' },
       source: { field: 'defra_transactionsource', type: 'optionset', ref: 'defra_financialtransactionsource' },
       total: { field: 'defra_total', type: 'decimal' }
+    },
+    relationships: {
+      poclFile: { property: 'defra_POCLFile', entity: PoclFile, parent: true },
+      transactionCurrency: { property: 'transactioncurrencyid', entity: TransactionCurrency, parent: true }
     }
   })
 
@@ -112,21 +118,5 @@ export class Transaction extends BaseEntity {
 
   set total (total) {
     super._setState('total', total)
-  }
-
-  /**
-   * Associate the transaction with a {@link TransactionCurrency}
-   * @param {TransactionCurrency} currency the {@link TransactionCurrency} with which to create an association
-   */
-  bindToTransactionCurrency (currency) {
-    super._bind('transactioncurrencyid@odata.bind', currency)
-  }
-
-  /**
-   * Associate the transaction with a {@link PoclFile}
-   * @param {PoclFile} poclFile the {@link PoclFile} with which to create an association
-   */
-  bindToPoclFile (poclFile) {
-    super._bind('defra_POCLFile@odata.bind', poclFile)
   }
 }

--- a/packages/dynamics-lib/src/index.js
+++ b/packages/dynamics-lib/src/index.js
@@ -1,3 +1,4 @@
+// Entities
 export * from './entities/contact.entity.js'
 export * from './entities/permission.entity.js'
 export * from './entities/permit.entity.js'
@@ -14,6 +15,14 @@ export * from './entities/pocl-staging-exception.entity.js'
 export * from './entities/recurring-payment.entity.js'
 export * from './entities/recurring-payment-instruction.entity.js'
 export * from './entities/staging-exception.entity.js'
-export { dynamicsClient } from './client/dynamics-client.js'
+
+// Option sets
 export * from './optionset/global-option-set-definition.js'
+
+// Queries
+export * from './queries/permission.queries.js'
+
+// Framework functionality
+export * from './client/util.js'
+export { dynamicsClient } from './client/dynamics-client.js'
 export * from './client/entity-manager.js'

--- a/packages/dynamics-lib/src/queries/__tests__/permission.queries.spec.js
+++ b/packages/dynamics-lib/src/queries/__tests__/permission.queries.spec.js
@@ -1,0 +1,20 @@
+import { permissionForLicensee } from '../permission.queries.js'
+
+describe('Permission Queries', () => {
+  describe('permissionForLicensee', () => {
+    it('builds a filter to run a query for a permission with a given licensee date of birth and postcode', async () => {
+      const query = permissionForLicensee('ABC123', '2000-01-01', 'AB12 3CD')
+      expect(query.toRetrieveRequest()).toEqual({
+        collection: 'defra_permissions',
+        expand: expect.arrayContaining([
+          expect.objectContaining({ property: 'defra_ContactId', select: expect.any(Array) }),
+          expect.objectContaining({ property: 'defra_PermitId', select: expect.any(Array) }),
+          expect.objectContaining({ property: 'defra_defra_permission_defra_concessionproof_PermissionId', select: expect.any(Array) })
+        ]),
+        filter:
+          "endswith(defra_name, 'ABC123') and defra_ContactId/defra_postcode eq 'AB12 3CD' and defra_ContactId/birthdate eq 2000-01-01 and statecode eq 0",
+        select: expect.any(Array)
+      })
+    })
+  })
+})

--- a/packages/dynamics-lib/src/queries/__tests__/predefined-query.spec.js
+++ b/packages/dynamics-lib/src/queries/__tests__/predefined-query.spec.js
@@ -1,0 +1,89 @@
+import { PredefinedQuery } from '../predefined-query.js'
+import TestEntity from '../../__mocks__/TestEntity.js'
+import { GlobalOptionSetDefinition } from '../../optionset/global-option-set-definition.js'
+
+describe('PredefinedQuery', () => {
+  const expectedTestEntitySelect = ['idval', 'strval', 'intval', 'decval', 'boolval', 'dateval', 'datetimeval', 'optionsetval']
+  const mockTestEntityResponseData = {
+    '@odata.etag': 'W/"186695153"',
+    idval: 'test-id',
+    strval: 'test-string',
+    intval: 12345,
+    decval: 0.12345,
+    boolval: true,
+    dateval: '2020-06-04',
+    datetimeval: '2020-06-04T15:26:00.000Z',
+    optionsetval: 910400001
+  }
+  const expectedTestEntityFields = expect.objectContaining({
+    id: 'test-id',
+    strVal: 'test-string',
+    intVal: 12345,
+    decVal: 0.12345,
+    boolVal: true,
+    dateVal: '2020-06-04',
+    dateTimeVal: '2020-06-04T15:26:00.000Z',
+    optionSetVal: expect.objectContaining({
+      id: 910400001,
+      label: 'test',
+      description: 'test'
+    })
+  })
+
+  const optionSetData = {
+    test_globaloption: {
+      options: {
+        910400001: new GlobalOptionSetDefinition('test_globaloption', { id: 910400001, label: 'test', description: 'test' })
+      }
+    }
+  }
+
+  it('builds a query using a filter and no expands', async () => {
+    const query = new PredefinedQuery({
+      root: TestEntity,
+      filter: `${TestEntity.definition.mappings.strVal.field} eq 'Test Value'`
+    })
+
+    expect(query.toRetrieveRequest()).toStrictEqual({
+      collection: 'test',
+      filter: "strval eq 'Test Value'",
+      select: expectedTestEntitySelect
+    })
+
+    const queryResult = query.fromResponse([mockTestEntityResponseData], optionSetData)
+    expect(queryResult).toMatchObject([{ entityTest: expectedTestEntityFields }])
+  })
+
+  it('builds a query using both a filter and expands', async () => {
+    const query = new PredefinedQuery({
+      root: TestEntity,
+      filter: `${TestEntity.definition.mappings.strVal.field} eq 'Test Value'`,
+      expands: [TestEntity.definition.relationships.parentTestEntity, TestEntity.definition.relationships.childTestEntity]
+    })
+
+    expect(query.toRetrieveRequest()).toStrictEqual({
+      collection: 'test',
+      filter: "strval eq 'Test Value'",
+      select: expectedTestEntitySelect,
+      expand: [
+        {
+          property: 'parent_test_entity',
+          select: expectedTestEntitySelect
+        },
+        {
+          property: 'child_test_entity',
+          select: expectedTestEntitySelect
+        }
+      ]
+    })
+
+    const queryResult = query.fromResponse(
+      [{ ...mockTestEntityResponseData, parent_test_entity: mockTestEntityResponseData, child_test_entity: [mockTestEntityResponseData] }],
+      optionSetData
+    )
+
+    expect(queryResult).toMatchObject([
+      { entityTest: expectedTestEntityFields, parentTestEntity: expectedTestEntityFields, childTestEntity: [expectedTestEntityFields] }
+    ])
+  })
+})

--- a/packages/dynamics-lib/src/queries/permission.queries.js
+++ b/packages/dynamics-lib/src/queries/permission.queries.js
@@ -1,0 +1,22 @@
+import { PredefinedQuery } from './predefined-query.js'
+import { Permission } from '../entities/permission.entity.js'
+import { escapeODataStringValue } from '../client/util.js'
+
+/**
+ * Builds a query to retrieve a permission and related entities for a given reference number and related contact information
+ *
+ * @param permissionReferenceNumber the reference number of the permission used to perform the lookup
+ * @param licenseeBirthDate the birth date of the contact associated with the permission
+ * @param licenseePostcode the postcode of the contact associated with the permission
+ * @returns {PredefinedQuery}
+ */
+export const permissionForLicensee = (permissionReferenceNumber, licenseeBirthDate, licenseePostcode) => {
+  const { licensee, permit, concessionProofs } = Permission.definition.relationships
+  let filter = `endswith(${Permission.definition.mappings.referenceNumber.field}, '${escapeODataStringValue(permissionReferenceNumber)}')`
+  filter += ` and ${licensee.property}/${licensee.entity.definition.mappings.postcode.field} eq '${escapeODataStringValue(
+    licenseePostcode
+  )}'`
+  filter += ` and ${licensee.property}/${licensee.entity.definition.mappings.birthDate.field} eq ${licenseeBirthDate}`
+  filter += ` and ${Permission.definition.defaultFilter}`
+  return new PredefinedQuery({ root: Permission, filter: filter, expands: [licensee, permit, concessionProofs] })
+}

--- a/packages/dynamics-lib/src/queries/predefined-query.js
+++ b/packages/dynamics-lib/src/queries/predefined-query.js
@@ -1,0 +1,49 @@
+export class PredefinedQuery {
+  /**
+   * Create a new PredefinedQuery
+   *
+   * @param {typeof BaseEntity} root the entity class acting as the root of the query
+   * @param {string} filter the ODATA filter to apply to the query
+   * @param {Array<Relationship>} [expands] optional relationships to be expanded when the query is executed
+   */
+  constructor ({ root, filter, expands }) {
+    this._root = root
+    this._retrieveRequest = {
+      ...root.definition.toRetrieveRequest(filter),
+      ...(expands && {
+        expand: expands.map(e => ({
+          property: e.property,
+          select: e.entity.definition.select
+        }))
+      })
+    }
+  }
+
+  /**
+   * @returns {{filter: string?, expands: Array<Expand>, select: Array<String>, collection: !string}}
+   */
+  toRetrieveRequest () {
+    return this._retrieveRequest
+  }
+
+  /**
+   * @param results
+   * @param optionSetData
+   * @returns {Array<Object>}
+   */
+  fromResponse (results, optionSetData) {
+    return results.map(r => ({
+      [this._root.definition.localName]: this._root.fromResponse(r, optionSetData),
+      ...Object.entries(this._root.definition.relationships).reduce((acc, [relationName, relationDefinition]) => {
+        if (r[relationDefinition.property]) {
+          if (relationDefinition.parent) {
+            acc[relationName] = relationDefinition.entity.fromResponse(r[relationDefinition.property], optionSetData)
+          } else {
+            acc[relationName] = r[relationDefinition.property].map(entry => relationDefinition.entity.fromResponse(entry, optionSetData))
+          }
+        }
+        return acc
+      }, {})
+    }))
+  }
+}

--- a/packages/gafl-webapp-service/src/__mocks__/data/permits.js
+++ b/packages/gafl-webapp-service/src/__mocks__/data/permits.js
@@ -2,7 +2,6 @@ export default [
   {
     id: '9d1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 1 day 2 Rod Licence (Full)',
-    permitId: '9d1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -40,7 +39,6 @@ export default [
   {
     id: '9f1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 1 day 2 Rod Licence (Senior)',
-    permitId: '9f1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -78,7 +76,6 @@ export default [
   {
     id: 'a51b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 1 day 1 Rod Licence (Full)',
-    permitId: 'a51b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -116,7 +113,6 @@ export default [
   {
     id: 'a71b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 1 day 1 Rod Licence (Senior)',
-    permitId: 'a71b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -154,7 +150,6 @@ export default [
   {
     id: 'a91b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 8 day 2 Rod Licence (Full)',
-    permitId: 'a91b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -192,7 +187,6 @@ export default [
   {
     id: 'ab1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 8 day 2 Rod Licence (Senior)',
-    permitId: 'ab1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -230,7 +224,6 @@ export default [
   {
     id: 'b11b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 8 day 1 Rod Licence (Full) ',
-    permitId: 'b11b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -268,7 +261,6 @@ export default [
   {
     id: 'b31b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 8 day 1 Rod Licence (Senior) ',
-    permitId: 'b31b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -306,7 +298,6 @@ export default [
   {
     id: 'b51b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 2 Rod Licence (Junior)',
-    permitId: 'b51b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -344,7 +335,6 @@ export default [
   {
     id: 'b71b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 2 Rod Licence (Full)',
-    permitId: 'b71b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -382,7 +372,6 @@ export default [
   {
     id: 'b91b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 2 Rod Licence (Senior)',
-    permitId: 'b91b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -420,7 +409,6 @@ export default [
   {
     id: 'bb1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 2 Rod Licence (Junior, Disabled)',
-    permitId: 'bb1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -458,7 +446,6 @@ export default [
   {
     id: 'bd1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 2 Rod Licence (Full, Disabled)',
-    permitId: 'bd1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -496,7 +483,6 @@ export default [
   {
     id: 'bf1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 2 Rod Licence (Senior, Disabled)',
-    permitId: 'bf1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -534,7 +520,6 @@ export default [
   {
     id: 'c11b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 3 Rod Licence (Junior)',
-    permitId: 'c11b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -572,7 +557,6 @@ export default [
   {
     id: 'c31b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 3 Rod Licence (Full)',
-    permitId: 'c31b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -610,7 +594,6 @@ export default [
   {
     id: 'c51b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 3 Rod Licence (Senior)',
-    permitId: 'c51b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -648,7 +631,6 @@ export default [
   {
     id: 'c71b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 3 Rod Licence (Junior, Disabled)',
-    permitId: 'c71b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -686,7 +668,6 @@ export default [
   {
     id: 'c91b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 3 Rod Licence (Full, Disabled)',
-    permitId: 'c91b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -724,7 +705,6 @@ export default [
   {
     id: 'cb1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Coarse 12 month 3 Rod Licence (Senior, Disabled)',
-    permitId: 'cb1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -762,7 +742,6 @@ export default [
   {
     id: 'd91b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 12 month 1 Rod Licence (Junior)',
-    permitId: 'd91b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -800,7 +779,6 @@ export default [
   {
     id: 'db1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 12 month 1 Rod Licence (Full)',
-    permitId: 'db1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -838,7 +816,6 @@ export default [
   {
     id: 'dd1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 12 month 1 Rod Licence (Senior)',
-    permitId: 'dd1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -876,7 +853,6 @@ export default [
   {
     id: 'df1b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 12 month 1 Rod Licence (Junior, Disabled)',
-    permitId: 'df1b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -914,7 +890,6 @@ export default [
   {
     id: 'e11b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 12 month 1 Rod Licence (Full, Disabled)',
-    permitId: 'e11b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',
@@ -952,7 +927,6 @@ export default [
   {
     id: 'e31b34a0-0c66-e611-80dc-c4346bad0190',
     description: 'Salmon 12 month 1 Rod Licence (Senior, Disabled)',
-    permitId: 'e31b34a0-0c66-e611-80dc-c4346bad0190',
     permitType: {
       id: 910400000,
       label: 'Rod Fishing Licence',

--- a/packages/gafl-webapp-service/src/__mocks__/mock-journeys.js
+++ b/packages/gafl-webapp-service/src/__mocks__/mock-journeys.js
@@ -123,13 +123,15 @@ export const ADULT_DISABLED_12_MONTH_LICENCE = {
         },
         issueDate: '2020-04-30T08:36:12.195Z',
         startDate: '2020-04-29T23:00:00.000Z',
-        concession: {
-          concessionId: 'd1ece997-ef65-e611-80dc-c4346bad4004',
-          proof: {
-            type: 'National Insurance Number',
-            referenceNumber: 'QQ 12 34 56 C'
+        concessions: [
+          {
+            id: 'd1ece997-ef65-e611-80dc-c4346bad4004',
+            proof: {
+              type: 'National Insurance Number',
+              referenceNumber: 'QQ 12 34 56 C'
+            }
           }
-        },
+        ],
         referenceNumber: '01300421-1WS3FGW-YK1TTK',
         endDate: '2021-04-29T23:00:00.000Z'
       }
@@ -179,12 +181,14 @@ export const SENIOR_12_MONTH_LICENCE = {
         },
         issueDate: '2020-04-30T09:16:58.635Z',
         startDate: '2020-04-29T23:00:00.000Z',
-        concession: {
-          concessionId: 'd0ece997-ef65-e611-80dc-c4346bad4004',
-          proof: {
-            type: 'No proof'
+        concessions: [
+          {
+            id: 'd0ece997-ef65-e611-80dc-c4346bad4004',
+            proof: {
+              type: 'No proof'
+            }
           }
-        },
+        ],
         referenceNumber: '01300420-1WS0SGW-78CGFU',
         endDate: '2020-04-29T23:00:00.000Z'
       }
@@ -232,12 +236,14 @@ export const JUNIOR_12_MONTH_LICENCE = {
         },
         issueDate: '2020-04-30T09:35:28.014Z',
         startDate: '2020-04-29T23:00:00.000Z',
-        concession: {
-          concessionId: '3230c68f-ef65-e611-80dc-c4346bad4004',
-          proof: {
-            type: 'No proof'
+        concessions: [
+          {
+            id: '3230c68f-ef65-e611-80dc-c4346bad4004',
+            proof: {
+              type: 'No proof'
+            }
           }
-        },
+        ],
         referenceNumber: '01300420-1WS0JGW-FLNA84',
         endDate: '2020-04-29T23:00:00.000Z'
       }

--- a/packages/gafl-webapp-service/src/pages/contact/address/entry/__tests__/address-entry-spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/entry/__tests__/address-entry-spec.js
@@ -94,14 +94,12 @@ describe('The manual address entry page', () => {
     expect(data.headers.location).toBe(ADDRESS_ENTRY.uri)
   })
 
-  it('controller redirects to contact page on posting a valid UK address', async () => {
+  it('redirects to contact page on posting a valid UK address', async () => {
     const addr = Object.assign({}, goodAddress)
     const data = await postRedirectGet(ADDRESS_ENTRY.uri, addr)
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(CONTACT.uri)
-  })
 
-  it('The contact information has been set in the transaction', async () => {
     const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
     expect(JSON.parse(payload).permissions[0].licensee).toEqual({
       premises: '14 Howecroft Court',
@@ -112,22 +110,20 @@ describe('The manual address entry page', () => {
     })
   })
 
-  it('controller redirects to contact page on posting a valid non-UK address', async () => {
+  it('redirects to contact page on posting a valid non-UK address', async () => {
     const addr = Object.assign({}, goodAddress)
     addr['country-code'] = 'FR'
     addr.postcode = 'not checked'
     const data = await postRedirectGet(ADDRESS_ENTRY.uri, addr)
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(CONTACT.uri)
-  })
 
-  it('The contact information has been set in the transaction', async () => {
     const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
     expect(JSON.parse(payload).permissions[0].licensee).toEqual({
       premises: '14 Howecroft Court',
       street: 'Eastmead Lane',
       town: 'Bristol',
-      postcode: 'not checked',
+      postcode: 'NOT CHECKED',
       countryCode: 'FR'
     })
   })

--- a/packages/gafl-webapp-service/src/pages/contact/address/entry/route.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/entry/route.js
@@ -12,9 +12,7 @@ const validator = Joi.object({
   postcode: Joi.alternatives().conditional('country-code', {
     is: 'GB',
     then: validation.contact.createUKPostcodeValidator(Joi),
-    otherwise: Joi.string()
-      .trim()
-      .required()
+    otherwise: validation.contact.createOverseasPostcodeValidator(Joi)
   }),
   'country-code': Joi.string().required()
 }).options({ abortEarly: false, allowUnknown: true })

--- a/packages/gafl-webapp-service/src/processors/api-transaction.js
+++ b/packages/gafl-webapp-service/src/processors/api-transaction.js
@@ -26,24 +26,30 @@ const prepareApiTransactionPayload = async request => {
 
       // Calculate the concession (proof entry) - disabl;ed takes precedence
       if (concessionHelper.hasDisabled(p)) {
-        permission.concession = {
-          concessionId: concessions.find(c => c.name === mappings.CONCESSION.DISABLED).id,
-          proof: p.concessions.find(c => c.type === mappings.CONCESSION.DISABLED).proof
-        }
+        permission.concessions = [
+          {
+            id: concessions.find(c => c.name === mappings.CONCESSION.DISABLED).id,
+            proof: p.concessions.find(c => c.type === mappings.CONCESSION.DISABLED).proof
+          }
+        ]
       } else if (concessionHelper.hasSenior(p)) {
-        permission.concession = {
-          concessionId: concessions.find(c => c.name === mappings.CONCESSION.SENIOR).id,
-          proof: {
-            type: mappings.CONCESSION_PROOF.none
+        permission.concessions = [
+          {
+            id: concessions.find(c => c.name === mappings.CONCESSION.SENIOR).id,
+            proof: {
+              type: mappings.CONCESSION_PROOF.none
+            }
           }
-        }
+        ]
       } else if (concessionHelper.hasJunior(p)) {
-        permission.concession = {
-          concessionId: concessions.find(c => c.name === mappings.CONCESSION.JUNIOR).id,
-          proof: {
-            type: mappings.CONCESSION_PROOF.none
+        permission.concessions = [
+          {
+            id: concessions.find(c => c.name === mappings.CONCESSION.JUNIOR).id,
+            proof: {
+              type: mappings.CONCESSION_PROOF.none
+            }
           }
-        }
+        ]
       }
 
       return permission

--- a/packages/gafl-webapp-service/src/processors/filter-permits.js
+++ b/packages/gafl-webapp-service/src/processors/filter-permits.js
@@ -9,7 +9,7 @@ const filterPermits = async request => {
 
   const permitsJoinPermitConcessions = permits.map(p => ({
     ...p,
-    concessions: permitConcessions.filter(pc => pc.permitId === p.permitId).map(pc => concessions.find(c => c.id === pc.concessionId))
+    concessions: permitConcessions.filter(pc => pc.permitId === p.id).map(pc => concessions.find(c => c.id === pc.concessionId))
   }))
 
   // Filter the joined list to include every and only those concessions in licenseeConcessions

--- a/packages/pocl-job/src/transform/bindings/pocl/licence/concession.bindings.js
+++ b/packages/pocl-job/src/transform/bindings/pocl/licence/concession.bindings.js
@@ -21,13 +21,15 @@ export const SeniorConcession = new Binding({
     const value = Binding.TransformTextOnly(context)
     return (
       value && {
-        concession: {
-          concessionId: await getConcessionId('Senior'),
-          proof: {
-            type: context.value,
-            referenceNumber: 'N/A'
+        concessions: [
+          {
+            id: await getConcessionId('Senior'),
+            proof: {
+              type: context.value,
+              referenceNumber: 'N/A'
+            }
           }
-        }
+        ]
       }
     )
   }
@@ -43,13 +45,15 @@ export const BlueBadgeConcession = new Binding({
     const value = Binding.TransformTextOnly(context)
     return (
       value && {
-        concession: {
-          concessionId: await getConcessionId('Disabled'),
-          proof: {
-            type: 'Blue Badge',
-            referenceNumber: context.value
+        concessions: [
+          {
+            id: await getConcessionId('Disabled'),
+            proof: {
+              type: 'Blue Badge',
+              referenceNumber: context.value
+            }
           }
-        }
+        ]
       }
     )
   }
@@ -65,13 +69,15 @@ export const PipConcession = new Binding({
     const value = Binding.TransformTextOnly(context)
     return (
       value && {
-        concession: {
-          concessionId: await getConcessionId('Disabled'),
-          proof: {
-            type: 'National Insurance Number',
-            referenceNumber: context.value
+        concessions: [
+          {
+            id: await getConcessionId('Disabled'),
+            proof: {
+              type: 'National Insurance Number',
+              referenceNumber: context.value
+            }
           }
-        }
+        ]
       }
     )
   }

--- a/packages/pocl-job/src/transform/bindings/pocl/transaction/__tests__/transaction.bindings.spec.js
+++ b/packages/pocl-job/src/transform/bindings/pocl/transaction/__tests__/transaction.bindings.spec.js
@@ -138,13 +138,15 @@ describe('transaction transforms', () => {
         permissions: [
           {
             permitId: 'permits-id',
-            concession: {
-              concessionId: 'concessions-id',
-              proof: {
-                referenceNumber: 'N/A',
-                type: 'Uncancelled Passport'
+            concessions: [
+              {
+                id: 'concessions-id',
+                proof: {
+                  referenceNumber: 'N/A',
+                  type: 'Uncancelled Passport'
+                }
               }
-            },
+            ],
             issueDate: '2020-06-01T08:00:00.000Z',
             startDate: '2020-05-31T23:01:00.000Z',
             licensee: {
@@ -229,13 +231,15 @@ describe('transaction transforms', () => {
         permissions: [
           {
             permitId: 'permits-id',
-            concession: {
-              concessionId: 'concessions-id',
-              proof: {
-                referenceNumber: '12ABCD01234X5678',
-                type: 'Blue Badge'
+            concessions: [
+              {
+                id: 'concessions-id',
+                proof: {
+                  referenceNumber: '12ABCD01234X5678',
+                  type: 'Blue Badge'
+                }
               }
-            },
+            ],
             issueDate: '2020-01-01T15:03:17.000Z',
             startDate: '2020-01-01T00:01:00.000Z',
             licensee: {
@@ -319,13 +323,15 @@ describe('transaction transforms', () => {
         permissions: [
           {
             permitId: 'permits-id',
-            concession: {
-              concessionId: 'concessions-id',
-              proof: {
-                referenceNumber: '12ABCD01234X5678',
-                type: 'Blue Badge'
+            concessions: [
+              {
+                id: 'concessions-id',
+                proof: {
+                  referenceNumber: '12ABCD01234X5678',
+                  type: 'Blue Badge'
+                }
               }
-            },
+            ],
             issueDate: '2020-01-01T15:03:17.000Z',
             startDate: '2020-01-01T00:01:00.000Z',
             licensee: {
@@ -407,13 +413,15 @@ describe('transaction transforms', () => {
         permissions: [
           {
             permitId: 'permits-id',
-            concession: {
-              concessionId: 'concessions-id',
-              proof: {
-                referenceNumber: 'QQ123456C',
-                type: 'National Insurance Number'
+            concessions: [
+              {
+                id: 'concessions-id',
+                proof: {
+                  referenceNumber: 'QQ123456C',
+                  type: 'National Insurance Number'
+                }
               }
-            },
+            ],
             issueDate: '2020-01-01T15:03:17.000Z',
             startDate: '2020-01-01T00:01:00.000Z',
             licensee: {

--- a/packages/sales-api-service/src/__mocks__/test-data.js
+++ b/packages/sales-api-service/src/__mocks__/test-data.js
@@ -1,4 +1,12 @@
-import { Concession, Contact, GlobalOptionSetDefinition, Permit, TransactionCurrency } from '@defra-fish/dynamics-lib'
+import {
+  Concession,
+  ConcessionProof,
+  Contact,
+  GlobalOptionSetDefinition,
+  Permission,
+  Permit,
+  TransactionCurrency
+} from '@defra-fish/dynamics-lib'
 import { readFileSync } from 'fs'
 import Project from '../project.cjs'
 import Path from 'path'
@@ -43,20 +51,22 @@ export const mockContactPayload = () => ({
 })
 
 export const mockContactWithIdPayload = () => ({
-  contactId: '1329a866-d175-ea11-a811-000d3a64905b',
+  id: '1329a866-d175-ea11-a811-000d3a64905b',
   ...mockContactPayload()
 })
 
 export const mockPermissionPayload = () => ({
   permitId: 'cb1b34a0-0c66-e611-80dc-c4346bad0190',
   licensee: mockContactPayload(),
-  concession: {
-    concessionId: 'd0ece997-ef65-e611-80dc-c4346bad4004',
-    proof: {
-      type: 'National Insurance Number',
-      referenceNumber: 'AB 01 02 03 CD'
+  concessions: [
+    {
+      id: 'd0ece997-ef65-e611-80dc-c4346bad4004',
+      proof: {
+        type: 'National Insurance Number',
+        referenceNumber: 'AB 01 02 03 CD'
+      }
     }
-  },
+  ],
   issueDate: '2020-04-09T08:51:26.825Z',
   startDate: '2020-04-09T08:51:26.825Z'
 })
@@ -148,8 +158,8 @@ export const MOCK_1DAY_FULL_PERMIT_DYNAMICS_RESPONSE = {
   defra_itemid: '42289'
 }
 
-export const MOCK_1DAY_SENIOR_PERMIT = Permit.fromResponse(MOCK_1DAY_SENIOR_PERMIT_DYNAMICS_RESPONSE, optionSetData)
-export const MOCK_1DAY_FULL_PERMIT = Permit.fromResponse(MOCK_1DAY_FULL_PERMIT_DYNAMICS_RESPONSE, optionSetData)
+export const MOCK_1DAY_SENIOR_PERMIT_ENTITY = Permit.fromResponse(MOCK_1DAY_SENIOR_PERMIT_DYNAMICS_RESPONSE, optionSetData)
+export const MOCK_1DAY_FULL_PERMIT_ENTITY = Permit.fromResponse(MOCK_1DAY_FULL_PERMIT_DYNAMICS_RESPONSE, optionSetData)
 
 export const MOCK_12MONTH_SENIOR_PERMIT_DYNAMICS_RESPONSE = {
   '@odata.etag': 'W/"51026180"',
@@ -190,6 +200,30 @@ export const MOCK_12MONTH_DISABLED_PERMIT_DYNAMICS_RESPONSE = {
 
 export const MOCK_12MONTH_SENIOR_PERMIT = Permit.fromResponse(MOCK_12MONTH_SENIOR_PERMIT_DYNAMICS_RESPONSE, optionSetData)
 export const MOCK_12MONTH_DISABLED_PERMIT = Permit.fromResponse(MOCK_12MONTH_DISABLED_PERMIT_DYNAMICS_RESPONSE, optionSetData)
+
+export const MOCK_CONCESSION_PROOF_ENTITY = ConcessionProof.fromResponse(
+  {
+    '@odata.etag': 'W/"53050428"',
+    defra_concessionproofid: 'ee336a19-417e-ea11-a811-000d3a64905b',
+    defra_referencenumber: 'AB 01 02 03 CD',
+    defra_concessionprooftype: 910400001
+  },
+  optionSetData
+)
+
+export const MOCK_EXISTING_PERMISSION_ENTITY = Permission.fromResponse(
+  {
+    '@odata.etag': 'W/"186695153"',
+    defra_permissionid: '347a9083-361e-ea11-a810-000d3a25c5d6',
+    defra_name: '00000000-2WC3FDR-CD379B',
+    defra_issuedate: '2019-12-13T09:00:00Z',
+    defra_startdate: '2019-12-14T00:00:00Z',
+    defra_enddate: '2020-12-13T23:59:59Z',
+    defra_stagingid: '71ad9a25-2a03-406b-a0e3-f4ff37799374',
+    defra_datasource: 910400003
+  },
+  optionSetData
+)
 
 export const MOCK_NEW_CONTACT_ENTITY = new Contact()
 

--- a/packages/sales-api-service/src/schema/authenticate.schema.js
+++ b/packages/sales-api-service/src/schema/authenticate.schema.js
@@ -1,0 +1,30 @@
+import Joi from '@hapi/joi'
+import { validation } from '@defra-fish/business-rules-lib'
+import { concessionProofSchema } from './concession-proof.schema.js'
+import { permitSchema } from './permit.schema.js'
+import { contactResponseSchema } from './contact.schema.js'
+import { permissionFieldsSchemaDefinitions } from './permission.schema.js'
+
+export const authenticateRenewalRequestParamsSchema = Joi.object({
+  referenceNumber: Joi.string()
+    .min(6)
+    .required()
+    .description('The permission reference number (supports partial)')
+}).label('authenticate-renewal-request-params')
+
+export const authenticateRenewalRequestQuerySchema = Joi.object({
+  licenseeBirthDate: validation.contact.createBirthDateValidator(Joi).description('The date of birth of the licensee'),
+  licenseePostcode: Joi.alternatives().try(
+    validation.contact.createUKPostcodeValidator(Joi).description('The postcode of the licensee'),
+    validation.contact.createOverseasPostcodeValidator(Joi)
+  )
+}).label('authenticate-renewal-request-query')
+
+export const authenticateRenewalResponseSchema = Joi.object({
+  permission: {
+    ...permissionFieldsSchemaDefinitions,
+    licensee: contactResponseSchema,
+    concessions: concessionProofSchema,
+    permit: permitSchema
+  }
+}).label('authenticate-renewal-response')

--- a/packages/sales-api-service/src/schema/concession-proof.schema.js
+++ b/packages/sales-api-service/src/schema/concession-proof.schema.js
@@ -1,18 +1,24 @@
 import Joi from '@hapi/joi'
 import { buildJoiOptionSetValidator, createReferenceDataEntityValidator } from './validators/validators.js'
 import { Concession } from '@defra-fish/dynamics-lib'
+import { v4 as uuid } from 'uuid'
 
-export const concessionProofSchema = Joi.object({
-  concessionId: Joi.string()
-    .guid()
-    .external(createReferenceDataEntityValidator(Concession))
-    .example('d0ece997-ef65-e611-80dc-c4346bad4004'),
-  proof: Joi.object({
-    type: buildJoiOptionSetValidator('defra_concessionproof', 'National Insurance Number'),
-    referenceNumber: Joi.string()
-      .optional()
-      .example('QQ 12 34 56 C')
-  })
-    .label('concession-proof-details')
-    .required()
-}).label('concession-proof')
+export const concessionProofSchema = Joi.array()
+  .items(
+    Joi.object({
+      id: Joi.string()
+        .guid()
+        .external(createReferenceDataEntityValidator(Concession))
+        .required()
+        .example(uuid()),
+      proof: Joi.object({
+        type: buildJoiOptionSetValidator('defra_concessionproof', 'National Insurance Number'),
+        referenceNumber: Joi.string()
+          .optional()
+          .example('QQ 12 34 56 C')
+      })
+        .label('concession-proof-details')
+        .required()
+    }).label('concession-proof')
+  )
+  .label('concession-proof-list')

--- a/packages/sales-api-service/src/schema/contact.schema.js
+++ b/packages/sales-api-service/src/schema/contact.schema.js
@@ -2,9 +2,10 @@ import Joi from '@hapi/joi'
 import { buildJoiOptionSetValidator, createEntityIdValidator } from './validators/validators.js'
 import { Contact } from '@defra-fish/dynamics-lib'
 import { validation } from '@defra-fish/business-rules-lib'
+import { optionSetOption } from './option-set.schema.js'
 
-export const contactSchema = Joi.object({
-  contactId: Joi.string()
+const commonContactSchema = {
+  id: Joi.string()
     .guid()
     .optional()
     .external(createEntityIdValidator(Contact))
@@ -22,10 +23,12 @@ export const contactSchema = Joi.object({
   postcode: Joi.alternatives().conditional('country', {
     is: Joi.string().valid('GB', 'United Kingdom'),
     then: validation.contact.createUKPostcodeValidator(Joi),
-    otherwise: Joi.string()
-      .trim()
-      .required()
-  }),
+    otherwise: validation.contact.createOverseasPostcodeValidator(Joi)
+  })
+}
+
+export const contactRequestSchema = Joi.object({
+  ...commonContactSchema,
   country: buildJoiOptionSetValidator('defra_country', 'GB'),
   preferredMethodOfConfirmation: buildJoiOptionSetValidator('defra_preferredcontactmethod', 'Text'),
   preferredMethodOfNewsletter: buildJoiOptionSetValidator('defra_preferredcontactmethod', 'Email'),
@@ -34,3 +37,13 @@ export const contactSchema = Joi.object({
   .required()
   .description('Details of the associated contact')
   .label('contact')
+
+export const contactResponseSchema = Joi.object({
+  ...commonContactSchema,
+  country: optionSetOption,
+  preferredMethodOfConfirmation: optionSetOption,
+  preferredMethodOfNewsletter: optionSetOption,
+  preferredMethodOfReminder: optionSetOption
+})
+  .required()
+  .label('contact-response')

--- a/packages/sales-api-service/src/schema/option-set.schema.js
+++ b/packages/sales-api-service/src/schema/option-set.schema.js
@@ -1,6 +1,6 @@
 import Joi from '@hapi/joi'
 
-export const optionSetOptionExample = { id: 910400000, label: '1 day', description: '' }
+export const optionSetOptionExample = { id: 910400000, label: 'Example Label', description: 'Example Description' }
 
 export const optionSetOption = Joi.object({
   id: Joi.number().required(),

--- a/packages/sales-api-service/src/schema/permission.schema.js
+++ b/packages/sales-api-service/src/schema/permission.schema.js
@@ -1,9 +1,27 @@
 import Joi from '@hapi/joi'
-import { contactSchema } from './contact.schema.js'
+import { contactRequestSchema } from './contact.schema.js'
 import { concessionProofSchema } from './concession-proof.schema.js'
+import { optionSetOption } from './option-set.schema.js'
 import { createReferenceDataEntityValidator, createPermitConcessionValidator } from './validators/validators.js'
 import { Permit } from '@defra-fish/dynamics-lib'
 import { validation } from '@defra-fish/business-rules-lib'
+import { v4 as uuid } from 'uuid'
+
+const issueDateSchema = Joi.string()
+  .isoDate()
+  .required()
+  .description('An ISO8601 compatible date string defining when the permission was issued')
+  .example(new Date().toISOString())
+const startDateSchema = Joi.string()
+  .isoDate()
+  .required()
+  .description('An ISO8601 compatible date string defining when the permission commences')
+  .example(new Date().toISOString())
+const endDateSchema = Joi.string()
+  .isoDate()
+  .required()
+  .description('An ISO8601 compatible date string defining when the permission expires')
+  .example(new Date().toISOString())
 
 export const createPermissionSchema = Joi.object({
   permitId: Joi.string()
@@ -12,18 +30,10 @@ export const createPermissionSchema = Joi.object({
     .required()
     .description('The ID of the permit associated with this permission')
     .example('cb1b34a0-0c66-e611-80dc-c4346bad0190'),
-  licensee: contactSchema,
-  concession: concessionProofSchema.optional(),
-  issueDate: Joi.string()
-    .isoDate()
-    .required()
-    .description('An ISO8601 compatible date string defining when the permission was issued')
-    .example(new Date().toISOString()),
-  startDate: Joi.string()
-    .isoDate()
-    .required()
-    .description('An ISO8601 compatible date string defining when the permission commences')
-    .example(new Date().toISOString())
+  licensee: contactRequestSchema,
+  concessions: concessionProofSchema.optional(),
+  issueDate: issueDateSchema,
+  startDate: startDateSchema
 })
   .external(createPermitConcessionValidator())
   .label('create-transaction-request-permission')
@@ -31,10 +41,24 @@ export const createPermissionSchema = Joi.object({
 export const createPermissionResponseSchema = createPermissionSchema
   .append({
     referenceNumber: validation.permission.createPermissionNumberValidator(Joi),
-    endDate: Joi.string()
-      .isoDate()
-      .required()
-      .description('An ISO8601 compatible date string defining when the permission expires')
-      .example(new Date().toISOString())
+    endDate: endDateSchema
   })
   .label('create-transaction-response-permission')
+
+export const permissionFieldsSchemaDefinitions = {
+  id: Joi.string()
+    .guid()
+    .required()
+    .example(uuid()),
+  referenceNumber: validation.permission.createPermissionNumberValidator(Joi),
+  issueDate: issueDateSchema,
+  startDate: startDateSchema,
+  endDate: endDateSchema,
+  stagingId: Joi.string()
+    .guid()
+    .required()
+    .example(uuid()),
+  dataSource: optionSetOption
+}
+
+export const permissionSchema = Joi.object(permissionFieldsSchemaDefinitions).label('permission')

--- a/packages/sales-api-service/src/schema/permit.schema.js
+++ b/packages/sales-api-service/src/schema/permit.schema.js
@@ -1,0 +1,37 @@
+import Joi from '@hapi/joi'
+import { optionSetOption } from './option-set.schema.js'
+import { v4 as uuid } from 'uuid'
+
+export const permitSchema = Joi.object({
+  id: Joi.string()
+    .guid()
+    .required()
+    .example(uuid()),
+  description: Joi.string()
+    .required()
+    .example('Coarse 12 month 3 Rod Licence (Senior, Disabled)'),
+  permitType: optionSetOption,
+  permitSubtype: optionSetOption,
+  durationMagnitude: 12,
+  durationDesignator: optionSetOption,
+  numberOfRods: 3,
+  availableFrom: Joi.string()
+    .isoDate()
+    .required()
+    .description('An ISO8601 compatible date string defining when the permit is available from')
+    .example(new Date().toISOString()),
+  availableTo: Joi.string()
+    .isoDate()
+    .required()
+    .description('An ISO8601 compatible date string defining when the permit is available to')
+    .example(new Date().toISOString()),
+  isForFulfilment: Joi.boolean().required(),
+  isCounterSales: Joi.boolean().required(),
+  isRecurringPaymentSupported: Joi.boolean().required(),
+  cost: Joi.number()
+    .integer()
+    .example(30),
+  itemId: Joi.number()
+    .integer()
+    .example('42347')
+}).label('permit')

--- a/packages/sales-api-service/src/schema/transaction.schema.js
+++ b/packages/sales-api-service/src/schema/transaction.schema.js
@@ -1,7 +1,7 @@
 import Joi from '@hapi/joi'
 import { PoclFile } from '@defra-fish/dynamics-lib'
 import { createPermissionSchema, createPermissionResponseSchema } from './permission.schema.js'
-import { contactSchema } from './contact.schema.js'
+import { contactRequestSchema } from './contact.schema.js'
 import { createAlternateKeyValidator, buildJoiOptionSetValidator } from './validators/validators.js'
 import { MAX_PERMISSIONS_PER_TRANSACTION } from '@defra-fish/business-rules-lib'
 
@@ -101,7 +101,7 @@ export const finaliseTransactionRequestSchema = Joi.object({
       .description('Channel specific identifier'),
     method: buildJoiOptionSetValidator('defra_paymenttype', 'Debit card'),
     recurring: Joi.object({
-      payer: contactSchema,
+      payer: contactRequestSchema,
       referenceNumber: Joi.string()
         .required()
         .description('The reference number associated with the recurring payment')

--- a/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
+++ b/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
@@ -80,7 +80,7 @@ describe('validators', () => {
     it('returns a validation function throwing an error when no reference data entity found', async () => {
       const spy = jest.spyOn(referenceData, 'getReferenceDataForEntityAndId').mockImplementation(async () => null)
       const validationFunction = createReferenceDataEntityValidator(TestEntity)
-      await expect(validationFunction('testValue')).rejects.toThrow('Unrecognised test identifier')
+      await expect(validationFunction('testValue')).rejects.toThrow('Unrecognised entityTest identifier')
       expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
   })
@@ -110,59 +110,59 @@ describe('validators', () => {
     it('returns a validation function throwing an error when no entity is found', async () => {
       const spy = jest.spyOn(entityManager, 'findById').mockImplementation(async () => null)
       const validationFunction = createEntityIdValidator(TestEntity)
-      await expect(validationFunction('testValue')).rejects.toThrow('Unrecognised test identifier')
+      await expect(validationFunction('testValue')).rejects.toThrow('Unrecognised entityTest identifier')
       expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
 
     it('returns a validation function throwing an error when an entity is found and negate is set', async () => {
       const spy = jest.spyOn(entityManager, 'findById').mockImplementation(async () => 'success')
       const validationFunction = createEntityIdValidator(TestEntity, true)
-      await expect(validationFunction('testValue')).rejects.toThrow('Entity for test identifier already exists')
+      await expect(validationFunction('testValue')).rejects.toThrow('Entity for entityTest identifier already exists')
       expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
   })
 
   describe('createAlternateKeyValidator', () => {
     it('returns a validation function returning undefined when an entity is successfully resolved', async () => {
-      const spy = jest.spyOn(entityManager, 'findById').mockImplementation(async () => 'success')
+      const spy = jest.spyOn(entityManager, 'findByAlternateKey').mockImplementation(async () => 'success')
       const validationFunction = createAlternateKeyValidator(TestEntity)
       await expect(validationFunction('testValue')).resolves.toEqual(undefined)
-      expect(spy).toHaveBeenCalledWith(TestEntity, "strval='testValue'")
+      expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
 
     it('returns a validation function which skips validation if the input value is undefined', async () => {
-      const spy = jest.spyOn(entityManager, 'findById')
+      const spy = jest.spyOn(entityManager, 'findByAlternateKey')
       const validationFunction = createAlternateKeyValidator(TestEntity, true)
       await expect(validationFunction(undefined)).resolves.toEqual(undefined)
       expect(spy).not.toHaveBeenCalled()
     })
 
     it('returns a validation function returning undefined when an entity is not resolved and negate is set', async () => {
-      const spy = jest.spyOn(entityManager, 'findById').mockImplementation(async () => null)
+      const spy = jest.spyOn(entityManager, 'findByAlternateKey').mockImplementation(async () => null)
       const validationFunction = createAlternateKeyValidator(TestEntity, true)
       await expect(validationFunction('testValue')).resolves.toEqual(undefined)
-      expect(spy).toHaveBeenCalledWith(TestEntity, "strval='testValue'")
+      expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
 
     it('returns a validation function throwing an error when no entity is found', async () => {
-      const spy = jest.spyOn(entityManager, 'findById').mockImplementation(async () => null)
+      const spy = jest.spyOn(entityManager, 'findByAlternateKey').mockImplementation(async () => null)
       const validationFunction = createAlternateKeyValidator(TestEntity)
-      await expect(validationFunction('testValue')).rejects.toThrow('Unrecognised test identifier')
-      expect(spy).toHaveBeenCalledWith(TestEntity, "strval='testValue'")
+      await expect(validationFunction('testValue')).rejects.toThrow('Unrecognised entityTest identifier')
+      expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
 
     it('returns a validation function throwing an error when an entity is found and negate is set', async () => {
-      const spy = jest.spyOn(entityManager, 'findById').mockImplementation(async () => 'success')
+      const spy = jest.spyOn(entityManager, 'findByAlternateKey').mockImplementation(async () => 'success')
       const validationFunction = createAlternateKeyValidator(TestEntity, true)
-      await expect(validationFunction('testValue')).rejects.toThrow('Entity for test identifier already exists')
-      expect(spy).toHaveBeenCalledWith(TestEntity, "strval='testValue'")
+      await expect(validationFunction('testValue')).rejects.toThrow('Entity for entityTest identifier already exists')
+      expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
 
     it('throws if attempting to create an alternate key validator using an object which does not support it', async () => {
       class TestNonAlternateKeyEntity extends BaseEntity {
         static get definition () {
           return new EntityDefinition({
-            localCollection: 'TestNonAlternateKeyEntity',
+            localName: 'TestNonAlternateKeyEntity',
             dynamicsCollection: 'TestNonAlternateKeyEntity',
             mappings: { id: { field: 'idval', type: 'string' } }
           })
@@ -176,57 +176,104 @@ describe('validators', () => {
 
   describe('createPermitConcessionValidator', () => {
     it('returns a validation function returning undefined when the permit and concession are successfully resolved', async () => {
-      const spy = jest
-        .spyOn(referenceData, 'getReferenceDataForEntity')
-        .mockImplementation(async () => [{ permitId: 'test-1', concessionId: 'test-1' }])
+      const spy = jest.spyOn(referenceData, 'getReferenceDataForEntity').mockImplementation(async () => [
+        {
+          permitId: 'test-1',
+          concessionId: 'test-1'
+        }
+      ])
       const validationFunction = createPermitConcessionValidator()
       await expect(
         validationFunction({
           permitId: 'test-1',
-          concession: {
-            concessionId: 'test-1'
-          }
+          concessions: [
+            {
+              id: 'test-1'
+            }
+          ]
         })
       ).resolves.toEqual(undefined)
       expect(spy).toHaveBeenCalledWith(PermitConcession)
     })
-  })
 
-  it('returns a validation function throwing an error if the permit and concession are not successfully resolved', async () => {
-    const spy = jest
-      .spyOn(referenceData, 'getReferenceDataForEntity')
-      .mockImplementation(async () => [{ permitId: 'test-1', concessionId: 'test-1' }])
-    const validationFunction = createPermitConcessionValidator()
-    await expect(
-      validationFunction({
-        permitId: 'test-1',
-        concession: {
-          concessionId: 'test-2'
+    it('returns a validation function throwing an error if the permit and concession are not successfully resolved', async () => {
+      const spy = jest.spyOn(referenceData, 'getReferenceDataForEntity').mockImplementation(async () => [
+        {
+          permitId: 'test-1',
+          concessionId: 'test-1'
         }
-      })
-    ).rejects.toThrow("The concession 'test-2' is not valid with respect to the permit 'test-1'")
-    expect(spy).toHaveBeenCalledWith(PermitConcession)
-  })
+      ])
+      const validationFunction = createPermitConcessionValidator()
+      await expect(
+        validationFunction({
+          permitId: 'test-1',
+          concessions: [
+            {
+              id: 'test-2'
+            }
+          ]
+        })
+      ).rejects.toThrow("The concession 'test-2' is not valid with respect to the permit 'test-1'")
+      expect(spy).toHaveBeenCalledWith(PermitConcession)
+    })
 
-  it('returns a validation function which skips validation if the input value is undefined', async () => {
-    const spy = jest
-      .spyOn(referenceData, 'getReferenceDataForEntity')
-      .mockImplementation(async () => [{ permitId: 'test-1', concessionId: 'test-1' }])
-    const validationFunction = createPermitConcessionValidator()
-    await expect(validationFunction()).resolves.toEqual(undefined)
-    expect(spy).not.toHaveBeenCalled()
-  })
+    it('returns a validation function throwing an error if the permit does not allow concessions but they are supplied', async () => {
+      const spy = jest.spyOn(referenceData, 'getReferenceDataForEntity').mockImplementation(async () => [{}])
+      const validationFunction = createPermitConcessionValidator()
+      await expect(
+        validationFunction({
+          permitId: 'test-1',
+          concessions: [
+            {
+              id: 'test-2'
+            }
+          ]
+        })
+      ).rejects.toThrow("The permit 'test-1' does not allow concessions but concession proofs were supplied")
+      expect(spy).toHaveBeenCalledWith(PermitConcession)
+    })
 
-  it('returns a validation function throwing an error if the permit requires a concession and none is supplied', async () => {
-    const spy = jest
-      .spyOn(referenceData, 'getReferenceDataForEntity')
-      .mockImplementation(async () => [{ permitId: 'test-1', concessionId: 'test-1' }])
-    const validationFunction = createPermitConcessionValidator()
-    await expect(
-      validationFunction({
-        permitId: 'test-1'
-      })
-    ).rejects.toThrow("The concession 'undefined' is not valid with respect to the permit 'test-1'")
-    expect(spy).toHaveBeenCalledWith(PermitConcession)
+    it('returns a validation function throwing an error if the permission contains duplicate concession proofs', async () => {
+      const spy = jest.spyOn(referenceData, 'getReferenceDataForEntity').mockImplementation(async () => [
+        { permitId: 'test-1', concessionId: 'test-1' },
+        { permitId: 'test-1', concessionId: 'test-2' }
+      ])
+      const validationFunction = createPermitConcessionValidator()
+      await expect(
+        validationFunction({
+          permitId: 'test-1',
+          concessions: [{ id: 'test-1' }, { id: 'test-1' }, { id: 'test-2' }, { id: 'test-2' }]
+        })
+      ).rejects.toThrow("The concession ids 'test-1,test-2' appear more than once, duplicates are not permitted")
+      expect(spy).toHaveBeenCalledWith(PermitConcession)
+    })
+
+    it('returns a validation function which skips validation if the input value is undefined', async () => {
+      const spy = jest.spyOn(referenceData, 'getReferenceDataForEntity').mockImplementation(async () => [
+        {
+          permitId: 'test-1',
+          concessionId: 'test-1'
+        }
+      ])
+      const validationFunction = createPermitConcessionValidator()
+      await expect(validationFunction(undefined)).resolves.toEqual(undefined)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('returns a validation function throwing an error if the permit requires a concession and none is supplied', async () => {
+      const spy = jest.spyOn(referenceData, 'getReferenceDataForEntity').mockImplementation(async () => [
+        {
+          permitId: 'test-1',
+          concessionId: 'test-1'
+        }
+      ])
+      const validationFunction = createPermitConcessionValidator()
+      await expect(
+        validationFunction({
+          permitId: 'test-1'
+        })
+      ).rejects.toThrow("The permit 'test-1' requires proof of concession however none were supplied")
+      expect(spy).toHaveBeenCalledWith(PermitConcession)
+    })
   })
 })

--- a/packages/sales-api-service/src/schema/validators/validators.js
+++ b/packages/sales-api-service/src/schema/validators/validators.js
@@ -94,21 +94,32 @@ export function createPermitConcessionValidator () {
       } else if (!concessionsRequiredForPermit.length && hasConcessionProofs) {
         throw new Error(`The permit '${permission.permitId}' does not allow concessions but concession proofs were supplied`)
       } else {
-        // Check list for duplicates
-        const counts = permission.concessions.reduce((acc, c) => ({ ...acc, [c.id]: (acc[c.id] || 0) + 1 }), {})
-        const duplicates = Object.keys(counts).filter(k => counts[k] > 1)
-        if (duplicates.length) {
-          throw new Error(`The concession ids '${duplicates}' appear more than once, duplicates are not permitted`)
-        }
-
-        // Check concession allowed for permit
-        permission.concessions.forEach(concession => {
-          if (!concessionsRequiredForPermit.find(pc => concession.id === pc.concessionId)) {
-            throw new Error(`The concession '${concession.id}' is not valid with respect to the permit '${permission.permitId}'`)
-          }
-        })
+        validateConcessionList(permission, concessionsRequiredForPermit)
       }
     }
     return undefined
   }
+}
+
+/**
+ * Validate that the supplied concessions list does not contain duplicates and are valid for the respective permit
+ *
+ * @param permission the permission containing the concessions to be validated
+ * @param concessionsRequiredForPermit the concessions allowed for the target permit
+ * @throws on validation error
+ */
+const validateConcessionList = (permission, concessionsRequiredForPermit) => {
+  // Check list for duplicates
+  const counts = permission.concessions.reduce((acc, c) => ({ ...acc, [c.id]: (acc[c.id] || 0) + 1 }), {})
+  const duplicates = Object.keys(counts).filter(k => counts[k] > 1)
+  if (duplicates.length) {
+    throw new Error(`The concession ids '${duplicates}' appear more than once, duplicates are not permitted`)
+  }
+
+  // Check concession allowed for permit
+  permission.concessions.forEach(concession => {
+    if (!concessionsRequiredForPermit.find(pc => concession.id === pc.concessionId)) {
+      throw new Error(`The concession '${concession.id}' is not valid with respect to the permit '${permission.permitId}'`)
+    }
+  })
 }

--- a/packages/sales-api-service/src/server/routes/__tests__/authenticate.spec.js
+++ b/packages/sales-api-service/src/server/routes/__tests__/authenticate.spec.js
@@ -1,0 +1,93 @@
+import initialiseServer from '../../index.js'
+import { executeQuery, permissionForLicensee } from '@defra-fish/dynamics-lib'
+import {
+  MOCK_EXISTING_PERMISSION_ENTITY,
+  MOCK_EXISTING_CONTACT_ENTITY,
+  MOCK_1DAY_SENIOR_PERMIT_ENTITY,
+  MOCK_CONCESSION_PROOF_ENTITY
+} from '../../../__mocks__/test-data.js'
+
+jest.mock('@defra-fish/dynamics-lib', () => ({
+  ...jest.requireActual('@defra-fish/dynamics-lib'),
+  permissionForLicensee: jest.fn(),
+  executeQuery: jest.fn()
+}))
+
+let server = null
+
+describe('authenticate handler', () => {
+  beforeAll(async () => {
+    server = await initialiseServer({ port: null })
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  describe('authenticateRenewal', () => {
+    it('authenticates a renewal request', async () => {
+      executeQuery.mockResolvedValueOnce([
+        {
+          permission: MOCK_EXISTING_PERMISSION_ENTITY,
+          licensee: MOCK_EXISTING_CONTACT_ENTITY,
+          concessionProofs: [MOCK_CONCESSION_PROOF_ENTITY],
+          permit: MOCK_1DAY_SENIOR_PERMIT_ENTITY
+        }
+      ])
+      const result = await server.inject({
+        method: 'GET',
+        url: '/authenticate/renewal/CD379B?licenseeBirthDate=2000-01-01&licenseePostcode=AB12 3CD'
+      })
+      expect(permissionForLicensee).toHaveBeenCalledWith('CD379B', '2000-01-01', 'AB12 3CD')
+      expect(result.statusCode).toBe(200)
+      expect(JSON.parse(result.payload)).toMatchObject({
+        permission: expect.objectContaining({
+          ...MOCK_EXISTING_PERMISSION_ENTITY.toJSON(),
+          licensee: MOCK_EXISTING_CONTACT_ENTITY.toJSON(),
+          concessions: [MOCK_CONCESSION_PROOF_ENTITY.toJSON()],
+          permit: MOCK_1DAY_SENIOR_PERMIT_ENTITY.toJSON()
+        })
+      })
+    })
+
+    it('throws 500 errors if more than one result was found for the query', async () => {
+      executeQuery.mockResolvedValueOnce([{}, {}])
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn())
+      const result = await server.inject({
+        method: 'GET',
+        url: '/authenticate/renewal/CD379B?licenseeBirthDate=2000-01-01&licenseePostcode=AB12 3CD'
+      })
+      expect(result.statusCode).toBe(500)
+      expect(JSON.parse(result.payload)).toMatchObject({
+        error: 'Internal Server Error',
+        message: 'Unable to authenticate, non-unique results for query',
+        statusCode: 500
+      })
+      expect(consoleErrorSpy).toHaveBeenCalled()
+    })
+
+    it('throws 401 errors if the renewal could not be authenticated', async () => {
+      executeQuery.mockResolvedValueOnce([])
+      const result = await server.inject({
+        method: 'GET',
+        url: '/authenticate/renewal/CD379B?licenseeBirthDate=2000-01-01&licenseePostcode=AB12 3CD'
+      })
+      expect(result.statusCode).toBe(401)
+      expect(JSON.parse(result.payload)).toMatchObject({
+        error: 'Unauthorized',
+        message: 'The licensee could not be authenticated',
+        statusCode: 401
+      })
+    })
+
+    it('throws 400 errors if the required parameters are not supplied', async () => {
+      const result = await server.inject({ method: 'GET', url: '/authenticate/renewal/CD379B?' })
+      expect(result.statusCode).toBe(400)
+      expect(JSON.parse(result.payload)).toMatchObject({
+        error: 'Bad Request',
+        message: 'Invalid query: "licenseeBirthDate" is required',
+        statusCode: 400
+      })
+    })
+  })
+})

--- a/packages/sales-api-service/src/server/routes/__tests__/reference-data.spec.js
+++ b/packages/sales-api-service/src/server/routes/__tests__/reference-data.spec.js
@@ -1,11 +1,11 @@
-import { MOCK_12MONTH_SENIOR_PERMIT, MOCK_1DAY_SENIOR_PERMIT } from '../../../__mocks__/test-data.js'
+import { MOCK_12MONTH_SENIOR_PERMIT, MOCK_1DAY_SENIOR_PERMIT_ENTITY } from '../../../__mocks__/test-data.js'
 import initialiseServer from '../../index.js'
 let server = null
 
 jest.mock('../../../services/reference-data.service.js', () => ({
   ENTITY_TYPES: [MOCK_12MONTH_SENIOR_PERMIT.constructor],
   getReferenceDataForEntity: jest.fn(async entityType => {
-    return [MOCK_12MONTH_SENIOR_PERMIT, MOCK_1DAY_SENIOR_PERMIT]
+    return [MOCK_12MONTH_SENIOR_PERMIT, MOCK_1DAY_SENIOR_PERMIT_ENTITY]
   })
 }))
 
@@ -34,7 +34,7 @@ describe('reference-data endpoint', () => {
           id: MOCK_12MONTH_SENIOR_PERMIT.id
         }),
         expect.objectContaining({
-          id: MOCK_1DAY_SENIOR_PERMIT.id
+          id: MOCK_1DAY_SENIOR_PERMIT_ENTITY.id
         })
       ])
     )

--- a/packages/sales-api-service/src/server/routes/authenticate.js
+++ b/packages/sales-api-service/src/server/routes/authenticate.js
@@ -1,0 +1,55 @@
+import Boom from '@hapi/boom'
+import {
+  authenticateRenewalRequestParamsSchema,
+  authenticateRenewalRequestQuerySchema,
+  authenticateRenewalResponseSchema
+} from '../../schema/authenticate.schema.js'
+import { permissionForLicensee, executeQuery } from '@defra-fish/dynamics-lib'
+
+export default [
+  {
+    method: 'GET',
+    path: '/authenticate/renewal/{referenceNumber}',
+    options: {
+      handler: async (request, h) => {
+        const { licenseeBirthDate, licenseePostcode } = request.query
+        const results = await executeQuery(permissionForLicensee(request.params.referenceNumber, licenseeBirthDate, licenseePostcode))
+        if (results.length === 1) {
+          const { permission, licensee, permit, concessionProofs } = results[0]
+          return h
+            .response({
+              permission: {
+                ...permission.toJSON(),
+                licensee: licensee.toJSON(),
+                concessions: concessionProofs.map(c => c.toJSON()),
+                permit: permit.toJSON()
+              }
+            })
+            .code(200)
+        } else if (results.length === 0) {
+          throw Boom.unauthorized('The licensee could not be authenticated')
+        } else {
+          throw new Error('Unable to authenticate, non-unique results for query')
+        }
+      },
+      description: 'Authenticate a licensee by checking the licence number corresponds with the provided contact details',
+      notes: `
+        Authenticate a licensee by checking the licence number corresponds with the provided contact details
+      `,
+      tags: ['api', 'authenticate'],
+      validate: {
+        params: authenticateRenewalRequestParamsSchema,
+        query: authenticateRenewalRequestQuerySchema
+      },
+      plugins: {
+        'hapi-swagger': {
+          responses: {
+            200: { description: 'The licensee was successfully authenticated', schema: authenticateRenewalResponseSchema },
+            401: { description: 'The licensee could not be authenticated' }
+          },
+          order: 1
+        }
+      }
+    }
+  }
+]

--- a/packages/sales-api-service/src/server/routes/index.js
+++ b/packages/sales-api-service/src/server/routes/index.js
@@ -4,7 +4,17 @@ import Transactions from './transactions.js'
 import TransactionFiles from './transaction-files.js'
 import PaymentJournals from './payment-journals.js'
 import StagingExceptions from './staging-exceptions.js'
+import Authenticate from './authenticate.js'
 
 import Static from './static.js'
 
-export default [...Static, ...ReferenceData, ...OptionSets, ...Transactions, ...TransactionFiles, ...PaymentJournals, ...StagingExceptions]
+export default [
+  ...Static,
+  ...ReferenceData,
+  ...OptionSets,
+  ...Transactions,
+  ...TransactionFiles,
+  ...PaymentJournals,
+  ...StagingExceptions,
+  ...Authenticate
+]

--- a/packages/sales-api-service/src/server/routes/transaction-files.js
+++ b/packages/sales-api-service/src/server/routes/transaction-files.js
@@ -1,5 +1,5 @@
 import Boom from '@hapi/boom'
-import { persist, findById, PoclFile } from '@defra-fish/dynamics-lib'
+import { persist, findByAlternateKey, PoclFile } from '@defra-fish/dynamics-lib'
 import {
   createTransactionFileResponseSchema,
   createTransactionFileSchema,
@@ -13,7 +13,7 @@ export default [
     path: '/transaction-files/{fileName}',
     options: {
       handler: async (request, h) => {
-        const file = await findById(PoclFile, `${PoclFile.definition.alternateKey}='${request.params.fileName}'`)
+        const file = await findByAlternateKey(PoclFile, request.params.fileName)
         if (!file) {
           throw Boom.notFound('An transaction file with the given identifier could not be found')
         }
@@ -44,14 +44,14 @@ export default [
     path: '/transaction-files/{fileName}',
     options: {
       handler: async (request, h) => {
-        let file = await findById(PoclFile, `${PoclFile.definition.alternateKey}='${request.params.fileName}'`)
+        let file = await findByAlternateKey(PoclFile, request.params.fileName)
         if (!file) {
           file = new PoclFile()
         }
 
         const payload = request.payload
-        payload.dataSource = await getGlobalOptionSetValue('defra_datasource', payload.dataSource)
-        payload.status = await getGlobalOptionSetValue('defra_poclfilestatus', payload.status)
+        payload.dataSource = await getGlobalOptionSetValue(PoclFile.definition.mappings.dataSource.ref, payload.dataSource)
+        payload.status = await getGlobalOptionSetValue(PoclFile.definition.mappings.status.ref, payload.status)
 
         const transactionFile = Object.assign(file, payload, { fileName: request.params.fileName })
         await persist(transactionFile)

--- a/packages/sales-api-service/src/services/__tests__/contacts.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/contacts.service.spec.js
@@ -24,7 +24,7 @@ describe('contacts service', () => {
       const mockPayload = mockContactWithIdPayload()
       const contact = await resolveContactPayload(mockPayload)
       expect(contact.isNew()).toBeFalsy()
-      expect(dynamicsLib.findById).toHaveBeenCalledWith(Contact, mockPayload.contactId)
+      expect(dynamicsLib.findById).toHaveBeenCalledWith(Contact, mockPayload.id)
     })
 
     it('creates a new contact entity if no contact found for an id', async () => {
@@ -32,7 +32,7 @@ describe('contacts service', () => {
       dynamicsLib.findById.mockImplementationOnce(() => undefined)
       const contact = await resolveContactPayload(mockPayload)
       expect(contact.isNew()).toBeTruthy()
-      expect(dynamicsLib.findById).toHaveBeenCalledWith(Contact, mockPayload.contactId)
+      expect(dynamicsLib.findById).toHaveBeenCalledWith(Contact, mockPayload.id)
     })
 
     it('resolves an existing contact by key fields', async () => {

--- a/packages/sales-api-service/src/services/__tests__/permissions.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/permissions.service.spec.js
@@ -2,9 +2,9 @@ import { generatePermissionNumber, calculateEndDate } from '../permissions.servi
 import moment from 'moment'
 import {
   MOCK_12MONTH_SENIOR_PERMIT,
-  MOCK_1DAY_SENIOR_PERMIT,
+  MOCK_1DAY_SENIOR_PERMIT_ENTITY,
   MOCK_12MONTH_DISABLED_PERMIT,
-  MOCK_1DAY_FULL_PERMIT,
+  MOCK_1DAY_FULL_PERMIT_ENTITY,
   MOCK_CONCESSION
 } from '../../__mocks__/test-data.js'
 import { JUNIOR_MAX_AGE, SENIOR_MIN_AGE } from '@defra-fish/business-rules-lib'
@@ -14,7 +14,12 @@ jest.mock('../reference-data.service.js', () => ({
   getReferenceDataForEntityAndId: async (entityType, id) => {
     let item = null
     if (entityType === MOCK_12MONTH_SENIOR_PERMIT.constructor) {
-      for (const permit of [MOCK_12MONTH_DISABLED_PERMIT, MOCK_12MONTH_SENIOR_PERMIT, MOCK_1DAY_SENIOR_PERMIT, MOCK_1DAY_FULL_PERMIT]) {
+      for (const permit of [
+        MOCK_12MONTH_DISABLED_PERMIT,
+        MOCK_12MONTH_SENIOR_PERMIT,
+        MOCK_1DAY_SENIOR_PERMIT_ENTITY,
+        MOCK_1DAY_FULL_PERMIT_ENTITY
+      ]) {
         if (permit.id === id) {
           return permit
         }
@@ -59,7 +64,7 @@ describe('permissions service', () => {
       const now = moment()
       const number = await generatePermissionNumber(
         {
-          permitId: MOCK_1DAY_FULL_PERMIT.id,
+          permitId: MOCK_1DAY_FULL_PERMIT_ENTITY.id,
           issueDate: now.toISOString(),
           startDate: now.toISOString(),
           licensee: {
@@ -85,7 +90,7 @@ describe('permissions service', () => {
       const now = moment()
       const number = await generatePermissionNumber(
         {
-          permitId: MOCK_1DAY_FULL_PERMIT.id,
+          permitId: MOCK_1DAY_FULL_PERMIT_ENTITY.id,
           issueDate: now.toISOString(),
           startDate: now.toISOString(),
           licensee: {

--- a/packages/sales-api-service/src/services/exceptions/exceptions.service.js
+++ b/packages/sales-api-service/src/services/exceptions/exceptions.service.js
@@ -1,4 +1,4 @@
-import { persist, StagingException, PoclStagingException, PoclFile } from '@defra-fish/dynamics-lib'
+import { persist, StagingException, PoclStagingException } from '@defra-fish/dynamics-lib'
 import db from 'debug'
 import { getGlobalOptionSetValue } from '../reference-data.service.js'
 const debug = db('sales:exceptions')
@@ -58,9 +58,7 @@ export const createTransactionFileException = async transactionFileError => {
     type: await getGlobalOptionSetValue(PoclStagingException.definition.mappings.type.ref, transactionFileError.type),
     status: await getGlobalOptionSetValue(PoclStagingException.definition.mappings.status.ref, 'Open')
   })
-  stagingException.bindToPoclFile(
-    `/${PoclFile.definition.dynamicsCollection}(${PoclFile.definition.alternateKey}='${transactionFileError.transactionFile}')`
-  )
+  stagingException.bindToAlternateKey(PoclStagingException.definition.relationships.poclFile, transactionFileError.transactionFile)
   await persist(stagingException)
   return stagingException
 }

--- a/packages/sales-api-service/src/services/permissions.service.js
+++ b/packages/sales-api-service/src/services/permissions.service.js
@@ -1,4 +1,4 @@
-import { Permit } from '@defra-fish/dynamics-lib'
+import { Permission, Permit } from '@defra-fish/dynamics-lib'
 import { isJunior, isSenior } from '@defra-fish/business-rules-lib'
 import { getGlobalOptionSetValue, getReferenceDataForEntityAndId } from './reference-data.service.js'
 import moment from 'moment'
@@ -28,7 +28,7 @@ export const generatePermissionNumber = async (
     .startOf('hour')
   const block1 = endTime.format('HH') + endDate.format('DDMMYY')
 
-  const dataSourceOptionSetValue = await getGlobalOptionSetValue('defra_datasource', dataSource)
+  const dataSourceOptionSetValue = await getGlobalOptionSetValue(Permission.definition.mappings.dataSource.ref, dataSource)
   const channel = dataSourceOptionSetValue.description.charAt(0)
   const type = permit.permitSubtype.description
 

--- a/packages/sales-api-service/src/services/transactions/__tests__/create-transaction.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/create-transaction.spec.js
@@ -5,7 +5,7 @@ import {
   MOCK_PERMISSION_NUMBER,
   MOCK_END_DATE,
   MOCK_12MONTH_SENIOR_PERMIT,
-  MOCK_1DAY_SENIOR_PERMIT
+  MOCK_1DAY_SENIOR_PERMIT_ENTITY
 } from '../../../__mocks__/test-data.js'
 import { TRANSACTIONS_STAGING_TABLE } from '../../../config.js'
 import AwsMock from 'aws-sdk'
@@ -22,8 +22,8 @@ jest.mock('../../reference-data.service.js', () => ({
     if (entityType === MOCK_12MONTH_SENIOR_PERMIT.constructor) {
       if (id === MOCK_12MONTH_SENIOR_PERMIT.id) {
         item = MOCK_12MONTH_SENIOR_PERMIT
-      } else if (id === MOCK_1DAY_SENIOR_PERMIT.id) {
-        item = MOCK_1DAY_SENIOR_PERMIT
+      } else if (id === MOCK_1DAY_SENIOR_PERMIT_ENTITY.id) {
+        item = MOCK_1DAY_SENIOR_PERMIT_ENTITY
       }
     }
     return item


### PR DESCRIPTION
- Add authentication using permission number, postcode and date of birth
- Add query framework to dynamics-lib
- Add localName in addition to localCollection property to entity definition
- Entity definition localCollection determined using pluralize of localName
- Remove unused permitId field on Permit entity (already present under id)
- Create common overseasPostcodeValidator (formats to uppercase)
- Allow multiple concession proofs when posting a new transaction