### PR TITLE
Changes to renewals procedure: fixes and changes around non-mandatory fields

### DIFF
--- a/packages/gafl-webapp-service/src/pages/contact/address/entry/__tests__/address-entry-spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/entry/__tests__/address-entry-spec.js
@@ -102,6 +102,7 @@ describe('The manual address entry page', () => {
 
     const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
     expect(JSON.parse(payload).permissions[0].licensee).toEqual({
+      organisation: null,
       premises: '14 Howecroft Court',
       street: 'Eastmead Lane',
       town: 'Bristol',
@@ -120,6 +121,7 @@ describe('The manual address entry page', () => {
 
     const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
     expect(JSON.parse(payload).permissions[0].licensee).toEqual({
+      organisation: null,
       premises: '14 Howecroft Court',
       street: 'Eastmead Lane',
       town: 'Bristol',

--- a/packages/gafl-webapp-service/src/pages/contact/address/entry/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/entry/update-transaction.js
@@ -9,6 +9,6 @@ export default async request => {
   const { payload } = await request.cache().helpers.page.getCurrentPermission(ADDRESS_ENTRY.page)
   const { licensee } = await request.cache().helpers.transaction.getCurrentPermission()
   const { premises, street, locality, town, postcode, 'country-code': countryCode } = payload
-  Object.assign(licensee, { premises, street, locality, town, postcode, countryCode })
+  Object.assign(licensee, { premises, street, locality, town, postcode, countryCode, organisation: null })
   await request.cache().helpers.transaction.setCurrentPermission({ licensee })
 }

--- a/packages/gafl-webapp-service/src/pages/contact/contact/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/contact/contact/update-transaction.js
@@ -14,14 +14,14 @@ export default async request => {
       licensee.preferredMethodOfConfirmation = HOW_CONTACTED.email
       licensee.preferredMethodOfReminder = HOW_CONTACTED.email
       licensee.email = payload.email
-      delete licensee.mobilePhone
+      licensee.mobilePhone = null
       break
 
     case 'text':
       licensee.preferredMethodOfConfirmation = HOW_CONTACTED.text
       licensee.preferredMethodOfReminder = HOW_CONTACTED.text
       licensee.mobilePhone = payload.text
-      delete licensee.email
+      licensee.email = null
       break
 
     default:
@@ -33,8 +33,8 @@ export default async request => {
         licensee.preferredMethodOfReminder = HOW_CONTACTED.none
       }
 
-      delete licensee.mobilePhone
-      delete licensee.email
+      licensee.mobilePhone = null
+      licensee.email = null
   }
 
   await request.cache().helpers.transaction.setCurrentPermission(permission)

--- a/packages/gafl-webapp-service/src/pages/contact/newsletter/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/contact/newsletter/update-transaction.js
@@ -16,7 +16,7 @@ export default async request => {
   } else {
     licensee.preferredMethodOfNewsletter = HOW_CONTACTED.none
     if (licensee.preferredMethodOfConfirmation !== HOW_CONTACTED.email) {
-      delete licensee.email
+      licensee.email = null
     }
   }
 

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete.njk
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete.njk
@@ -130,7 +130,7 @@
         {{ govukButton({
             href: data.uri.new,
             attributes: { id: 'continue' },
-            text: "By another licence",
+            text: "Buy another licence",
             classes: "govuk-!-margin-top-9 no-print"
         }) }}
     </div>

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/__mocks__/data/authentication-result.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/__mocks__/data/authentication-result.js
@@ -18,6 +18,7 @@ export const authenticationResult = {
       birthDate: '1970-01-01',
       email: 'angling@email.com',
       mobilePhone: '07700 900 900',
+      organisation: null,
       premises: 'Howecroft Court',
       street: '2 Eastmead Lane',
       locality: '3',

--- a/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
+++ b/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
@@ -21,13 +21,19 @@ export const setUpCacheFromAuthenticationResult = async (request, authentication
   permission.licenceStartDate = moment(authenticationResult.permission.endDate).format('YYYY-MM-DD')
   permission.renewedEndDate = permission.licenceStartDate
   permission.licensee = Object.assign(
-    (({ country, preferredMethodOfConfirmation, preferredMethodOfNewsletter, preferredMethodOfReminder, organisation, ...l }) => l)(
+    (({ country, preferredMethodOfConfirmation, preferredMethodOfNewsletter, preferredMethodOfReminder, ...l }) => l)(
       authenticationResult.permission.licensee
     ),
     {
       countryCode: 'GB'
     }
   )
+
+  // Delete any licensee objects which are null
+  Object.entries(permission.licensee)
+    .filter(e => !e[1])
+    .map(e => e[0])
+    .forEach(k => delete permission.licensee[k])
 
   permission.licensee.preferredMethodOfNewsletter = authenticationResult.permission.licensee.preferredMethodOfNewsletter.label
   permission.licensee.preferredMethodOfConfirmation = authenticationResult.permission.licensee.preferredMethodOfConfirmation.label

--- a/packages/sales-api-service/src/schema/contact.schema.js
+++ b/packages/sales-api-service/src/schema/contact.schema.js
@@ -14,16 +14,17 @@ const commonContactSchema = {
   firstName: validation.contact.createFirstNameValidator(Joi),
   lastName: validation.contact.createLastNameValidator(Joi),
   birthDate: validation.contact.createBirthDateValidator(Joi),
-  email: validation.contact.createEmailValidator(Joi),
-  mobilePhone: validation.contact.createMobilePhoneValidator(Joi),
+  email: validation.contact.createEmailValidator(Joi).allow(null),
+  mobilePhone: validation.contact.createMobilePhoneValidator(Joi).allow(null),
   organisation: Joi.string()
     .trim()
     .min(1)
     .optional()
+    .allow(null)
     .example('Example Organisation'),
   premises: validation.contact.createPremisesValidator(Joi),
-  street: validation.contact.createStreetValidator(Joi),
-  locality: validation.contact.createLocalityValidator(Joi),
+  street: validation.contact.createStreetValidator(Joi).allow(null),
+  locality: validation.contact.createLocalityValidator(Joi).allow(null),
   town: validation.contact.createTownValidator(Joi),
   postcode: Joi.alternatives().conditional('country', {
     is: Joi.string().valid('GB', 'United Kingdom'),


### PR DESCRIPTION
(1) If an organisation is set (from pocl) for the licence being renewed it is retained (but not seen) unless the address is changed.
(2) If the user changes the method of reminder from email to mobile or vice-versa, then the old method is deleted from the CRM.
(3) Fix bug where non-mandatory address fields set null from the renewal data were not validated ok by the sales-api. These are now joi.allow(null) in the api.