### PR TITLE
Expose concession id in renewals authentication response

### DIFF
--- a/packages/dynamics-lib/src/entities/__tests__/concession-proof.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/concession-proof.entity.spec.js
@@ -20,7 +20,7 @@ describe('concession proof entity', () => {
     const expectedFields = {
       id: 'ee336a19-417e-ea11-a811-000d3a64905b',
       referenceNumber: 'AB 01 02 03 CD',
-      proofType: expect.objectContaining({ id: 910400001, label: 'National Insurance Number', description: 'National Insurance Number' })
+      type: expect.objectContaining({ id: 910400001, label: 'National Insurance Number', description: 'National Insurance Number' })
     }
 
     expect(proof).toBeInstanceOf(ConcessionProof)
@@ -43,7 +43,7 @@ describe('concession proof entity', () => {
 
     const concessionProof = new ConcessionProof()
     concessionProof.referenceNumber = 'TEST'
-    concessionProof.proofType = optionSetData.defra_concessionproof.options['910400000']
+    concessionProof.type = optionSetData.defra_concessionproof.options['910400000']
     concessionProof.bindToEntity(ConcessionProof.definition.relationships.permission, permission)
     concessionProof.bindToEntity(ConcessionProof.definition.relationships.concession, concession)
 

--- a/packages/dynamics-lib/src/entities/concession-proof.entity.js
+++ b/packages/dynamics-lib/src/entities/concession-proof.entity.js
@@ -15,7 +15,7 @@ export class ConcessionProof extends BaseEntity {
     mappings: {
       id: { field: 'defra_concessionproofid', type: 'string' },
       referenceNumber: { field: 'defra_referencenumber', type: 'string' },
-      proofType: { field: 'defra_concessionprooftype', type: 'optionset', ref: 'defra_concessionproof' }
+      type: { field: 'defra_concessionprooftype', type: 'optionset', ref: 'defra_concessionproof' }
     },
     relationships: {
       permission: { property: 'defra_PermissionId', entity: Permission, parent: true },
@@ -47,11 +47,11 @@ export class ConcessionProof extends BaseEntity {
    * The type of the concession proof
    * @type {GlobalOptionSetDefinition}
    */
-  get proofType () {
-    return super._getState('proofType')
+  get type () {
+    return super._getState('type')
   }
 
-  set proofType (proofType) {
-    super._setState('proofType', proofType)
+  set type (type) {
+    super._setState('type', type)
   }
 }

--- a/packages/dynamics-lib/src/queries/__tests__/fulfilment.queries.spec.js
+++ b/packages/dynamics-lib/src/queries/__tests__/fulfilment.queries.spec.js
@@ -9,10 +9,9 @@ describe('Fulfilment Queries', () => {
         expand: expect.arrayContaining([
           expect.objectContaining({
             property: 'defra_PermissionId',
-            select: expect.any(Array),
             expand: expect.arrayContaining([
-              expect.objectContaining({ property: 'defra_ContactId', select: expect.any(Array) }),
-              expect.objectContaining({ property: 'defra_PermitId', select: expect.any(Array) })
+              expect.objectContaining({ property: 'defra_ContactId' }),
+              expect.objectContaining({ property: 'defra_PermitId' })
             ])
           })
         ]),

--- a/packages/dynamics-lib/src/queries/__tests__/permission.queries.spec.js
+++ b/packages/dynamics-lib/src/queries/__tests__/permission.queries.spec.js
@@ -7,9 +7,9 @@ describe('Permission Queries', () => {
       expect(query.toRetrieveRequest()).toEqual({
         collection: 'defra_permissions',
         expand: expect.arrayContaining([
-          expect.objectContaining({ property: 'defra_ContactId', select: expect.any(Array) }),
-          expect.objectContaining({ property: 'defra_PermitId', select: expect.any(Array) }),
-          expect.objectContaining({ property: 'defra_defra_permission_defra_concessionproof_PermissionId', select: expect.any(Array) })
+          expect.objectContaining({ property: 'defra_ContactId' }),
+          expect.objectContaining({ property: 'defra_PermitId' }),
+          expect.objectContaining({ property: 'defra_defra_permission_defra_concessionproof_PermissionId' })
         ]),
         filter:
           "endswith(defra_name, 'ABC123') and defra_ContactId/defra_postcode eq 'AB12 3CD' and defra_ContactId/birthdate eq 2000-01-01 and statecode eq 0",

--- a/packages/dynamics-lib/src/queries/__tests__/predefined-query.spec.js
+++ b/packages/dynamics-lib/src/queries/__tests__/predefined-query.spec.js
@@ -66,12 +66,10 @@ describe('PredefinedQuery', () => {
       select: expectedTestEntitySelect,
       expand: [
         {
-          property: 'parent_test_entity',
-          select: expectedTestEntitySelect
+          property: 'parent_test_entity'
         },
         {
-          property: 'child_test_entity',
-          select: expectedTestEntitySelect
+          property: 'child_test_entity'
         }
       ]
     })

--- a/packages/dynamics-lib/src/queries/permission.queries.js
+++ b/packages/dynamics-lib/src/queries/permission.queries.js
@@ -1,5 +1,6 @@
 import { PredefinedQuery } from './predefined-query.js'
 import { Permission } from '../entities/permission.entity.js'
+import { ConcessionProof } from '../entities/concession-proof.entity.js'
 import { escapeODataStringValue } from '../client/util.js'
 
 /**
@@ -12,11 +13,16 @@ import { escapeODataStringValue } from '../client/util.js'
  */
 export const permissionForLicensee = (permissionReferenceNumber, licenseeBirthDate, licenseePostcode) => {
   const { licensee, permit, concessionProofs } = Permission.definition.relationships
+  const { concession } = ConcessionProof.definition.relationships
   let filter = `endswith(${Permission.definition.mappings.referenceNumber.field}, '${escapeODataStringValue(permissionReferenceNumber)}')`
   filter += ` and ${licensee.property}/${licensee.entity.definition.mappings.postcode.field} eq '${escapeODataStringValue(
     licenseePostcode
   )}'`
   filter += ` and ${licensee.property}/${licensee.entity.definition.mappings.birthDate.field} eq ${licenseeBirthDate}`
   filter += ` and ${Permission.definition.defaultFilter}`
-  return new PredefinedQuery({ root: Permission, filter: filter, expand: [licensee, permit, concessionProofs] })
+  return new PredefinedQuery({
+    root: Permission,
+    filter: filter,
+    expand: [licensee, permit, { ...concessionProofs, expand: [concession] }]
+  })
 }

--- a/packages/dynamics-lib/src/queries/predefined-query.js
+++ b/packages/dynamics-lib/src/queries/predefined-query.js
@@ -9,7 +9,6 @@ const buildExpands = expand => ({
   ...(expand && {
     expand: expand.map(e => ({
       property: e.property,
-      select: e.entity.definition.select,
       ...buildExpands(e.expand)
     }))
   })

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/__mocks__/data/authentication-result.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/__mocks__/data/authentication-result.js
@@ -47,12 +47,27 @@ export const authenticationResult = {
     },
     concessions: [
       {
-        id: '3a4cb914-f7b1-ea11-a812-000d3a64905b',
-        referenceNumber: '1233',
-        proofType: {
-          id: 910400000,
-          label: 'Blue Badge',
-          description: 'Blue Badge'
+        id: 'd1ece997-ef65-e611-80dc-c4346bad4004',
+        proof: {
+          id: 'concession-proof-id',
+          referenceNumber: '1233',
+          type: {
+            id: 910400000,
+            label: 'Blue Badge',
+            description: 'Blue Badge'
+          }
+        }
+      },
+      {
+        id: 'unknown-should-be-ignored',
+        proof: {
+          id: 'unknown',
+          referenceNumber: 'unknown',
+          type: {
+            id: 910400000,
+            label: 'Blue Badge',
+            description: 'Blue Badge'
+          }
         }
       }
     ],

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/__tests__/identity.spec.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/__tests__/identity.spec.js
@@ -12,6 +12,7 @@ import { start, stop, initialize, injectWithCookies, postRedirectGet } from '../
 import { salesApi } from '@defra-fish/connectors-lib'
 import { JUNIOR_MAX_AGE, RENEW_AFTER_DAYS, RENEW_BEFORE_DAYS } from '@defra-fish/business-rules-lib'
 import { authenticationResult } from '../__mocks__/data/authentication-result.js'
+import mockConcessions from '../../../../__mocks__/data/concessions.js'
 import moment from 'moment'
 import * as constants from '../../../../processors/mapping-constants.js'
 import { hasSenior } from '../../../../processors/concession-helper.js'
@@ -32,6 +33,7 @@ const dobHelper = d => ({
 })
 
 jest.mock('@defra-fish/connectors-lib')
+salesApi.concessions.getAll.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(mockConcessions))))
 
 describe('The easy renewal identification page', () => {
   it('returns a failure when called with an invalid permission reference ', async () => {
@@ -67,7 +69,7 @@ describe('The easy renewal identification page', () => {
   })
 
   it('redirects back to itself on posting an valid but not authenticated details', async () => {
-    salesApi.authenticate = jest.fn(async () => new Promise(resolve => resolve(null)))
+    salesApi.authenticate.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(null))))
     await injectWithCookies('GET', VALID_RENEWAL_PUBLIC_URI)
     await injectWithCookies('GET', IDENTIFY.uri)
     const data = await injectWithCookies(
@@ -95,7 +97,7 @@ describe('The easy renewal identification page', () => {
     newAuthenticationResult.permission.endDate = moment()
       .startOf('day')
       .toISOString()
-    salesApi.authenticate = jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult)))
+    salesApi.authenticate.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult))))
     await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
     await injectWithCookies('GET', IDENTIFY.uri)
     const data = await injectWithCookies(
@@ -118,7 +120,7 @@ describe('The easy renewal identification page', () => {
     newAuthenticationResult.permission.licensee.birthDate = moment()
       .add(-65, 'years')
       .add(-1, 'days')
-    salesApi.authenticate = jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult)))
+    salesApi.authenticate.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult))))
     await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
     await injectWithCookies('GET', IDENTIFY.uri)
     await injectWithCookies(
@@ -139,7 +141,7 @@ describe('The easy renewal identification page', () => {
       .startOf('day')
       .add(RENEW_BEFORE_DAYS + 1, 'days')
       .toISOString()
-    salesApi.authenticate = jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult)))
+    salesApi.authenticate.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult))))
     await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
     await injectWithCookies('GET', IDENTIFY.uri)
     await injectWithCookies(
@@ -166,7 +168,7 @@ describe('The easy renewal identification page', () => {
       .startOf('day')
       .add(-1 * (RENEW_AFTER_DAYS + 1), 'days')
       .toISOString()
-    salesApi.authenticate = jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult)))
+    salesApi.authenticate.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult))))
     await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
     await injectWithCookies('GET', IDENTIFY.uri)
     await injectWithCookies(
@@ -183,7 +185,7 @@ describe('The easy renewal identification page', () => {
     const newAuthenticationResult = Object.assign({}, authenticationResult)
     newAuthenticationResult.permission.permit.durationMagnitude = 1
     newAuthenticationResult.permission.permit.durationDesignator.description = 'D'
-    salesApi.authenticate = jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult)))
+    salesApi.authenticate.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult))))
     await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
     await injectWithCookies('GET', IDENTIFY.uri)
     await injectWithCookies(

--- a/packages/sales-api-service/src/server/routes/__tests__/authenticate.spec.js
+++ b/packages/sales-api-service/src/server/routes/__tests__/authenticate.spec.js
@@ -4,7 +4,8 @@ import {
   MOCK_EXISTING_PERMISSION_ENTITY,
   MOCK_EXISTING_CONTACT_ENTITY,
   MOCK_1DAY_SENIOR_PERMIT_ENTITY,
-  MOCK_CONCESSION_PROOF_ENTITY
+  MOCK_CONCESSION_PROOF_ENTITY,
+  MOCK_CONCESSION
 } from '../../../__mocks__/test-data.js'
 
 jest.mock('@defra-fish/dynamics-lib', () => ({
@@ -31,7 +32,7 @@ describe('authenticate handler', () => {
           entity: MOCK_EXISTING_PERMISSION_ENTITY,
           expanded: {
             licensee: { entity: MOCK_EXISTING_CONTACT_ENTITY, expanded: {} },
-            concessionProofs: [{ entity: MOCK_CONCESSION_PROOF_ENTITY, expanded: {} }],
+            concessionProofs: [{ entity: MOCK_CONCESSION_PROOF_ENTITY, expanded: { concession: { entity: MOCK_CONCESSION } } }],
             permit: { entity: MOCK_1DAY_SENIOR_PERMIT_ENTITY, expanded: {} }
           }
         }
@@ -46,7 +47,12 @@ describe('authenticate handler', () => {
         permission: expect.objectContaining({
           ...MOCK_EXISTING_PERMISSION_ENTITY.toJSON(),
           licensee: MOCK_EXISTING_CONTACT_ENTITY.toJSON(),
-          concessions: [MOCK_CONCESSION_PROOF_ENTITY.toJSON()],
+          concessions: [
+            {
+              id: MOCK_CONCESSION.id,
+              proof: MOCK_CONCESSION_PROOF_ENTITY.toJSON()
+            }
+          ],
           permit: MOCK_1DAY_SENIOR_PERMIT_ENTITY.toJSON()
         })
       })

--- a/packages/sales-api-service/src/server/routes/authenticate.js
+++ b/packages/sales-api-service/src/server/routes/authenticate.js
@@ -20,7 +20,10 @@ export default [
               permission: {
                 ...results[0].entity.toJSON(),
                 licensee: results[0].expanded.licensee.entity.toJSON(),
-                concessions: results[0].expanded.concessionProofs.map(c => c.entity.toJSON()),
+                concessions: results[0].expanded.concessionProofs.map(c => ({
+                  id: c.expanded.concession.entity.id,
+                  proof: c.entity.toJSON()
+                })),
                 permit: results[0].expanded.permit.entity.toJSON()
               }
             })

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -192,7 +192,7 @@ const createFulfilmentRequest = async permission => {
 const createConcessionProof = async (concession, permission) => {
   const proof = new ConcessionProof()
   const concessionEntity = await getReferenceDataForEntityAndId(Concession, concession.id)
-  proof.proofType = await getGlobalOptionSetValue(ConcessionProof.definition.mappings.proofType.ref, concession.proof.type)
+  proof.type = await getGlobalOptionSetValue(ConcessionProof.definition.mappings.type.ref, concession.proof.type)
   proof.referenceNumber = concession.proof.referenceNumber
   proof.bindToEntity(ConcessionProof.definition.relationships.permission, permission)
   proof.bindToEntity(ConcessionProof.definition.relationships.concession, concessionEntity)


### PR DESCRIPTION
- Concession id now exposed
- Modified structure of response to more closely match the create transaction schema
- Frontend updated to process new structure