### PR TITLE
Adjust licence validator, introduce disinfect library, refactoring improvements

### DIFF
--- a/packages/business-rules-lib/src/validators/permission.js
+++ b/packages/business-rules-lib/src/validators/permission.js
@@ -11,6 +11,7 @@ export const permissionNumberUniqueComponentValidator = joi =>
   joi
     .string()
     .trim()
+    .uppercase()
     .pattern(/^[A-Z0-9]{6}$/)
     .required()
     .description('The unqiue part of the permission reference number')

--- a/packages/business-rules-lib/src/validators/permission.js
+++ b/packages/business-rules-lib/src/validators/permission.js
@@ -11,7 +11,7 @@ export const permissionNumberUniqueComponentValidator = joi =>
   joi
     .string()
     .trim()
-    .pattern(/^[A-HJ-NP-Z0-9]{6}$/)
+    .pattern(/^[A-Z0-9]{6}$/)
     .required()
     .description('The unqiue part of the permission reference number')
     .example('U6HLG9')

--- a/packages/gafl-webapp-service/package-lock.json
+++ b/packages/gafl-webapp-service/package-lock.json
@@ -1085,6 +1085,14 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
       "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk="
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "async-done": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
@@ -1922,6 +1930,17 @@
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         }
+      }
+    },
+    "disinfect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/disinfect/-/disinfect-1.1.0.tgz",
+      "integrity": "sha512-ZxFp9MD8RBTmJEsrIe8SuqxUXGkLAMxeNR2b2ankitUqAP/VI5MvfqbcAfdWs31pPAq9eBja/UzNt0zESkulOg==",
+      "requires": {
+        "async": "^2.6.0",
+        "hoek": "^5.0.3",
+        "joi": "^13.1.2",
+        "sanitizer": "^0.1.3"
       }
     },
     "duplexer2": {
@@ -3771,6 +3790,11 @@
         }
       }
     },
+    "hoek": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -4120,6 +4144,14 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4137,6 +4169,16 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "joi": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+      "requires": {
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      }
     },
     "js-base64": {
       "version": "2.5.2",
@@ -4304,8 +4346,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -5320,8 +5361,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -5650,6 +5690,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sanitizer": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/sanitizer/-/sanitizer-0.1.3.tgz",
+      "integrity": "sha1-1PCvdHXZp7ryqeWmEXGLqheKOeE="
     },
     "sass-graph": {
       "version": "2.2.5",
@@ -6439,6 +6484,21 @@
       "dev": true,
       "requires": {
         "through2": "^2.0.3"
+      }
+    },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "requires": {
+        "hoek": "6.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
+        }
       }
     },
     "tough-cookie": {

--- a/packages/gafl-webapp-service/package-lock.json
+++ b/packages/gafl-webapp-service/package-lock.json
@@ -1130,29 +1130,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "aws-sdk": {
-      "version": "2.718.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.718.0.tgz",
-      "integrity": "sha512-YMWR1RJ3VuSbUOGeOfDw2QqRzwX51oa9TCm2G6SW+JywJUy0FTxi/Nj0VjVEQvKC0GqGu5QCgUTaarF7S0nQdw==",
-      "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
-    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1374,23 +1351,6 @@
         "ast-transform": "0.0.0",
         "ast-types": "^0.7.0",
         "browser-resolve": "^1.8.1"
-      }
-    },
-    "buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-          "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-        }
       }
     },
     "buffer-equal": {
@@ -2188,11 +2148,6 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -2853,7 +2808,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2874,12 +2830,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2894,17 +2852,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3021,7 +2982,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3033,6 +2995,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3047,6 +3010,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3054,12 +3018,14 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3078,6 +3044,7 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -3139,7 +3106,8 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -3167,7 +3135,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3179,6 +3148,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3256,7 +3226,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3292,6 +3263,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3311,6 +3283,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3354,12 +3327,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -3830,11 +3805,6 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
     "ignore": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
@@ -4167,11 +4137,6 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
-    },
-    "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-base64": {
       "version": "2.5.2",
@@ -4834,7 +4799,8 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "optional": true
     },
     "now-and-later": {
       "version": "2.0.1",
@@ -5363,11 +5329,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
     "quote-stream": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
@@ -5824,11 +5785,6 @@
           }
         }
       }
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "scope-analyzer": {
       "version": "2.1.1",
@@ -6694,22 +6650,6 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        }
-      }
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -6905,20 +6845,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.2",

