### PR TITLE
Improvements to POCL loader to ensure process is resumable and improve efficiency 

### DIFF
--- a/packages/dynamics-lib/src/client/__tests__/cache.spec.js
+++ b/packages/dynamics-lib/src/client/__tests__/cache.spec.js
@@ -1,14 +1,26 @@
-jest.mock('cache-manager', () => ({
-  caching: () => ({
-    store: {
-      getClient: () => ({
-        on: () => {}
-      })
-    }
+jest.mock('cache-manager', () => {
+  const mockCache = {}
+  const mockCacheGet = jest.fn(async (key, value) => mockCache[key])
+  const mockCacheSet = jest.fn(async (key, value, options) => {
+    mockCache[key] = value
   })
-}))
+
+  return {
+    caching: () => ({
+      get: mockCacheGet,
+      set: mockCacheSet,
+      store: {
+        getClient: () => ({
+          on: () => {}
+        })
+      }
+    })
+  }
+})
 
 describe('cache', () => {
+  beforeEach(jest.clearAllMocks)
+
   it('uses redis on the configured host and port', async () => {
     process.env.REDIS_HOST = 'localhost'
     process.env.REDIS_PORT = 123
@@ -56,5 +68,48 @@ describe('cache', () => {
       store: 'memory',
       ttl: 60 * 60 * 12
     })
+  })
+
+  it('does not use the cache when calling .execute()', async () => {
+    const { CacheableOperation, default: cache } = require('../cache.js')
+
+    const testFetchOp = jest.fn(async () => 'fetchOpResult')
+    const testResultProcessor = jest.fn(result => result)
+    const test = new CacheableOperation(Math.random(), testFetchOp, testResultProcessor)
+
+    await expect(test.execute()).resolves.toEqual('fetchOpResult')
+    await expect(test.execute()).resolves.toEqual('fetchOpResult')
+    expect(testFetchOp).toHaveBeenCalledTimes(2)
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('caches the first time .cached() is called', async () => {
+    const { CacheableOperation, default: cache } = require('../cache.js')
+
+    const testFetchOp = jest.fn(async () => 'fetchOpResult')
+    const testResultProcessor = jest.fn(result => result)
+    const test = new CacheableOperation(Math.random(), testFetchOp, testResultProcessor)
+
+    await expect(test.cached()).resolves.toEqual('fetchOpResult')
+    await expect(test.cached()).resolves.toEqual('fetchOpResult')
+    expect(testFetchOp).toHaveBeenCalledTimes(1)
+    expect(cache.get).toHaveBeenCalledTimes(2)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses to cache values if isCacheableValue returns false', async () => {
+    const { CacheableOperation, default: cache } = require('../cache.js')
+
+    const testFetchOp = jest.fn(async () => 'fetchOpResult')
+    const testResultProcessor = jest.fn(result => result)
+    const testIsCacheableValue = jest.fn(() => false)
+    const test = new CacheableOperation(Math.random(), testFetchOp, testResultProcessor, testIsCacheableValue)
+
+    await expect(test.cached()).resolves.toEqual('fetchOpResult')
+    await expect(test.cached()).resolves.toEqual('fetchOpResult')
+    expect(testFetchOp).toHaveBeenCalledTimes(2)
+    expect(cache.get).toHaveBeenCalledTimes(2)
+    expect(cache.set).not.toHaveBeenCalled()
   })
 })

--- a/packages/dynamics-lib/src/client/cache.js
+++ b/packages/dynamics-lib/src/client/cache.js
@@ -24,19 +24,35 @@ const cache = cacheManager.caching(config())
 process.env.REDIS_HOST && cache.store.getClient().on('error', console.error)
 
 export class CacheableOperation {
-  constructor (cacheKey, fetchOp, resultProcessor) {
+  /**
+   * Create a new CacheableOperation
+   *
+   * @param {string} cacheKey the key to use for the cache
+   * @param {function: Promise<*>} fetchOp the fetch operation whose result will be cached
+   * @param {function(*): *} resultProcessor a post-processor to apply to the result
+   * @param {function(string): Promise<boolean>} isCacheableValue a function which is passed a result and may return false to exclude the value from the cache
+   */
+  constructor (cacheKey, fetchOp, resultProcessor, isCacheableValue = () => true) {
     this._cacheKey = cacheKey
     this._fetchOp = fetchOp
     this._resultProcessor = resultProcessor
+    this._isCacheableValue = isCacheableValue
   }
 
   async execute () {
     return this._resultProcessor(await this._fetchOp())
   }
 
-  async cached () {
-    const data = await cache.wrap(this._cacheKey, this._fetchOp)
-    return this._resultProcessor(data)
+  async cached (options = {}) {
+    let result = await cache.get(this._cacheKey)
+    if (result === undefined || result === null) {
+      result = await this._fetchOp()
+      const isCacheable = await this._isCacheableValue(result)
+      if (isCacheable) {
+        await cache.set(this._cacheKey, result, options)
+      }
+    }
+    return this._resultProcessor(result)
   }
 }
 

--- a/packages/dynamics-lib/src/index.js
+++ b/packages/dynamics-lib/src/index.js
@@ -27,4 +27,5 @@ export * from './queries/fulfilment.queries.js'
 // Framework functionality
 export * from './client/util.js'
 export { dynamicsClient } from './client/dynamics-client.js'
+export * from './client/cache.js'
 export * from './client/entity-manager.js'

--- a/packages/pocl-job/src/transform/bindings/pocl/licence/licence.bindings.js
+++ b/packages/pocl-job/src/transform/bindings/pocl/licence/licence.bindings.js
@@ -1,6 +1,14 @@
 import { Binding } from '../../binding.js'
 import { salesApi } from '@defra-fish/connectors-lib'
 
+const permitIds = {}
+const getPermitId = async itemId => {
+  if (!permitIds[itemId]) {
+    permitIds[itemId] = (await salesApi.permits.find({ itemId: itemId }))?.id
+  }
+  return permitIds[itemId]
+}
+
 /**
  * Licence item identifier
  * @type {Binding}
@@ -10,8 +18,7 @@ export const ItemId = new Binding({
   transform: async context => {
     let permitId
     if (context.value) {
-      const permit = await salesApi.permits.find({ itemId: context.value })
-      permitId = permit && permit.id
+      permitId = await getPermitId(context.value)
     }
     return permitId
   }

--- a/packages/sales-api-service/src/schema/transaction.schema.js
+++ b/packages/sales-api-service/src/schema/transaction.schema.js
@@ -13,6 +13,12 @@ import { v4 as uuidv4 } from 'uuid'
  */
 export const BATCH_CREATE_MAX_COUNT = 25
 
+/**
+ * Allow the existence of a transaction file to be cached for a period of time to reduce calls to Dynamics when processing POCL files
+ * @type {number}
+ */
+export const TRANSACTION_FILE_VALIDATION_CACHE_TTL = 60 * 15 // 15 minutes
+
 const createTransactionRequestSchemaContent = {
   permissions: Joi.array()
     .min(1)
@@ -96,7 +102,7 @@ export const createTransactionBatchResponseSchema = Joi.array()
 const finaliseTransactionRequestSchemaContent = {
   transactionFile: Joi.string()
     .optional()
-    .external(createAlternateKeyValidator(PoclFile)),
+    .external(createAlternateKeyValidator(PoclFile, { cache: TRANSACTION_FILE_VALIDATION_CACHE_TTL })),
   payment: Joi.object({
     amount: Joi.number().required(),
     timestamp: Joi.string()

--- a/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
+++ b/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
@@ -93,16 +93,23 @@ describe('validators', () => {
       expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
 
+    it('allows the validation result to be cached', async () => {
+      const spy = jest.spyOn(entityManager, 'findById').mockImplementation(async () => 'success')
+      const validationFunction = createEntityIdValidator(TestEntity, { cache: 1 })
+      await expect(validationFunction('testValue')).resolves.toEqual(undefined)
+      expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
+    })
+
     it('returns a validation function which skips validation if the input value is undefined', async () => {
       const spy = jest.spyOn(entityManager, 'findById')
-      const validationFunction = createEntityIdValidator(TestEntity, true)
+      const validationFunction = createEntityIdValidator(TestEntity, { negate: true })
       await expect(validationFunction(undefined)).resolves.toEqual(undefined)
       expect(spy).not.toHaveBeenCalled()
     })
 
     it('returns a validation function returning undefined when an entity is not resolved and negate is set', async () => {
       const spy = jest.spyOn(entityManager, 'findById').mockImplementation(async () => null)
-      const validationFunction = createEntityIdValidator(TestEntity, true)
+      const validationFunction = createEntityIdValidator(TestEntity, { negate: true })
       await expect(validationFunction('testValue')).resolves.toEqual(undefined)
       expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
@@ -116,7 +123,7 @@ describe('validators', () => {
 
     it('returns a validation function throwing an error when an entity is found and negate is set', async () => {
       const spy = jest.spyOn(entityManager, 'findById').mockImplementation(async () => 'success')
-      const validationFunction = createEntityIdValidator(TestEntity, true)
+      const validationFunction = createEntityIdValidator(TestEntity, { negate: true })
       await expect(validationFunction('testValue')).rejects.toThrow('Entity for entityTest identifier already exists')
       expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
@@ -130,16 +137,23 @@ describe('validators', () => {
       expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
 
+    it('allows the validation result to be cached', async () => {
+      const spy = jest.spyOn(entityManager, 'findByAlternateKey').mockImplementation(async () => 'success')
+      const validationFunction = createAlternateKeyValidator(TestEntity, { cache: 1 })
+      await expect(validationFunction('testValue')).resolves.toEqual(undefined)
+      expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
+    })
+
     it('returns a validation function which skips validation if the input value is undefined', async () => {
       const spy = jest.spyOn(entityManager, 'findByAlternateKey')
-      const validationFunction = createAlternateKeyValidator(TestEntity, true)
+      const validationFunction = createAlternateKeyValidator(TestEntity, { negate: true })
       await expect(validationFunction(undefined)).resolves.toEqual(undefined)
       expect(spy).not.toHaveBeenCalled()
     })
 
     it('returns a validation function returning undefined when an entity is not resolved and negate is set', async () => {
       const spy = jest.spyOn(entityManager, 'findByAlternateKey').mockImplementation(async () => null)
-      const validationFunction = createAlternateKeyValidator(TestEntity, true)
+      const validationFunction = createAlternateKeyValidator(TestEntity, { negate: true })
       await expect(validationFunction('testValue')).resolves.toEqual(undefined)
       expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })
@@ -153,7 +167,7 @@ describe('validators', () => {
 
     it('returns a validation function throwing an error when an entity is found and negate is set', async () => {
       const spy = jest.spyOn(entityManager, 'findByAlternateKey').mockImplementation(async () => 'success')
-      const validationFunction = createAlternateKeyValidator(TestEntity, true)
+      const validationFunction = createAlternateKeyValidator(TestEntity, { negate: true })
       await expect(validationFunction('testValue')).rejects.toThrow('Entity for entityTest identifier already exists')
       expect(spy).toHaveBeenCalledWith(TestEntity, 'testValue')
     })

--- a/packages/sales-api-service/src/schema/validators/validators.js
+++ b/packages/sales-api-service/src/schema/validators/validators.js
@@ -3,7 +3,7 @@ import {
   getReferenceDataForEntity,
   getReferenceDataForEntityAndId
 } from '../../services/reference-data.service.js'
-import { findById, findByAlternateKey, PermitConcession } from '@defra-fish/dynamics-lib'
+import { findById, findByAlternateKey, PermitConcession, CacheableOperation } from '@defra-fish/dynamics-lib'
 import Joi from '@hapi/joi'
 
 export function buildJoiOptionSetValidator (optionSetName, exampleValue) {
@@ -39,13 +39,28 @@ export function createReferenceDataEntityValidator (entityType) {
   }
 }
 
-export function createEntityIdValidator (entityType, negate = false) {
+/**
+ * Create a validator which checks if an entity exists using a primary key lookup
+ *
+ * @param {typeof BaseEntity} entityType the type of entity to check
+ * @param {boolean|number} [cache] if falsy, do not cache the result.  a positive numeric value specifies the time to cache the validation result
+ * @param {boolean} [negate] if true then validates that the entity does not exist, defaults to false
+ * @returns {function: Promise<>}
+ */
+export function createEntityIdValidator (entityType, { cache, negate } = { cache: false, negate: false }) {
   return async value => {
     if (value) {
-      const entity = await findById(entityType, value)
-      if (!negate && !entity) {
+      const check = new CacheableOperation(
+        `createEntityIdValidator-${entityType.definition.localName}-${value}`,
+        async () => !!(await findById(entityType, value)),
+        result => result,
+        result => !!result // only cache the result if the entity exists
+      )
+
+      const exists = cache ? await check.cached({ ttl: cache }) : await check.execute()
+      if (!negate && !exists) {
         throw new Error(`Unrecognised ${entityType.definition.localName} identifier`)
-      } else if (negate && entity) {
+      } else if (negate && exists) {
         throw new Error(`Entity for ${entityType.definition.localName} identifier already exists`)
       }
     }
@@ -57,20 +72,27 @@ export function createEntityIdValidator (entityType, negate = false) {
  * Create a validator which checks if an entity exists using an alternate key lookup
  *
  * @param {typeof BaseEntity} entityType the type of entity to check
- * @param {boolean} negate if true then validates that the entity does not exist, defaults to false
- * @returns {function(*=): undefined}
+ * @param {boolean|number} [cache] if falsy, do not cache the result.  a positive numeric value specifies the time to cache the validation result
+ * @param {boolean} [negate] if true then validates that the entity does not exist, defaults to false
+ * @returns {function: Promise<>}
  */
-export function createAlternateKeyValidator (entityType, negate = false) {
+export function createAlternateKeyValidator (entityType, { cache, negate } = { cache: false, negate: false }) {
   if (!entityType.definition.alternateKey) {
     throw new Error(`The entity ${entityType.name} does not support alternate key lookups`)
   }
-
   return async value => {
     if (value) {
-      const entity = await findByAlternateKey(entityType, value)
-      if (!negate && !entity) {
+      const check = new CacheableOperation(
+        `createAlternateKeyValidator-${entityType.definition.localName}-${value}`,
+        async () => !!(await findByAlternateKey(entityType, value)),
+        result => result,
+        result => !!result // only cache the result if the entity exists
+      )
+
+      const exists = cache ? await check.cached({ ttl: cache }) : await check.execute()
+      if (!negate && !exists) {
         throw new Error(`Unrecognised ${entityType.definition.localName} identifier`)
-      } else if (negate && entity) {
+      } else if (negate && exists) {
         throw new Error(`Entity for ${entityType.definition.localName} identifier already exists`)
       }
     }

--- a/packages/sales-api-service/src/server/routes/transactions.js
+++ b/packages/sales-api-service/src/server/routes/transactions.js
@@ -124,7 +124,10 @@ export default [
             404: { description: 'A transaction for the specified identifier was not found' },
             402: { description: 'The payment amount did not match the cost of the transaction' },
             409: { description: 'The transaction does not support recurring payments but an instruction was supplied' },
-            410: { description: 'The transaction has already been finalised' },
+            410: {
+              description:
+                'The transaction has already been finalised.  The previously finalised transaction data will be returned under the data key.'
+            },
             422: { description: 'The transaction completion payload was invalid' }
           },
           order: 2

--- a/packages/sales-api-service/src/server/server.js
+++ b/packages/sales-api-service/src/server/server.js
@@ -30,10 +30,14 @@ export default async (opts = { port: SERVER.Port }) => {
 
   server.ext('onPreResponse', (request, h) => {
     const response = request.response
-    if (response.isBoom && response.isServer) {
-      const requestDetail = { path: request.path, query: request.query, params: request.params, payload: request.payload }
-      console.error('Error processing request. Request: %j, Exception: %o', requestDetail, response)
+    if (response.isBoom) {
+      if (response.isServer) {
+        const requestDetail = { path: request.path, query: request.query, params: request.params, payload: request.payload }
+        console.error('Error processing request. Request: %j, Exception: %o', requestDetail, response)
+      }
+
       response.reformat(true)
+      response.output.payload.data = response.data
     }
     return h.continue
   })

--- a/packages/sales-api-service/src/services/transactions/finalise-transaction.js
+++ b/packages/sales-api-service/src/services/transactions/finalise-transaction.js
@@ -15,7 +15,7 @@ export async function finaliseTransaction ({ id, ...payload }) {
   const transactionRecord = await retrieveStagedTransaction(id)
 
   if (transactionRecord.status?.id === TRANSACTION_STATUS.FINALISED) {
-    throw Boom.resourceGone('The transaction has already been finalised')
+    throw Boom.resourceGone('The transaction has already been finalised', transactionRecord)
   }
   if (transactionRecord.cost !== payload.payment.amount) {
     throw Boom.paymentRequired('The payment amount did not match the cost of the transaction')

--- a/packages/sales-api-service/src/services/transactions/retrieve-transaction.js
+++ b/packages/sales-api-service/src/services/transactions/retrieve-transaction.js
@@ -1,5 +1,5 @@
 import Boom from '@hapi/boom'
-import { TRANSACTION_STAGING_TABLE } from '../../config.js'
+import { TRANSACTION_STAGING_TABLE, TRANSACTION_STAGING_HISTORY_TABLE } from '../../config.js'
 import { AWS } from '@defra-fish/connectors-lib'
 import db from 'debug'
 const { docClient } = AWS()
@@ -7,11 +7,16 @@ const debug = db('sales:transactions')
 
 export const retrieveStagedTransaction = async id => {
   const result = await docClient.get({ TableName: TRANSACTION_STAGING_TABLE.TableName, Key: { id }, ConsistentRead: true }).promise()
-  const record = result.Item
-  if (!record) {
+  if (!result.Item) {
     debug('Failed to retrieve a transaction with staging id %s', id)
+    const historical = await docClient
+      .get({ TableName: TRANSACTION_STAGING_HISTORY_TABLE.TableName, Key: { id }, ConsistentRead: true })
+      .promise()
+    if (historical.Item) {
+      throw Boom.resourceGone('The transaction has already been finalised', historical.Item)
+    }
     throw Boom.notFound('A transaction for the specified identifier was not found')
   }
   debug('Retrieved transaction record for staging id %s', id)
-  return record
+  return result.Item
 }


### PR DESCRIPTION
- Ensure POCL process resumes correctly when running finalisation (HTTP 410 Gone errors now treated as a success case (not resulting in a staging exception being raised)
- Cache permits in local memory once retrieved from the Sales API
- Update SalesAPI to allow the existence of a transaction file to be cached for a period of time to reduce calls to Dynamics when processing POCL files