### PR TITLE
Fix calendar noshow on IE11

### DIFF
--- a/packages/gafl-webapp-service/assets/sass/rod-licensing/_calendar.scss
+++ b/packages/gafl-webapp-service/assets/sass/rod-licensing/_calendar.scss
@@ -6,7 +6,6 @@ div.flatpickr-calendar {
 div#cal-image-div {
   display: inline-block;
   position: relative;
-  content: url('/public/images/icon-calendar-2x.png');
   top: 18px;
   cursor: pointer;
   border-radius: 0;

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
@@ -88,6 +88,9 @@
         const calImageDiv = document.createElement('div')
         calImageDiv.height = dataInputDiv.height
         calImageDiv.id = 'cal-image-div'
+        const calImage = document.createElement('img')
+        calImage.src = '/public/images/icon-calendar-2x.png'
+        calImageDiv.appendChild(calImage)
         calImageDiv.setAttribute('aria-hidden', true)
         dataInputDiv.appendChild(calImageDiv)
         const fpk = flatpickr(calImageDiv, {


### PR DESCRIPTION
Calendar does not work on IE due to div:content different behaviour. Change to use standard image. 