### PR TITLE
Change error messages on name page

### DIFF
--- a/packages/gafl-webapp-service/src/pages/contact/name/name.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/name/name.njk
@@ -14,7 +14,7 @@
             'string.empty': { ref: '#last-name', text: 'Enter your last name' },
             'string.min': { ref: '#last-name', text: 'Your last name must contain at least 2 letters' },
             'string.max': { ref: '#last-name', text: 'Your last name must not be longer than 100 letters' },
-            'string.forbidden': { ref: '#last-name', 'Your last name must only contain letters' }
+            'string.forbidden': { ref: '#last-name', text: 'Your last name must only contain letters' }
         }
     }
 %}

--- a/packages/gafl-webapp-service/src/pages/contact/name/name.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/name/name.njk
@@ -6,15 +6,15 @@
 {% set errorMap = {
         'first-name': {
             'string.empty': { ref: '#first-name', text: 'Enter your first name' },
-            'string.min': { ref: '#first-name', text: 'Your first name must be between 2 and 100 characters' },
-            'string.max': { ref: '#first-name', text: 'Your first name must be between 2 and 100 characters' },
+            'string.min': { ref: '#first-name', text: 'Your first name must contain at least 2 letters' },
+            'string.max': { ref: '#first-name', text: 'Your first name must not be longer than 100 letters' },
             'string.forbidden': { ref: '#first-name', text: 'Your first name must only contain letters' }
         },
         'last-name': {
             'string.empty': { ref: '#last-name', text: 'Enter your last name' },
-            'string.min': { ref: '#last-name', text: 'Your last name must be between 2 and 100 characters' },
-            'string.max': { ref: '#last-name', text: 'Your last name must be between 2 and 100 characters' },
-            'string.forbidden': { ref: '#last-name', Your: 'The last name must only contain letters' }
+            'string.min': { ref: '#last-name', text: 'Your last name must contain at least 2 letters' },
+            'string.max': { ref: '#last-name', text: 'Your last name must not be longer than 100 letters' },
+            'string.forbidden': { ref: '#last-name', 'Your last name must only contain letters' }
         }
     }
 %}


### PR DESCRIPTION
Change the error messages given in the name page - this is a little tricky but at this stage in the game not suitable to major surgery. 

The was a little ambiguous  - simplified to the following:

(1) 'Your first name must contain at least 2 letters' (for char count < 2 after exclusions)
(2) 'our first name must not be longer than 100 letters' (For the processed name)
(3) 'Your first name must only contain letters' - only if length requirements are met and name contains disallowed 