### PR TITLE
Filter non-iso compliant entries from countries list

### DIFF
--- a/packages/gafl-webapp-service/src/processors/refdata-helper.js
+++ b/packages/gafl-webapp-service/src/processors/refdata-helper.js
@@ -8,14 +8,20 @@ const optionProc = c =>
 
 const local = {}
 
+const fetch = async () =>
+  optionProc(await salesApi.countries.getAll())
+    .filter(c => !['GB-ENG', 'GB-WLS', 'GB-SCT', 'GB-NIR'].includes(c.code))
+    .sort(a => (a.code === 'GB' ? -1 : 0))
+
+// .filter(c => !['GB-ENG', 'GB-WLS', 'GB_SCT', 'GB-NIR'].includes(c.code))
 // Process the country code option set into a useful form - once
 export const countries = {
   getAll: async () => {
-    local.countries = local.countries || optionProc(await salesApi.countries.getAll()).sort(a => (a.code === 'GB' ? -1 : 0))
+    local.countries = local.countries || (await fetch())
     return local.countries
   },
   nameFromCode: async code => {
-    local.countries = local.countries || optionProc(await salesApi.countries.getAll()).sort(a => (a.code === 'GB' ? -1 : 0))
+    local.countries = local.countries || (await fetch())
     return local.countries.find(c => c.code === code).name
   }
 }

--- a/packages/gafl-webapp-service/src/server.js
+++ b/packages/gafl-webapp-service/src/server.js
@@ -144,7 +144,7 @@ const init = async () => {
     path: '/'
   }
 
-  console.debug({ sessionCookieOptions })
+  console.debug((({ password, ...o }) => o)(sessionCookieOptions))
 
   server.state(sessionCookieName, sessionCookieOptions)
 


### PR DESCRIPTION
(1) Filter out the home countries from the drop down on the front end
(2) Do not show the cookie password in the debug.