### PR TITLE
Performance tuning of SQS integration and POCL job

### DIFF
--- a/docker/env/sqs_receiver.env
+++ b/docker/env/sqs_receiver.env
@@ -13,13 +13,13 @@ AWS_SQS_ENDPOINT=http://host.docker.internal:9324
 TRANSACTION_QUEUE_URL=http://host.docker.internal:9324/queue/TransactionsQueue.fifo
 TRANSACTION_QUEUE_MAX_POLLING_INTERVAL_MS=30000
 TRANSACTION_QUEUE_VISIBILITY_TIMEOUT_MS=300000
-TRANSACTION_QUEUE_SUBSCRIBER=http://host.docker.internal:4000/process-queue
+TRANSACTION_QUEUE_SUBSCRIBER=http://host.docker.internal:4000/process-queue/transactions
 
 # Transactions dead letter queue
 TRANSACTION_DLQ_URL=http://host.docker.internal:9324/queue/TransactionsDlq.fifo
 TRANSACTION_DLQ_MAX_POLLING_INTERVAL_MS=180000
 TRANSACTION_DLQ_VISIBILITY_TIMEOUT_MS=300000
-TRANSACTION_DLQ_SUBSCRIBER=http://host.docker.internal:4000/process-dlq
+TRANSACTION_DLQ_SUBSCRIBER=http://host.docker.internal:4000/process-dlq/transactions
 
 # Debug settings
 DEBUG=sqs:*

--- a/packages/pocl-job/src/staging/__tests__/create-transactions.spec.js
+++ b/packages/pocl-job/src/staging/__tests__/create-transactions.spec.js
@@ -1,6 +1,6 @@
 import Project from '../../project.cjs'
 import { createTransactions } from '../create-transactions.js'
-import { RECORD_STAGE, MAX_BATCH_SIZE } from '../constants.js'
+import { RECORD_STAGE, MAX_CREATE_TRANSACTION_BATCH_SIZE } from '../constants.js'
 import * as db from '../../io/db.js'
 import { v4 as uuidv4 } from 'uuid'
 import { salesApi } from '@defra-fish/connectors-lib'