--- a/packages/gafl-webapp-service/package.json
+++ b/packages/gafl-webapp-service/package.json
@@ -50,6 +50,7 @@
     "@hapi/vision": "^6.0.0",
     "blankie": "^5.0.0",
     "debug": "^4.1.1",
+    "disinfect": "^1.1.0",
     "find": "^0.3.0",
     "govuk-frontend": "^3.7.0",
     "moment": "^2.27.0",

--- a/packages/gafl-webapp-service/src/__tests__/server-test-sanitize.js
+++ b/packages/gafl-webapp-service/src/__tests__/server-test-sanitize.js
@@ -1,0 +1,31 @@
+import { start, stop, initialize, injectWithCookies, server } from '../__mocks__/test-utils.js'
+
+beforeAll(d => {
+  start(d)
+})
+
+beforeAll(d => initialize(d))
+
+beforeAll(() => {
+  server.route({
+    method: 'POST',
+    path: '/public/input-input/{uri}',
+    handler: async request => ({
+      payload: request.payload,
+      uri: request.params.uri,
+      query: request.query
+    })
+  })
+})
+
+afterAll(d => stop(d))
+
+describe('That the server', () => {
+  it('sanitizes user input', async () => {
+    const data = await injectWithCookies('POST', '/public/input-input/<script>?thing=<script>', { foo: '<script></script>' })
+    expect(data.statusCode).toBe(200)
+    expect(JSON.parse(data.payload).payload.foo).toBe('')
+    expect(JSON.parse(data.payload).uri).toBe('')
+    expect(JSON.parse(data.payload).query).toEqual({ thing: '' })
+  })
+})

--- a/packages/gafl-webapp-service/src/handlers/__tests__/attribution-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/attribution-handler.spec.js
@@ -27,20 +27,6 @@ describe('The attribution handler', () => {
     })
   })
 
