### PR TITLE
Fix: all indirect methods of selecting a 12 month licence 

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
@@ -7,6 +7,7 @@ import moment from 'moment-timezone'
 import JoiDate from '@hapi/joi-date'
 import { ageConcessionHelper } from '../processors/concession-helper.js'
 import { licenceToStart } from '../pages/licence-details/licence-to-start/update-transaction.js'
+import { cacheDateFormat } from '../processors/date-and-time-display.js'
 
 const JoiX = Joi.extend(JoiDate)
 /**
@@ -47,9 +48,9 @@ export default async (request, h) => {
       year: payload['licence-start-date-year'],
       month: Number.parseInt(payload['licence-start-date-month']) - 1,
       day: payload['licence-start-date-day']
-    }).format('YYYY-MM-DD')
+    }).format(cacheDateFormat)
 
-    if (moment(permission.licenceStartDate, 'YYYY-MM-DD').isSame(endDateMoment, 'day')) {
+    if (moment(permission.licenceStartDate, cacheDateFormat).isSame(endDateMoment, 'day')) {
       // If today is the day of the renewal
       if (endDateMoment.isAfter()) {
         // Not yet expired - set the start time accordingly

--- a/packages/gafl-webapp-service/src/pages/concessions/date-of-birth/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/concessions/date-of-birth/update-transaction.js
@@ -1,6 +1,7 @@
 import moment from 'moment'
 import { DATE_OF_BIRTH } from '../../../uri.js'
 import { ageConcessionHelper } from '../../../processors/concession-helper.js'
+import { checkAfterPayment } from '../../licence-details/licence-to-start/update-transaction.js'
 
 /**
  * Transfer the validated page object
@@ -24,6 +25,7 @@ export default async request => {
 
   // Set age related concessions
   ageConcessionHelper(permission)
+  checkAfterPayment(permission)
 
   // Write the permission down
   await request.cache().helpers.transaction.setCurrentPermission(permission)

--- a/packages/gafl-webapp-service/src/pages/concessions/date-of-birth/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/concessions/date-of-birth/update-transaction.js
@@ -2,7 +2,7 @@ import moment from 'moment'
 import { DATE_OF_BIRTH } from '../../../uri.js'
 import { ageConcessionHelper } from '../../../processors/concession-helper.js'
 import { checkAfterPayment } from '../../licence-details/licence-to-start/update-transaction.js'
-
+import { cacheDateFormat } from '../../../processors/date-and-time-display.js'
 /**
  * Transfer the validated page object
  * @param request
@@ -15,7 +15,7 @@ export default async request => {
     year: payload['date-of-birth-year'],
     month: Number.parseInt(payload['date-of-birth-month']) - 1,
     day: payload['date-of-birth-day']
-  }).format('YYYY-MM-DD')
+  }).format(cacheDateFormat)
 
   // Work out the junior or senior concession at the point at which the licence starts
   const permission = await request.cache().helpers.transaction.getCurrentPermission()

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-length/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-length/update-transaction.js
@@ -1,9 +1,7 @@
 import * as mappings from '../../../processors/mapping-constants.js'
-import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
 import { LICENCE_LENGTH } from '../../../uri.js'
 import * as concessionHelper from '../../../processors/concession-helper.js'
-import { licenceToStart } from '../licence-to-start/update-transaction.js'
-import moment from 'moment-timezone'
+import { checkAfterPayment } from '../licence-to-start/update-transaction.js'
 
 /**
  * Transfer the validate page object
@@ -13,26 +11,17 @@ import moment from 'moment-timezone'
 export default async request => {
   const { payload } = await request.cache().helpers.page.getCurrentPermission(LICENCE_LENGTH.page)
   const permission = await request.cache().helpers.transaction.getCurrentPermission()
+  permission.licenceLength = payload['licence-length']
 
   // Setting the licence length to anything other that 12 months removes disabled concessions
-  if (payload['licence-length'] !== '12M') {
+  if (permission.licenceLength !== '12M') {
     concessionHelper.removeDisabled(permission)
     if (permission.licenceType === mappings.LICENCE_TYPE['trout-and-coarse']) {
       permission.numberOfRods = '2'
     }
   } else {
-    permission.licenceStartTime = null
-    // If the licence start date has previously be chosen as today, for a 12 month
-    // then set start after payment
-    if (
-      moment(permission.licenceStartDate, 'YYYY-MM-DD')
-        .tz(SERVICE_LOCAL_TIME)
-        .isSame(moment(), 'day')
-    ) {
-      permission.licenceToStart = licenceToStart.AFTER_PAYMENT
-    }
+    checkAfterPayment(permission)
   }
 
-  permission.licenceLength = payload['licence-length']
   await request.cache().helpers.transaction.setCurrentPermission(permission)
 }

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/route.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/route.js
@@ -3,9 +3,10 @@ import pageRoute from '../../../routes/page-route.js'
 import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
 import Joi from '@hapi/joi'
 import moment from 'moment-timezone'
+import { cacheDateFormat } from '../../../processors/date-and-time-display.js'
 
 const minHour = permission =>
-  moment(permission.licenceStartDate, 'YYYY-MM-DD')
+  moment(permission.licenceStartDate, cacheDateFormat)
     .tz(SERVICE_LOCAL_TIME)
     .isSame(moment(), 'day')
     ? moment()
@@ -29,7 +30,7 @@ const validator = Joi.object({
 
 const getData = async request => {
   const permission = await request.cache().helpers.transaction.getCurrentPermission()
-  const startDateStr = moment(permission.licenceStartDate, 'YYYY-MM-DD').format('dddd, Do MMMM, YYYY')
+  const startDateStr = moment(permission.licenceStartDate, cacheDateFormat).format('dddd, Do MMMM, YYYY')
   return { startDateStr, minHour: minHour(permission) }
 }
 

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/update-transaction.js
@@ -1,6 +1,7 @@
 import moment from 'moment'
 import { LICENCE_TO_START, LICENCE_START_TIME } from '../../../uri.js'
 import { ageConcessionHelper } from '../../../processors/concession-helper.js'
+import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
 /**
  * Transfer the validate page object
  * @param request
@@ -9,6 +10,21 @@ import { ageConcessionHelper } from '../../../processors/concession-helper.js'
 export const licenceToStart = {
   AFTER_PAYMENT: 'after-payment',
   ANOTHER_DATE: 'another-date'
+}
+
+// If the licence start date has be chosen as today, and the licence is changed to a 12 month
+// then set the start after payment flag
+export const checkAfterPayment = permission => {
+  if (permission.licenceLength === '12M') {
+    if (
+      moment(permission.licenceStartDate, 'YYYY-MM-DD')
+        .tz(SERVICE_LOCAL_TIME)
+        .isSame(moment(), 'day')
+    ) {
+      permission.licenceToStart = licenceToStart.AFTER_PAYMENT
+      permission.licenceStartTime = null
+    }
+  }
 }
 
 export default async request => {
@@ -30,6 +46,7 @@ export default async request => {
 
   // Write the age concessions into the cache
   ageConcessionHelper(permission)
+  checkAfterPayment(permission)
 
   await request.cache().helpers.transaction.setCurrentPermission(permission)
 

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/update-transaction.js
@@ -2,6 +2,8 @@ import moment from 'moment'
 import { LICENCE_TO_START, LICENCE_START_TIME } from '../../../uri.js'
 import { ageConcessionHelper } from '../../../processors/concession-helper.js'
 import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
+import { cacheDateFormat } from '../../../processors/date-and-time-display.js'
+
 /**
  * Transfer the validate page object
  * @param request
@@ -15,15 +17,14 @@ export const licenceToStart = {
 // If the licence start date has be chosen as today, and the licence is changed to a 12 month
 // then set the start after payment flag
 export const checkAfterPayment = permission => {
-  if (permission.licenceLength === '12M') {
-    if (
-      moment(permission.licenceStartDate, 'YYYY-MM-DD')
-        .tz(SERVICE_LOCAL_TIME)
-        .isSame(moment(), 'day')
-    ) {
-      permission.licenceToStart = licenceToStart.AFTER_PAYMENT
-      permission.licenceStartTime = null
-    }
+  if (
+    permission.licenceLength === '12M' &&
+    moment(permission.licenceStartDate, cacheDateFormat)
+      .tz(SERVICE_LOCAL_TIME)
+      .isSame(moment(), 'day')
+  ) {
+    permission.licenceToStart = licenceToStart.AFTER_PAYMENT
+    permission.licenceStartTime = null
   }
 }
 
@@ -33,7 +34,7 @@ export default async request => {
 
   if (payload['licence-to-start'] === 'after-payment') {
     permission.licenceToStart = licenceToStart.AFTER_PAYMENT
-    permission.licenceStartDate = moment().format('YYYY-MM-DD')
+    permission.licenceStartDate = moment().format(cacheDateFormat)
     delete permission.licenceStartTime
   } else {
     permission.licenceToStart = licenceToStart.ANOTHER_DATE
@@ -41,7 +42,7 @@ export default async request => {
       year: payload['licence-start-date-year'],
       month: Number.parseInt(payload['licence-start-date-month']) - 1,
       day: payload['licence-start-date-day']
-    }).format('YYYY-MM-DD')
+    }).format(cacheDateFormat)
   }
 
   // Write the age concessions into the cache

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-type/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-type/update-transaction.js
@@ -1,9 +1,8 @@
 import { LICENCE_TYPE } from '../../../uri.js'
 import * as constants from '../../../processors/mapping-constants.js'
 import { licenseTypes } from './route.js'
-import moment from 'moment-timezone'
-import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
-import { licenceToStart } from '../licence-to-start/update-transaction.js'
+import { checkAfterPayment } from '../licence-to-start/update-transaction.js'
+
 /**
  * Transfer the validate page object
  * @param request
@@ -21,15 +20,7 @@ export default async request => {
     permission.numberOfRods = '3'
     permission.licenceLength = '12M'
     permission.licenceStartTime = null
-    // If the licence start date has previously be chosen as today, for a 12 month
-    // then set start after payment
-    if (
-      moment(permission.licenceStartDate, 'YYYY-MM-DD')
-        .tz(SERVICE_LOCAL_TIME)
-        .isSame(moment(), 'day')
-    ) {
-      permission.licenceToStart = licenceToStart.AFTER_PAYMENT
-    }
+    checkAfterPayment(permission)
   } else {
     permission.licenceType = constants.LICENCE_TYPE['salmon-and-sea-trout']
     permission.numberOfRods = '1'

--- a/packages/gafl-webapp-service/src/pages/summary/licence-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/licence-summary/route.js
@@ -2,7 +2,7 @@ import moment from 'moment'
 import pageRoute from '../../../routes/page-route.js'
 import GetDataRedirect from '../../../handlers/get-data-redirect.js'
 import findPermit from '../find-permit.js'
-import { displayStartTime } from '../../../processors/date-and-time-display.js'
+import { displayStartTime, cacheDateFormat } from '../../../processors/date-and-time-display.js'
 import * as concessionHelper from '../../../processors/concession-helper.js'
 import { licenceTypeDisplay } from '../../../processors/licence-type-display.js'
 import { getTrackingProductDetailsFromTransaction } from '../../../processors/analytics.js'
@@ -68,12 +68,12 @@ export const getData = async request => {
     licenceTypeStr: licenceTypeDisplay(permission),
     isRenewal: status.renewal,
     isContinuing: !!(permission.renewedEndDate && permission.renewedEndDate === permission.licenceStartDate),
-    hasExpired: moment(moment()).isAfter(moment(permission.renewedEndDate, 'YYYY-MM-DD')),
+    hasExpired: moment(moment()).isAfter(moment(permission.renewedEndDate, cacheDateFormat)),
     disabled: permission.concessions && permission.concessions.find(c => c.type === CONCESSION.DISABLED),
     concessionProofs: CONCESSION_PROOF,
     hasJunior: concessionHelper.hasJunior(permission),
     cost: permission.permit.cost,
-    birthDateStr: moment(permission.licensee.birthDate, 'YYYY-MM-DD').format('Qo MMMM YYYY'),
+    birthDateStr: moment(permission.licensee.birthDate, cacheDateFormat).format('Qo MMMM YYYY'),
     uri: {
       licenceLength: LICENCE_LENGTH.uri,
       licenceType: LICENCE_TYPE.uri,

--- a/packages/gafl-webapp-service/src/processors/date-and-time-display.js
+++ b/packages/gafl-webapp-service/src/processors/date-and-time-display.js
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone'
 import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
 export const dateDisplayFormat = 'dddd, MMMM Do, YYYY'
-const cacheDateFormat = 'YYYY-MM-DD'
+export const cacheDateFormat = 'YYYY-MM-DD'
 
 export const advancePurchaseDateMoment = permission =>
   moment.tz(permission.licenceStartDate, cacheDateFormat, SERVICE_LOCAL_TIME).add(permission.licenceStartTime ?? 0, 'hours')

--- a/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
+++ b/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
@@ -8,9 +8,8 @@ import { CONTACT_SUMMARY_SEEN } from '../constants.js'
 import { licenceToStart } from '../pages/licence-details/licence-to-start/update-transaction.js'
 import { licenseTypes } from '../pages/licence-details/licence-type/route.js'
 import { salesApi } from '@defra-fish/connectors-lib'
-
+import { cacheDateFormat } from './date-and-time-display.js'
 const debug = db('webapp:renewals-write-cache')
-
 /**
  * Module is used for easy renewals where the data is read from the CRM and written into the session
  * cache.
@@ -27,7 +26,7 @@ export const setUpCacheFromAuthenticationResult = async (request, authentication
   const renewedHasExpired = !endDateMoment.isAfter()
 
   permission.licenceToStart = renewedHasExpired ? licenceToStart.AFTER_PAYMENT : licenceToStart.ANOTHER_DATE
-  permission.licenceStartDate = renewedHasExpired ? moment().format('YYYY-MM-DD') : endDateMoment.format('YYYY-MM-DD')
+  permission.licenceStartDate = renewedHasExpired ? moment().format(cacheDateFormat) : endDateMoment.format(cacheDateFormat)
   permission.licenceStartTime = renewedHasExpired ? 0 : endDateMoment.hours()
   permission.renewedEndDate = endDateMoment.toISOString()
   permission.renewedHasExpired = renewedHasExpired


### PR DESCRIPTION
If a 12 month licence is indirectly by changing (a) age, (b) type=3-rod, (c) the length then if the licence is starting later today, always set the 'after-payment' flag 