@@ -40,11 +40,11 @@ describe('create-transactions', () => {
   })
 
   it('stages the 25 record test file (on batch-size boundary)', async () => {
-    salesApi.createTransactions.mockReturnValue(generateApiSuccessResponse(MAX_BATCH_SIZE))
+    salesApi.createTransactions.mockReturnValue(generateApiSuccessResponse(MAX_CREATE_TRANSACTION_BATCH_SIZE))
     await createTransactions(`${Project.root}/src/__mocks__/test-25-records.xml`)
-    expectCreateTransactionCalls(MAX_BATCH_SIZE)
+    expectCreateTransactionCalls(MAX_CREATE_TRANSACTION_BATCH_SIZE)
     expect(db.updateRecordStagingTable.mock.calls).toHaveLength(1)
-    expect(db.updateRecordStagingTable.mock.calls[0][1]).toHaveLength(MAX_BATCH_SIZE)
+    expect(db.updateRecordStagingTable.mock.calls[0][1]).toHaveLength(MAX_CREATE_TRANSACTION_BATCH_SIZE)
     expect(db.updateRecordStagingTable.mock.calls[0][1]).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -58,9 +58,9 @@ describe('create-transactions', () => {
   it('stages the 30 record test file (over batch-size boundary)', async () => {
     salesApi.createTransactions.mockReturnValue(generateApiSuccessResponse(30))
     await createTransactions(`${Project.root}/src/__mocks__/test-30-records.xml`)
-    expectCreateTransactionCalls(MAX_BATCH_SIZE, 5)
+    expectCreateTransactionCalls(MAX_CREATE_TRANSACTION_BATCH_SIZE, 5)
     expect(db.updateRecordStagingTable.mock.calls).toHaveLength(2)
-    expect(db.updateRecordStagingTable.mock.calls[0][1]).toHaveLength(MAX_BATCH_SIZE)
+    expect(db.updateRecordStagingTable.mock.calls[0][1]).toHaveLength(MAX_CREATE_TRANSACTION_BATCH_SIZE)
     expect(db.updateRecordStagingTable.mock.calls[0][1]).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/packages/pocl-job/src/staging/__tests__/finalise-transactions.spec.js
+++ b/packages/pocl-job/src/staging/__tests__/finalise-transactions.spec.js
@@ -1,5 +1,5 @@
 import { finaliseTransactions } from '../finalise-transactions.js'
-import { RECORD_STAGE, MAX_BATCH_SIZE } from '../constants.js'
+import { RECORD_STAGE, MAX_FINALISE_TRANSACTION_BATCH_SIZE } from '../constants.js'
 import * as db from '../../io/db.js'
 import { salesApi } from '@defra-fish/connectors-lib'
 
@@ -62,13 +62,13 @@ describe('finalise-transactions', () => {
     ])
   })
 
-  it(`calls finalisation in batches of ${MAX_BATCH_SIZE}`, async () => {
+  it(`calls finalisation in batches of ${MAX_FINALISE_TRANSACTION_BATCH_SIZE}`, async () => {
     db.getProcessedRecords.mockReturnValueOnce(
-      Array(MAX_BATCH_SIZE + 1).fill({ id: `test-${Math.random()}`, stage: RECORD_STAGE.TransactionCreated })
+      Array(MAX_FINALISE_TRANSACTION_BATCH_SIZE + 1).fill({ id: `test-${Math.random()}`, stage: RECORD_STAGE.TransactionCreated })
     )
     salesApi.finaliseTransaction.mockResolvedValue({ messageId: `message-${Math.random()}`, status: 'queued' })
     await finaliseTransactions(TEST_FILENAME)
-    expect(salesApi.finaliseTransaction).toHaveBeenCalledTimes(MAX_BATCH_SIZE + 1)
+    expect(salesApi.finaliseTransaction).toHaveBeenCalledTimes(MAX_FINALISE_TRANSACTION_BATCH_SIZE + 1)
     expect(db.updateRecordStagingTable).toHaveBeenCalledTimes(2)
   })
 

--- a/packages/pocl-job/src/staging/constants.js
+++ b/packages/pocl-job/src/staging/constants.js
@@ -1,4 +1,5 @@
-export const MAX_BATCH_SIZE = 25
+export const MAX_CREATE_TRANSACTION_BATCH_SIZE = 25
+export const MAX_FINALISE_TRANSACTION_BATCH_SIZE = 10
 
 export const POST_OFFICE_DATASOURCE = 'Post Office Sales'
 

--- a/packages/pocl-job/src/staging/create-transactions.js
+++ b/packages/pocl-job/src/staging/create-transactions.js
@@ -1,6 +1,6 @@
 import { salesApi } from '@defra-fish/connectors-lib'
 import Path from 'path'
-import { MAX_BATCH_SIZE, RECORD_STAGE } from './constants.js'
+import { MAX_CREATE_TRANSACTION_BATCH_SIZE, RECORD_STAGE } from './constants.js'
 import { transform } from '../transform/pocl-transform-stream.js'
 import { getProcessedRecords, updateRecordStagingTable } from '../io/db.js'
 import db from 'debug'
@@ -21,7 +21,7 @@ export const createTransactions = async xmlFilePath => {
       if (!state.processedIds.has(data.id)) {
         state.processedIds.add(data.id)
         state.buffer.push(data)
-        if (state.buffer.length === MAX_BATCH_SIZE) {
+        if (state.buffer.length === MAX_CREATE_TRANSACTION_BATCH_SIZE) {
           await createTransactionsInSalesApi(filename, state)
         }
       }

--- a/packages/pocl-job/src/staging/finalise-transactions.js
+++ b/packages/pocl-job/src/staging/finalise-transactions.js
@@ -1,6 +1,6 @@
 import { salesApi } from '@defra-fish/connectors-lib'
 import Path from 'path'
-import { MAX_BATCH_SIZE, RECORD_STAGE } from './constants.js'
+import { MAX_FINALISE_TRANSACTION_BATCH_SIZE, RECORD_STAGE } from './constants.js'
 import { getProcessedRecords, updateRecordStagingTable } from '../io/db.js'
 import db from 'debug'
 const debug = db('pocl:staging')
@@ -14,8 +14,8 @@ const debug = db('pocl:staging')
 export const finaliseTransactions = async xmlFilePath => {
   const filename = Path.basename(xmlFilePath)
   const state = await getInitialState(filename)
-  for (let i = 0; i < state.remainingRecords.length; i += MAX_BATCH_SIZE) {
-    state.buffer = state.remainingRecords.slice(i, i + MAX_BATCH_SIZE)
+  for (let i = 0; i < state.remainingRecords.length; i += MAX_FINALISE_TRANSACTION_BATCH_SIZE) {
+    state.buffer = state.remainingRecords.slice(i, i + MAX_FINALISE_TRANSACTION_BATCH_SIZE)
     await finaliseTransactionsInSalesApi(filename, state)
   }
   return { succeeded: state.succeeded, failed: state.failed }

--- a/packages/sales-api-service/src/services/transactions/__tests__/finalise-transaction.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/finalise-transaction.spec.js
@@ -40,7 +40,7 @@ describe('transaction service', () => {
       expect(AwsMock.SQS.mockedMethods.sendMessage).toBeCalledWith(
         expect.objectContaining({
           QueueUrl: TRANSACTION_QUEUE.Url,
-          MessageGroupId: 'transactions',
+          MessageGroupId: mockRecord.id,
           MessageDeduplicationId: mockRecord.id,
           MessageBody: JSON.stringify({ id: mockRecord.id })
         })

--- a/packages/sales-api-service/src/services/transactions/finalise-transaction.js
+++ b/packages/sales-api-service/src/services/transactions/finalise-transaction.js
@@ -31,7 +31,7 @@ export async function finaliseTransaction ({ id, ...payload }) {
   const receipt = await sqs
     .sendMessage({
       QueueUrl: TRANSACTION_QUEUE.Url,
-      MessageGroupId: 'transactions',
+      MessageGroupId: id,
       MessageDeduplicationId: id,
       MessageBody: JSON.stringify({ id })
     })

--- a/packages/sqs-receiver-service/README.md
+++ b/packages/sqs-receiver-service/README.md
@@ -17,7 +17,7 @@ If the response from the subscriber is successful the message will be removed fr
 | <RECEIVER_PREFIX>\_VISIBILITY_TIMEOUT_MS   | The length of time the message is made invisible to other processes      |   yes    |                    |                                                                                                 |                                                                                                                               |
 | <RECEIVER_PREFIX>\_MAX_POLLING_INTERVAL_MS | The maximum amount of time to wait between subsequent read requests      |    no    | 300000 (5 minutes) |                                                                                                 | For each read request returning no messages, an exponential delay is calculated before reading again. This limits that delay. |
 | <RECEIVER_PREFIX>\_ATTEMPTS_WITH_NO_DELAY  | Number of receive requests with no messages before imposing a delay      |    no    | 10                 |                                                                                                 | Receive message requests may return no messages even if there are messages waiting. Allow this many requests before delaying. |
-| <RECEIVER_PREFIX>\_SUBSCRIBER              | The location of the subscriber. The message group id is appended         |   yes    |                    |                                                                                                 |                                                                                                                               |
+| <RECEIVER_PREFIX>\_SUBSCRIBER              | The location of the subscriber.                                          |   yes    |                    |                                                                                                 |                                                                                                                               |
 | <RECEIVER_PREFIX>\_SUBSCRIBER_TIMEOUT_MS   | Prefix for reading environment variables specific to a receiver instance |    no    | 180000 (3m)        |                                                                                                 |                                                                                                                               |
 | DEBUG                                      | Enable debug output                                                      |    no    |                    | sqs:\*, sqs:receiver, sqs:read-queue, sqs:process-message, sqs:delete-messages, sqs:queue-stats | Enables debug output for the given category, accepts wildcards                                                                |
 
@@ -65,10 +65,10 @@ DEBUG=sqs:*
 TRANSACTION_QUEUE_URL=http://0.0.0.0:9324/queue/TransactionsQueue.fifo
 TRANSACTION_QUEUE_MAX_POLLING_INTERVAL_MS=30000
 TRANSACTION_QUEUE_VISIBILITY_TIMEOUT_MS=300000
-TRANSACTION_QUEUE_SUBSCRIBER=http://0.0.0.0:4000/process-queue
+TRANSACTION_QUEUE_SUBSCRIBER=http://0.0.0.0:4000/process-queue/transactions
 
 TRANSACTION_DLQ_URL=http://0.0.0.0:9324/queue/TransactionsDlq.fifo
 TRANSACTION_DLQ_MAX_POLLING_INTERVAL_MS=180000
 TRANSACTION_DLQ_VISIBILITY_TIMEOUT_MS=300000
-TRANSACTION_DLQ_SUBSCRIBER=http://0.0.0.0:4000/process-dlq
+TRANSACTION_DLQ_SUBSCRIBER=http://0.0.0.0:4000/process-dlq/transactions
 ```

--- a/packages/sqs-receiver-service/src/process-message.js
+++ b/packages/sqs-receiver-service/src/process-message.js
@@ -15,8 +15,7 @@ const debug = db('sqs:process-message')
  */
 
 /**
- * Posts what ever is in the body of the message to the subscriber. The message group id is added to the
- * subscriber url to allow the sent message to be directed to a specific endpoint
+ * Posts what ever is in the body of the message to the subscriber.
  *
  * @param {SQS.Message} message The message to be processed
  * @param {string} subscriber The subscriber URL
@@ -24,10 +23,7 @@ const debug = db('sqs:process-message')
  * @returns {Promise<ProcessingResponse>}
  */
 const processMessage = async (message, subscriber, subscriberTimeoutMs) => {
-  const subscriberURL = message.Attributes.MessageGroupId
-    ? new URL(`${subscriber}/${message.Attributes.MessageGroupId}`)
-    : new URL(subscriber)
-
+  const subscriberURL = new URL(subscriber)
   let responseData
   try {
     debug('Sending message to %s: %o', subscriberURL.toString(), message)


### PR DESCRIPTION
**Remove routing based on MessageGroupId and revise poll delay logic**
- Avoid using the same MessageGroupId for all messages
- Avoid queue being blocked if one message fails to be delivered
- Fix issue with poll delay logic to allow delay to be increased incrementally

**Reduce batch size of concurrent finalise transaction requests in POCL job**
- Separate batch size for create transaction and finalise transaction calls