-  it.each([
-    [UTM.CAMPAIGN, '<script>alert("hacked")</script>', '%3Cscript%3Ealert(%22hacked%22)%3C%2Fscript%3E'],
-    [UTM.MEDIUM, '<script>alert("busted")</script>', '%3Cscript%3Ealert(%22busted%22)%3C%2Fscript%3E'],
-    [UTM.CONTENT, '<script>alert("stolen")</script>', '%3Cscript%3Ealert(%22stolen%22)%3C%2Fscript%3E'],
-    [UTM.SOURCE, '<script>alert("pilfered")</script>', '%3Cscript%3Ealert(%22pilfered%22)%3C%2Fscript%3E'],
-    [UTM.TERM, '<script>alert("pinched")</script>', '%3Cscript%3Ealert(%22pinched%22)%3C%2Fscript%3E']
-  ])('Sanitises input values before persisting them', async (utmValue, sampleValue, sanitised) => {
-    const request = generateRequestMock({ [utmValue]: sampleValue })
-    await attributionHandler(request, generateResponseToolkitMock())
-    expect(request.cache.mock.results[0].value.helpers.status.set).toHaveBeenCalledWith({
-      attribution: expect.objectContaining({ [utmValue]: sanitised })
-    })
-  })
-
   it("redirects to ATTRIBUTION_REDIRECT_DEFAULT if ATTRIBUTION_REDIRECT env var isn't set", async () => {
     delete process.env.ATTRIBUTION_REDIRECT
     const query = { [UTM.CAMPAIGN]: 'campaign', [UTM.MEDIUM]: 'popup' }

--- a/packages/gafl-webapp-service/src/handlers/attribution-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/attribution-handler.js
@@ -1,7 +1,5 @@
 import { UTM, ATTRIBUTION_REDIRECT_DEFAULT } from '../constants.js'
 
-const sanitiseInput = value => (value ? encodeURIComponent(value) : value)
-
 /**
  * Attribution route handler
  * @param request
@@ -13,11 +11,11 @@ export default async (request, h) => {
   const cache = request.cache()
   await cache.helpers.status.set({
     attribution: {
-      [UTM.CAMPAIGN]: sanitiseInput(request.query[UTM.CAMPAIGN]),
-      [UTM.MEDIUM]: sanitiseInput(request.query[UTM.MEDIUM]),
-      [UTM.CONTENT]: sanitiseInput(request.query[UTM.CONTENT]),
-      [UTM.SOURCE]: sanitiseInput(request.query[UTM.SOURCE]),
-      [UTM.TERM]: sanitiseInput(request.query[UTM.TERM])
+      [UTM.CAMPAIGN]: request.query[UTM.CAMPAIGN],
+      [UTM.MEDIUM]: request.query[UTM.MEDIUM],
+      [UTM.CONTENT]: request.query[UTM.CONTENT],
+      [UTM.SOURCE]: request.query[UTM.SOURCE],
+      [UTM.TERM]: request.query[UTM.TERM]
     }
   })
   return h.redirect(redirectTarget)

--- a/packages/gafl-webapp-service/src/pages/contact/name/__tests__/name.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/name/__tests__/name.spec.js
@@ -64,7 +64,7 @@ describe('The name page', () => {
 
   it('Redirects back to itself on posting a last name with invalid characters', async () => {
     const data = await injectWithCookies('POST', NAME.uri, {
-      'last-name': '&&&',
+      'last-name': '%%%%',
       'first-name': 'OK'
     })
     expect(data.statusCode).toBe(302)

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -14,9 +14,9 @@
     set errorMap = {
         'referenceNumber' : {
             'string.empty': { text: 'Enter the last six digits of your licence number', ref: '#ref' },
-            'string.pattern.base': { text: 'The last six digits of your licence number doesn\'t look right. Check and enter again', ref: '#ref' },
+            'string.pattern.base': { text: 'The last six digits of your licence number don\'t look right. Check and enter again', ref: '#ref' },
             'string.invalid': {
-                text: 'The details you entered do not match those we have on record for licence number ' + payload.referenceNumber + '. Please check you have entered the correct date of birth and postcode',
+                text: 'The details you entered do not match those we have on record for the licence number ending ' + payload.referenceNumber + '. Please check you have entered your correct date of birth and postcode.',
                 ref: "#ref"
             }
         },

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -12,6 +12,14 @@
 
 {%
     set errorMap = {
+        'referenceNumber' : {
+            'string.empty': { text: 'Enter the last six digits of your licence number', ref: '#ref' },
+            'string.pattern.base': { text: 'The last six digits of your licence number doesn\'t look right. Check and enter again', ref: '#ref' },
+            'string.invalid': {
+                text: 'The details you entered do not match those we have on record for licence number ' + payload.referenceNumber + '. Please check you have entered the correct date of birth and postcode',
+                ref: "#ref"
+            }
+        },
         'date-of-birth': {
             'date.format': { ref: '#date-of-birth-day', text: 'Enter your date of birth and include a day, month and year' },
             'date.max': { ref: '#date-of-birth-day', text: 'Your date of birth must be in the past' },
@@ -20,14 +28,6 @@
         'postcode': {
             'string.empty': { ref: '#postcode', text: 'You did not enter your postcode' },
             'string.pattern.base': { ref: '#postcode', text: 'Your postcode doesn\'t look right. Check and enter again' }
-        },
-        'referenceNumber' : {
-            'string.empty': { text: 'Enter the last six digits of your licence number', ref: '#ref' },
-            'string.pattern.base': { text: 'The last six digits of your licence number doesn\'t look right. Check and enter again', ref: '#ref' },
-            'string.invalid': {
-                text: 'The details you entered do not match those we have on record for licence number ' + payload.referenceNumber + '. Please check you have entered the correct date of birth and postcode',
-                ref: "#ref"
-            }
         }
     }
 %}

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -16,7 +16,7 @@
             'string.empty': { text: 'Enter the last six digits of your licence number', ref: '#ref' },
             'string.pattern.base': { text: 'The last six digits of your licence number don\'t look right. Check and enter again', ref: '#ref' },
             'string.invalid': {
-                text: 'The details you entered do not match those we have on record for the licence number ending ' + payload.referenceNumber + '. Please check you have entered your correct date of birth and postcode.',
+                text: 'We do not have any record of a licence number ending ' + payload.referenceNumber + ' matching these details.',
                 ref: "#ref"
             }
         },

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/route.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/route.js
@@ -21,9 +21,9 @@ const getData = async request => {
 }
 
 const schema = Joi.object({
+  referenceNumber: validation.permission.permissionNumberUniqueComponentValidator(Joi),
   'date-of-birth': validation.contact.createBirthDateValidator(Joi),
-  postcode: validation.contact.createUKPostcodeValidator(Joi),
-  referenceNumber: validation.permission.permissionNumberUniqueComponentValidator(Joi)
+  postcode: validation.contact.createUKPostcodeValidator(Joi)
 }).options({ abortEarly: false, allowUnknown: true })
 
 const validator = async payload => {

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -7,12 +7,12 @@ import Crumb from '@hapi/crumb'
 import HapiGapi from '@defra/hapi-gapi'
 import { useSessionCookie } from './session-cache/session-manager.js'
 import { UTM } from './constants.js'
-
+import { getCsrfTokenCookieName } from './server.js'
 // This is a hash of the inline script at line 31 of the GDS template. It is added to the CSP to except the in-line
 // script. It needs the quotes.
 const scriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
 
-export const getPlugins = (getSessionCookieName, getCsrfTokenCookieName) => {
+export const getPlugins = () => {
   const hapiGapiPropertySettings = []
   if (process.env.ANALYTICS_PRIMARY_PROPERTY) {
     hapiGapiPropertySettings.push({

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -1,0 +1,93 @@
+import Inert from '@hapi/inert'
+import Vision from '@hapi/vision'
+import Disinfect from 'disinfect'
+import Scooter from '@hapi/scooter'
+import Blankie from 'blankie'
+import Crumb from '@hapi/crumb'
+import HapiGapi from '@defra/hapi-gapi'
+import { useSessionCookie } from './session-cache/session-manager.js'
+import { UTM } from './constants.js'
+
+// This is a hash of the inline script at line 31 of the GDS template. It is added to the CSP to except the in-line
+// script. It needs the quotes.
+const scriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
+
+export const getPlugIns = (getSessionCookieName, getCsrfTokenCookieName) => {
+  const hapiGapiPropertySettings = []
+  if (process.env.ANALYTICS_PRIMARY_PROPERTY) {
+    hapiGapiPropertySettings.push({
+      id: process.env.ANALYTICS_PRIMARY_PROPERTY,
+      hitTypes: ['pageview', 'event', 'ecommerce']
+    })
+  } else {
+    console.warn("ANALYTICS_PRIMARY_PROPERTY not set, so Google Analytics won't track this")
+  }
+  if (process.env.ANALYTICS_XGOV_PROPERTY) {
+    hapiGapiPropertySettings.push({
+      id: process.env.ANALYTICS_XGOV_PROPERTY,
+      hitTypes: ['pageview']
+    })
+  } else {
+    console.warn("ANALYTICS_XGOV_PROPERTY not set, so Google Analytics won't track this")
+  }
+
+  return [
+    Inert,
+    Vision,
+    Scooter,
+    {
+      plugin: Disinfect,
+      options: {
+        disinfectQuery: true,
+        disinfectParams: true,
+        disinfectPayload: true
+      }
+    },
+    {
+      plugin: Blankie,
+      options: {
+        /*
+         * This defines the content security policy - which is as restrictive as possible
+         * It must allow web-fonts from 'fonts.gstatic.com'
+         */
+        fontSrc: ['self', 'fonts.gstatic.com', 'data:'],
+        scriptSrc: [scriptHash],
+        generateNonces: true
+      }
+    },
+    {
+      plugin: Crumb,
+      options: {
+        key: getCsrfTokenCookieName(),
+        cookieOptions: {
+          isSecure: process.env.NODE_ENV !== 'development',
+          isHttpOnly: process.env.NODE_ENV !== 'development'
+        },
+        logUnauthorized: true
+      }
+    },
+    {
+      plugin: HapiGapi,
+      options: {
+        propertySettings: hapiGapiPropertySettings,
+        sessionIdProducer: request => (useSessionCookie(request) ? request.cache().getId() : null),
+        attributionProducer: async request => {
+          if (useSessionCookie(request)) {
+            const { attribution } = await request.cache().helpers.status.get()
+
+            if (attribution) {
+              return {
+                campaign: attribution[UTM.CAMPAIGN],
+                content: attribution[UTM.CONTENT],
+                medium: attribution[UTM.MEDIUM],
+                source: attribution[UTM.SOURCE],
+                term: attribution[UTM.TERM]
+              }
+            }
+          }
+          return {}
+        }
+      }
+    }
+  ]
+}

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -12,7 +12,7 @@ import { UTM } from './constants.js'
 // script. It needs the quotes.
 const scriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
 
