### PR TITLE
Revise git commit hooks to fix issues with sftp keys and secrets.env files

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "husky": {
     "hooks": {
-      "post-checkout": "chmod 0600 docker/resources/infrastructure/sftp/ssh_host_* && git update-index --assume-unchanged docker/env/*.secrets.env",
+      "post-merge": "chmod 0600 docker/resources/infrastructure/sftp/ssh_host_* && git update-index --skip-worktree docker/env/*.secrets.env",
       "pre-commit": "npm run test:only-changed && lint-staged"
     }
   },


### PR DESCRIPTION
- Move from post-checkout to post-merge to ensure hooks run after git pull
- Use --skip-worktree rather than --assume-unchanged for secrets.env files to avoid overwriting local customisations