### PR TITLE
Changes to correct renewal start time logic and other changes

### DIFF
--- a/packages/gafl-webapp-service/src/__mocks__/test-utils-system.js
+++ b/packages/gafl-webapp-service/src/__mocks__/test-utils-system.js
@@ -41,13 +41,13 @@ const start = async done => {
   server.route({
     method: 'GET',
     path: GET_PRICING_TYPES.uri,
-    handler: async request => pricingDetail(LICENCE_TYPE.page, request)
+    handler: async request => pricingDetail(LICENCE_TYPE.page, await request.cache().helpers.transaction.getCurrentPermission())
   })
 
   server.route({
     method: 'GET',
     path: GET_PRICING_LENGTHS.uri,
-    handler: async request => pricingDetail(LICENCE_LENGTH.page, request)
+    handler: async request => pricingDetail(LICENCE_LENGTH.page, await request.cache().helpers.transaction.getCurrentPermission())
   })
 
   // clear cache

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-length/route.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-length/route.js
@@ -12,7 +12,7 @@ const validator = Joi.object({
 
 const getData = async request => {
   const permission = await request.cache().helpers.transaction.getCurrentPermission()
-  const pricing = await pricingDetail(LICENCE_LENGTH.page, request)
+  const pricing = await pricingDetail(LICENCE_LENGTH.page, permission)
   return { pricing, licenceTypeStr: licenceTypeDisplay(permission) }
 }
 

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/route.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/route.js
@@ -1,10 +1,13 @@
 import { LICENCE_START_TIME, CONTROLLER } from '../../../uri.js'
 import pageRoute from '../../../routes/page-route.js'
+import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
 import Joi from '@hapi/joi'
 import moment from 'moment'
 
 const minHour = permission =>
-  moment(permission.licenceStartDate, 'YYYY-MM-DD').isSame(moment(), 'day')
+  moment(permission.licenceStartDate, 'YYYY-MM-DD')
+    .tz(SERVICE_LOCAL_TIME)
+    .isSame(moment(), 'day')
     ? moment()
       .add(30, 'minute')
       .hour()

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-type/route.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-type/route.js
@@ -17,7 +17,7 @@ const validator = Joi.object({
 
 const getData = async request => {
   const permission = await request.cache().helpers.transaction.getCurrentPermission()
-  const pricing = await pricingDetail(LICENCE_TYPE.page, request)
+  const pricing = await pricingDetail(LICENCE_TYPE.page, permission)
   return { licenseTypes, permission, pricing }
 }
 

--- a/packages/gafl-webapp-service/src/pages/renewals/renewal-start-date/renewal-start-date.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/renewal-start-date/renewal-start-date.njk
@@ -33,8 +33,8 @@
 %}
 
 {% block pageContent %}
-    <p class="govuk-body-m">Your current licence expires on {{ data.expiryTimeString }}</p>
-    <p class="govuk-body-m">Your licence can start up to {{ data.advancedPurchaseMaxDays }} days after your current licence expires</p>
+    <p class="govuk-body-m">Your current licence {% if data.hasExpired %}expired on{% else %}expires{% endif %} on {{ data.expiryTimeString }}</p>
+    <p class="govuk-body-m">Your licence can start up to {{ data.advancedPurchaseMaxDays }} days after your current licence {% if data.hasExpired %}expired{% else %}expires{% endif %}</p>
     {{ govukDateInput({
       id: "licence-start-date",
       namePrefix: "licence-start-date",

--- a/packages/gafl-webapp-service/src/pages/summary/find-permit.js
+++ b/packages/gafl-webapp-service/src/pages/summary/find-permit.js
@@ -13,7 +13,7 @@ export default async (permission, request) => {
 
   // To calculate a permit, hash and save
   const addHashAndPermit = async () => {
-    const permit = await filterPermits(request)
+    const permit = await filterPermits(permission)
     permission.permit = permit
     const hash = crypto.createHash('sha256')
     hash.update(JSON.stringify(hashOperand))

--- a/packages/gafl-webapp-service/src/pages/summary/licence-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/licence-summary/route.js
@@ -18,8 +18,8 @@ import {
   NEW_TRANSACTION
 } from '../../../uri.js'
 import { START_AFTER_PAYMENT_MINUTES } from '@defra-fish/business-rules-lib'
-
 import { LICENCE_SUMMARY_SEEN } from '../../../constants.js'
+import { CONCESSION } from '../../../processors/mapping-constants.js'
 
 export const getData = async request => {
   const status = await request.cache().helpers.status.getCurrentPermission()
@@ -64,7 +64,7 @@ export const getData = async request => {
     isRenewal: status.renewal,
     isContinuing: !!(permission.renewedEndDate && permission.renewedEndDate === permission.licenceStartDate),
     hasExpired: moment(moment()).isAfter(moment(permission.renewedEndDate, 'YYYY-MM-DD')),
-    disabled: concessionHelper.hasDisabled(permission),
+    disabled: permission.concessions && permission.concessions.find(c => c.type === CONCESSION.DISABLED),
     hasJunior: concessionHelper.hasJunior(permission),
     cost: permission.permit.cost,
     birthDateStr: moment(permission.licensee.birthDate, 'YYYY-MM-DD').format('LL'),

--- a/packages/gafl-webapp-service/src/processors/api-transaction.js
+++ b/packages/gafl-webapp-service/src/processors/api-transaction.js
@@ -13,7 +13,7 @@ export const prepareApiTransactionPayload = async request => {
   const countryList = await countries.getAll()
 
   return {
-    dataSource: mappings.DATA_SOURCE.web,
+    dataSource: process.env.CHANNEL === 'telesales' ? mappings.DATA_SOURCE.telesales : mappings.DATA_SOURCE.web,
     permissions: transactionCache.permissions.map(p => {
       const permission = {
         permitId: p.permit.id,

--- a/packages/gafl-webapp-service/src/processors/date-and-time-display.js
+++ b/packages/gafl-webapp-service/src/processors/date-and-time-display.js
@@ -20,22 +20,22 @@ export const displayStartTime = permission => {
   return `${startMoment.format(dateDisplayFormat)}, ${timeComponent}`
 }
 
-// For renewals
-export const displayExpiryDate = permission => {
-  const startDateString = moment(permission.renewedEndDate, cacheDateFormat)
-    .add(-1, 'days')
-    .format(dateDisplayFormat)
-  return `${startDateString}, 11:59pm`
-}
-
-export const displayEndTime = permission => {
-  let endMoment = moment.utc(permission.endDate).tz(SERVICE_LOCAL_TIME)
-  const timeComponent = endMoment
+const endMomentStr = m => {
+  const timeComponent = m
     .format('h:mma')
     .replace('12:00am', () => {
-      endMoment = endMoment.subtract(1, 'days')
+      m = m.subtract(1, 'days')
       return '11:59pm'
     })
     .replace('12:00pm', '12:00pm (midday)')
-  return `${endMoment.format(dateDisplayFormat)}, ${timeComponent}`
+  return `${m.format(dateDisplayFormat)}, ${timeComponent}`
+}
+
+// For renewals
+export const displayExpiryDate = permission => {
+  return endMomentStr(moment.utc(permission.renewedEndDate).tz(SERVICE_LOCAL_TIME))
+}
+
+export const displayEndTime = permission => {
+  return endMomentStr(moment.utc(permission.endDate).tz(SERVICE_LOCAL_TIME))
 }

--- a/packages/gafl-webapp-service/src/processors/filter-permits.js
+++ b/packages/gafl-webapp-service/src/processors/filter-permits.js
@@ -10,8 +10,7 @@ export const getPermitsJoinPermitConcessions = async () => {
   }))
 }
 
-const filterPermits = async request => {
-  const permission = await request.cache().helpers.transaction.getCurrentPermission()
+const filterPermits = async permission => {
   const licenseeConcessions = permission.concessions || []
   const permitsJoinPermitConcessions = await getPermitsJoinPermitConcessions()
 

--- a/packages/gafl-webapp-service/src/processors/pricing-summary.js
+++ b/packages/gafl-webapp-service/src/processors/pricing-summary.js
@@ -67,8 +67,7 @@ const resultTransformer = (permitWithConcessions, permitWithoutConcessions, len,
  * @param request
  * @returns  {Promise<{byLength: {}}|{byType: {}}>}
  */
-export const pricingDetail = async (page, request) => {
-  const permission = await request.cache().helpers.transaction.getCurrentPermission()
+export const pricingDetail = async (page, permission) => {
   const permitsJoinPermitConcessions = await getPermitsJoinPermitConcessions()
 
   const userConcessions = []

--- a/packages/gafl-webapp-service/src/routes/journey-definition.js
+++ b/packages/gafl-webapp-service/src/routes/journey-definition.js
@@ -19,7 +19,8 @@ import {
   PAYMENT_CANCELLED,
   PAYMENT_FAILED,
   IDENTIFY,
-  RENEWAL_INACTIVE
+  RENEWAL_INACTIVE,
+  RENEWAL_START_DATE
 } from '../uri.js'
 
 import { CommonResults, CONTACT_SUMMARY_SEEN, LICENCE_SUMMARY_SEEN } from '../constants.js'
@@ -293,5 +294,11 @@ export default [
         page: LICENCE_SUMMARY.uri
       }
     }
+  },
+
+  // The change start time is handled directly - not via the controller, as it has dynamic validation
+  {
+    currentPage: RENEWAL_START_DATE.page,
+    backLink: LICENCE_SUMMARY.uri
   }
 ]

--- a/packages/gafl-webapp-service/src/session-cache/session-manager.js
+++ b/packages/gafl-webapp-service/src/session-cache/session-manager.js
@@ -30,7 +30,8 @@ const protectionExemptSet = [
 
 const forbiddenUnlessAgreedSet = [ORDER_COMPLETE.uri, ORDER_COMPLETE_PDF.uri, PAYMENT_FAILED.uri, PAYMENT_CANCELLED.uri]
 
-export const useSessionCookie = request => !request.path.startsWith('/public') && !request.path.startsWith('/oidc')
+export const useSessionCookie = request =>
+  !request.path.startsWith('/public') && !request.path.startsWith('/oidc') && request.path !== '/robots.txt'
 
 /**
  * If there is no session cookie create it and initialize user cache contexts


### PR DESCRIPTION
(1) Changes to renewal start date logic IWTF-1306
(2) Change to start time logic IWTF-1325
(3) Fix disabled concession display problem on licence summary IWTF-1328

Also
Exclude robots file from session handler
Add back link to the renewal start date page
Fix double lookup of permission in the pricing boxes
Add the datasource mapping to the api-transaction