### PR TITLE
Improve the look of the calendar control

### DIFF
--- a/packages/gafl-webapp-service/assets/sass/rod-licensing/_calendar.scss
+++ b/packages/gafl-webapp-service/assets/sass/rod-licensing/_calendar.scss
@@ -1,6 +1,7 @@
 div.flatpickr-calendar {
   font-family: 'GDS Transport', Arial, sans-serif;
   border-radius: 0;
+  font-size: 0.9em;
 }
 
 div#cal-image-div {
@@ -9,4 +10,25 @@ div#cal-image-div {
   top: 18px;
   cursor: pointer;
   border-radius: 0;
+}
+.flatpickr-current-month input.cur-year[disabled],
+.flatpickr-current-month input.cur-year[disabled]:hover {
+  color: #505a5f;
+}
+.flatpickr-day {
+  color: #505a5f;
+  &.nextMonthDay {
+    color: #1d70b8;
+  }
+  &.prevMonthDay {
+    color: #1d70b8;
+  }
+  &.selected {
+    colour: #fff;
+    background: #2d89c9;
+    border-color: #2d89c9;
+  }
+  &.flatpickr-disabled {
+    color: #b1b4b6;
+  }
 }

--- a/packages/gafl-webapp-service/build/gulpfile.cjs
+++ b/packages/gafl-webapp-service/build/gulpfile.cjs
@@ -11,7 +11,6 @@ const sass = require('gulp-sass')
 const sourcemaps = require('gulp-sourcemaps')
 const del = require('del')
 const minify = require('gulp-minify')
-const merge = require('gulp-merge')
 const path = require('path')
 const concat = require('gulp-concat')
 

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
@@ -107,6 +107,19 @@
                 document.getElementById('licence-start-date-day').value = d.getDate()
                 document.getElementById('licence-start-date-month').value = d.getMonth() + 1
                 document.getElementById('licence-start-date-year').value = d.getFullYear()
+            },
+            onOpen: [ function(selectedDates, dateStr, instance) {
+                const yearInputWrapper = document.getElementsByClassName('numInputWrapper')[0];
+                yearInputWrapper.style.display= 'none';
+                const currentMonthDiv = document.getElementsByClassName('flatpickr-current-month')[0];
+                const yearReadOnly = document.createElement('span');
+                yearReadOnly.id = 'year-read-only';
+                yearReadOnly.innerHTML = ' ' + instance.currentYear;
+                currentMonthDiv.appendChild(yearReadOnly);
+            } ],
+            onYearChange: function(selectedDates, dateStr, instance) {
+                const yearReadOnly = document.getElementById('year-read-only');
+                yearReadOnly.innerHTML = ' ' + instance.currentYear;
             }
         })
         window.addEventListener('keydown', function (event) {

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
@@ -86,7 +86,6 @@
     <script nonce={{nonce}}>(function () {
         const dataInputDiv = document.getElementById('licence-start-date')
         const calImageDiv = document.createElement('div')
-        calImageDiv.height = dataInputDiv.height
         calImageDiv.id = 'cal-image-div'
         const calImage = document.createElement('img')
         calImage.src = '/public/images/icon-calendar-2x.png'
@@ -102,6 +101,7 @@
             monthSelectorType: 'static',
             showMonths: 1,
             clickOpens: false,
+            ariaDateFormat: "",
             onChange: function(selectedDates, dateStr, instance) {
                 var d = new Date(selectedDates[0])
                 document.getElementById('licence-start-date-day').value = d.getDate()

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
@@ -109,13 +109,15 @@
                 document.getElementById('licence-start-date-year').value = d.getFullYear()
             },
             onOpen: [ function(selectedDates, dateStr, instance) {
-                const yearInputWrapper = document.getElementsByClassName('numInputWrapper')[0];
-                yearInputWrapper.style.display= 'none';
-                const currentMonthDiv = document.getElementsByClassName('flatpickr-current-month')[0];
-                const yearReadOnly = document.createElement('span');
-                yearReadOnly.id = 'year-read-only';
-                yearReadOnly.innerHTML = ' ' + instance.currentYear;
-                currentMonthDiv.appendChild(yearReadOnly);
+                if (!document.getElementById('year-read-only')) {
+                    const yearInputWrapper = document.getElementsByClassName('numInputWrapper')[0];
+                    yearInputWrapper.style.display= 'none';
+                    const currentMonthDiv = document.getElementsByClassName('flatpickr-current-month')[0];
+                    const yearReadOnly = document.createElement('span');
+                    yearReadOnly.id = 'year-read-only';
+                    yearReadOnly.innerHTML = ' ' + instance.currentYear;
+                    currentMonthDiv.appendChild(yearReadOnly);
+                }
             } ],
             onYearChange: function(selectedDates, dateStr, instance) {
                 const yearReadOnly = document.getElementById('year-read-only');
@@ -131,7 +133,7 @@
             }
         })
         calImageDiv.onclick = function() {
-            fpk.open()
+            fpk.toggle()
         }
     })()</script>
 {% endblock %}


### PR DESCRIPTION
Some css changes to colour code the next and previous month dates and to increase the text size to .9em which imho looks a lot better. I think we can give this to Jon also to check over. 
Do not display the year input control, it does not really work very well. Replace it with a ready only year which is updated by the arrows, '<' and '>'.
Added a toggle action to the icon.
Tested on old browsers and passed by HD.
![image](https://user-images.githubusercontent.com/18460056/93437216-a17f3100-f8c3-11ea-9255-05539e8710f1.png)
