### PR TITLE
Fix length issue and add coverage

### DIFF
--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-length/update-transaction.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-length/update-transaction.js
@@ -29,14 +29,15 @@ const checkContactDetails = permission => {
  * @param permission
  */
 const checkLicenceToStart = permission => {
-  if (
-    permission.licenceLength === '12M' &&
-    moment(permission.licenceStartDate, cacheDateFormat)
-      .tz(SERVICE_LOCAL_TIME)
-      .isSame(moment(), 'day')
-  ) {
-    permission.licenceToStart = licenceToStart.AFTER_PAYMENT
+  if (permission.licenceLength === '12M') {
     permission.licenceStartTime = null
+    if (
+      moment(permission.licenceStartDate, cacheDateFormat)
+        .tz(SERVICE_LOCAL_TIME)
+        .isSame(moment(), 'day')
+    ) {
+      permission.licenceToStart = licenceToStart.AFTER_PAYMENT
+    }
   }
 }
 


### PR DESCRIPTION
Fix: Licence to start future --> 8 day licence --> 4pm --> 12 month --> start time = 4pm
Now: Licence to start future --> 8 day licence --> 4pm --> 12 month --> start time = midnight
and - no regression on
Fix: Licence to start later today --> 8 day licence --> 4pm --> 12 month --> start time = after payment
Unit tests for this
Fix uncovered line in result function