-export const getPlugIns = (getSessionCookieName, getCsrfTokenCookieName) => {
+export const getPlugins = (getSessionCookieName, getCsrfTokenCookieName) => {
   const hapiGapiPropertySettings = []
   if (process.env.ANALYTICS_PRIMARY_PROPERTY) {
     hapiGapiPropertySettings.push({

--- a/packages/gafl-webapp-service/src/server.js
+++ b/packages/gafl-webapp-service/src/server.js
@@ -58,7 +58,7 @@ const createServer = options => {
  * The hapi plugins and their options which will be registered on initialization
  */
 const getSessionCookieName = () => process.env.SESSION_COOKIE_NAME || SESSION_COOKIE_NAME_DEFAULT
-const getCsrfTokenCookieName = () => process.env.CSRF_TOKEN_COOKIE_NAME || CSRF_TOKEN_COOKIE_NAME_DEFAULT
+export const getCsrfTokenCookieName = () => process.env.CSRF_TOKEN_COOKIE_NAME || CSRF_TOKEN_COOKIE_NAME_DEFAULT
 
 /**
  * Adds the uri's used by the layout page to each relevant response
@@ -83,7 +83,7 @@ const layoutContextAmalgamation = (request, h) => {
 }
 
 const init = async () => {
-  await server.register(getPlugins(getSessionCookieName, getCsrfTokenCookieName))
+  await server.register(getPlugins())
   const viewPaths = [...new Set(find.fileSync(/\.njk$/, path.join(Dirname, './src/pages')).map(f => path.dirname(f)))]
 
   server.views({

--- a/packages/gafl-webapp-service/src/server.js
+++ b/packages/gafl-webapp-service/src/server.js
@@ -22,7 +22,7 @@ import { ACCESSIBILITY_STATEMENT, COOKIES, PRIVACY_POLICY, REFUND_POLICY } from 
 import sessionManager from './session-cache/session-manager.js'
 import { cacheDecorator } from './session-cache/cache-decorator.js'
 import { errorHandler } from './handlers/error-handler.js'
-import { getPlugIns } from './plugins.js'
+import { getPlugins } from './plugins.js'
 
 let server
 
@@ -83,7 +83,7 @@ const layoutContextAmalgamation = (request, h) => {
 }
 
 const init = async () => {
-  await server.register(getPlugIns(getSessionCookieName, getCsrfTokenCookieName))
+  await server.register(getPlugins(getSessionCookieName, getCsrfTokenCookieName))
   const viewPaths = [...new Set(find.fileSync(/\.njk$/, path.join(Dirname, './src/pages')).map(f => path.dirname(f)))]
 
   server.views({


### PR DESCRIPTION
(1) Changed the ordering of the messages on the renewals page.
(2) Relax validation of reference number to allow old licence numbers to be renewed
(3) Add input sanitisation - removed existing function around the attribution handler - 
this; http://0.0.0.0:3000/buy/attribution?utm_campaign='<script>HACK!!!</script>'&utm_medium='This is ok'
Is safe, as are inputs via the payload.
Note that disinfect simply removes anything that could be a script; <, > etc is escaped but  <.*> is replaced by ''. 
(4) Extracted the plugins to another file - server.js was getting too long