### PR TITLE
Fix IE11 problem

### DIFF
--- a/packages/gafl-webapp-service/src/pages/layout/layout.njk
+++ b/packages/gafl-webapp-service/src/pages/layout/layout.njk
@@ -92,6 +92,6 @@
 {% endblock %}
 
 {% block bodyEnd %}
-    <script nonce={{nonce}} src="/public/javascript/all-min.js"></script>
+    <script src="/public/javascript/all-min.js"></script>
     <script nonce={{nonce}}>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -53,7 +53,7 @@ export const getPlugins = () => {
          * It must allow web-fonts from 'fonts.gstatic.com'
          */
         fontSrc: ['self', 'fonts.gstatic.com', 'data:'],
-        scriptSrc: [scriptHash],
+        scriptSrc: ['self', 'unsafe-inline', scriptHash],
         generateNonces: true,
         frameAncestors: 'none'
       }


### PR DESCRIPTION
This fixes IE11. 

The unsafe-inline directive is ignored on modern browsers where nonces are set so this does not undermine the CSP.

IE11 does not support CSP, removing the nonce from the tag and setting 'self' allows all-min.js to run. This ran with the nonce on FF and Chrome anyway but this is now correct I think.

Tested on IE11 and Safari back to Snow Leopard. Allso some adhoc tests: FF and the Galaxy S3. 