### PR TITLE
Workaround for bug in adal-node failing to cache tokens and leaking memory

### DIFF
--- a/packages/dynamics-lib/package-lock.json
+++ b/packages/dynamics-lib/package-lock.json
@@ -130,6 +130,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",

--- a/packages/dynamics-lib/package.json
+++ b/packages/dynamics-lib/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@hapi/joi": "^17.1.1",
     "adal-node": "^0.2.1",
+    "bottleneck": "^2.19.5",
     "cache-manager": "^3.3.0",
     "cache-manager-ioredis": "^2.1.0",
     "debug": "^4.1.1",

--- a/packages/dynamics-lib/src/client/dynamics-client.js
+++ b/packages/dynamics-lib/src/client/dynamics-client.js
@@ -1,8 +1,18 @@
 import util from 'util'
 import DynamicsWebApi from 'dynamics-web-api'
 import AdalNode from 'adal-node'
+import Bottleneck from 'bottleneck'
 import db from 'debug'
 const debug = db('dynamics:auth')
+
+/*
+Bottleneck is used to prevent more than one request to retrieve a token from being executed concurrently. This is due to a bug in adal-node which
+adds multiple cache entries if acquireTokenWithClientCredentials is invoked more than once before the first call returns (asynchronously).
+Once this occurs, subsequent calls to the cache always fail as the cache finds more than one candidate to return.  Therefore more entries get added
+to the cache and it keeps growing forever.
+I have raised an issue with Microsoft here: https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/issues/239
+ */
+const limiter = new Bottleneck({ maxConcurrent: 1 })
 
 export function config () {
   if (debug.enabled) {
@@ -15,7 +25,7 @@ export function config () {
 
   const authorityUrl = `${process.env.OAUTH_AUTHORITY_HOST_URL}${process.env.OAUTH_TENANT}`
   const adalContext = new AdalNode.AuthenticationContext(authorityUrl)
-  const acquireTokenWithClientCredentials = util.promisify(adalContext.acquireTokenWithClientCredentials).bind(adalContext)
+  const acquireTokenWithClientCredentials = limiter.wrap(util.promisify(adalContext.acquireTokenWithClientCredentials).bind(adalContext))
 
   return {
     webApiUrl: process.env.DYNAMICS_API_PATH,


### PR DESCRIPTION
Issue described here: https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/issues/239