### PR TITLE
Updates and fixes to the ETL tasks

### DIFF
--- a/docker/env/fulfilment_job.env
+++ b/docker/env/fulfilment_job.env
@@ -3,6 +3,10 @@
 ####################################################################################
 NODE_ENV=development
 
+# Redis
+REDIS_HOST=host.docker.internal
+REDIS_PORT=6379
+
 # AWS settings
 AWS_REGION=eu-west-2
 AWS_ACCESS_KEY_ID=local

--- a/packages/dynamics-lib/src/client/__tests__/cache.spec.js
+++ b/packages/dynamics-lib/src/client/__tests__/cache.spec.js
@@ -1,3 +1,4 @@
+const mockCacheManagerClientQuit = jest.fn()
 jest.mock('cache-manager', () => {
   const mockCache = {}
   const mockCacheGet = jest.fn(async (key, value) => mockCache[key])
@@ -10,7 +11,9 @@ jest.mock('cache-manager', () => {
       get: mockCacheGet,
       set: mockCacheSet,
       store: {
+        name: 'redis',
         getClient: () => ({
+          quit: mockCacheManagerClientQuit,
           on: () => {}
         })
       }
@@ -111,5 +114,11 @@ describe('cache', () => {
     expect(testFetchOp).toHaveBeenCalledTimes(2)
     expect(cache.get).toHaveBeenCalledTimes(2)
     expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('exposes a method to allow the cache to be terminated', async () => {
+    const { terminateCacheManager } = require('../cache.js')
+    await expect(terminateCacheManager()).resolves.toBeUndefined()
+    expect(mockCacheManagerClientQuit).toHaveBeenCalled()
   })
 })

--- a/packages/dynamics-lib/src/client/cache.js
+++ b/packages/dynamics-lib/src/client/cache.js
@@ -56,4 +56,10 @@ export class CacheableOperation {
   }
 }
 
+/**
+ * Terminate the cache manager to release any resources
+ * @returns {Promise<boolean|*>}
+ */
+export const terminateCacheManager = async () => cache.store.name === 'redis' && cache.store.getClient().quit()
+
 export default cache

--- a/packages/fulfilment-job/src/__tests__/fulfilment-processor.spec.js
+++ b/packages/fulfilment-job/src/__tests__/fulfilment-processor.spec.js
@@ -2,15 +2,26 @@ import { processFulfilment } from '../fulfilment-processor.js'
 import config from '../config.js'
 import { createPartFiles } from '../staging/create-part-files.js'
 import { deliverFulfilmentFiles } from '../staging/deliver-fulfilment-files.js'
-import { DistributedLock } from '@defra-fish/connectors-lib'
 
+global.simulateLockError = false
+global.lockReleased = false
 jest.mock('@defra-fish/connectors-lib', () => ({
   ...jest.requireActual('@defra-fish/connectors-lib'),
   DistributedLock: jest.fn().mockReturnValue({
-    obtainAndExecute: jest.fn(async ({ onLockObtained }) => {
-      await onLockObtained()
+    obtainAndExecute: jest.fn(async ({ onLockObtained, onLockError }) => {
+      if (global.simulateLockError) {
+        await onLockError(new Error('Test error'))
+      } else {
+        try {
+          await onLockObtained()
+        } finally {
+          global.lockReleased = true
+        }
+      }
     }),
-    release: jest.fn()
+    release: jest.fn(async () => {
+      global.lockReleased = true
+    })
   })
 }))
 
@@ -21,18 +32,35 @@ jest.mock('../staging/create-part-files.js')
 jest.mock('../staging/deliver-fulfilment-files.js')
 
 describe('fulfilment-processor', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    global.simulateLockError = false
+    global.lockReleased = false
+  })
+
   it('processes fulfilment', async () => {
     await expect(processFulfilment()).resolves.toBeUndefined()
     expect(config.initialise).toHaveBeenCalled()
     expect(createPartFiles).toHaveBeenCalled()
     expect(deliverFulfilmentFiles).toHaveBeenCalled()
+    expect(global.lockReleased).toEqual(true)
+  })
+
+  it('outputs a warning and exits with code 0 if the lock cannot be obtained', async () => {
+    global.simulateLockError = true
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn())
+    const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(jest.fn())
+    await expect(processFulfilment()).resolves.toBeUndefined()
+    expect(config.initialise).not.toHaveBeenCalled()
+    expect(consoleLogSpy).toHaveBeenCalledWith('Unable to obtain a lock for the fulfilment job, skipping execution.', expect.any(Error))
+    expect(processExitSpy).toHaveBeenCalledWith(0)
   })
 
   it.each(['SIGINT', 'SIGTERM'])('implements a shutdown handler to respond to the %s signal', async signal => {
-    const processStopSpy = jest.spyOn(process, 'exit').mockImplementation(() => {})
+    const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(jest.fn())
     await process.emit(signal)
-    expect(processStopSpy).toHaveBeenCalledWith(0)
-    expect(DistributedLock.mock.results[0].value.release).toHaveBeenCalled()
+    expect(processExitSpy).toHaveBeenCalledWith(0)
+    expect(global.lockReleased).toEqual(true)
     jest.restoreAllMocks()
   })
 })

--- a/packages/fulfilment-job/src/fulfilment-processor.js
+++ b/packages/fulfilment-job/src/fulfilment-processor.js
@@ -2,6 +2,7 @@ import config from './config.js'
 import { createPartFiles } from './staging/create-part-files.js'
 import { deliverFulfilmentFiles } from './staging/deliver-fulfilment-files.js'
 import { DistributedLock } from '@defra-fish/connectors-lib'
+import { terminateCacheManager } from '@defra-fish/dynamics-lib'
 
 /**
  * Lock for the ETL process.  Set for default 5 minute TTL unless explicitly released on completion.
@@ -10,20 +11,28 @@ import { DistributedLock } from '@defra-fish/connectors-lib'
 const lock = new DistributedLock('fulfilment-etl', 5 * 60 * 1000)
 
 /**
- * Process fulfilmnent requests.  Queries Dynamics for outstanding requests and the stages these into S3 (as part files) before they are finally
+ * Process fulfilment requests.  Queries Dynamics for outstanding requests and the stages these into S3 (as part files) before they are finally
  * aggregated and sent to the sFTP endpoint
  *
  * @returns {Promise<void>}
  */
 export const processFulfilment = async () => {
-  await lock.obtainAndExecute({
-    onLockObtained: async () => {
-      await config.initialise()
-      await createPartFiles()
-      await deliverFulfilmentFiles()
-    },
-    maxWaitSeconds: 0
-  })
+  try {
+    await lock.obtainAndExecute({
+      onLockObtained: async () => {
+        await config.initialise()
+        await createPartFiles()
+        await deliverFulfilmentFiles()
+      },
+      onLockError: async e => {
+        console.log('Unable to obtain a lock for the fulfilment job, skipping execution.', e)
+        process.exit(0)
+      },
+      maxWaitSeconds: 0
+    })
+  } finally {
+    await terminateCacheManager()
+  }
 }
 
 const shutdown = async () => {

--- a/packages/fulfilment-job/src/staging/__tests__/create-part-files.spec.js
+++ b/packages/fulfilment-job/src/staging/__tests__/create-part-files.spec.js
@@ -88,6 +88,47 @@ describe('createPartFiles', () => {
     expect(persist).toHaveBeenCalledWith(fulfilmentFileExpectations, fulfilmentRequestExpectations)
   })
 
+  it('calculates the next file in the sequence correctly', async () => {
+    const fulfilmentFileExpectations = expect.objectContaining({
+      fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}1010.json`,
+      date: expect.anything(),
+      notes: expect.stringMatching(/^The fulfilment file finished exporting at .+/),
+      numberOfRequests: 1,
+      status: expect.objectContaining({ id: 910400004, label: 'Exported', description: 'Exported' })
+    })
+    const fulfilmentRequestExpectations = expect.objectContaining(
+      Object.assign(mockFulfilmentRequest.toJSON(), {
+        status: expect.objectContaining({ id: 910400001, label: 'Sent', description: 'Sent' })
+      })
+    )
+
+    executePagedQuery.mockImplementation(jest.fn(async (query, onPageReceived) => onPageReceived([mockFulfilmentRequestQueryResult])))
+    executeQuery.mockImplementation(
+      jest.fn(async () => [
+        { entity: { fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0003.json`, status: { label: 'Delivered' } } },
+        { entity: { fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0002.json`, status: { label: 'Delivered' } } },
+        { entity: { fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}1009.json`, status: { label: 'Delivered' } } },
+        { entity: { fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0001.json`, status: { label: 'Delivered' } } },
+        { entity: { fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0006.json`, status: { label: 'Delivered' } } }
+      ])
+    )
+    await expect(createPartFiles()).resolves.toBeUndefined()
+    expect(writeS3PartFile).toHaveBeenCalledWith(
+      fulfilmentFileExpectations,
+      0,
+      expect.arrayContaining([
+        {
+          fulfilmentRequest: fulfilmentRequestExpectations,
+          licensee: MOCK_EXISTING_CONTACT_ENTITY,
+          permission: MOCK_EXISTING_PERMISSION_ENTITY,
+          permit: MOCK_12MONTH_SENIOR_PERMIT
+        }
+      ])
+    )
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist).toHaveBeenCalledWith(fulfilmentFileExpectations, fulfilmentRequestExpectations)
+  })
+
   it('will write multiple part files as necessary', async () => {
     config.file.size = 2
     const fulfilmentRequestExpectations = expect.objectContaining(

--- a/packages/fulfilment-job/src/staging/__tests__/deliver-fulfilment-files.spec.js
+++ b/packages/fulfilment-job/src/staging/__tests__/deliver-fulfilment-files.spec.js
@@ -18,39 +18,93 @@ describe('deliverFulfilmentFiles', () => {
   beforeEach(jest.clearAllMocks)
 
   it('delivers all fulfilment files marked with the Exported status to the fulfilment provider', async () => {
-    const mockFulfilmentRequestFile = Object.assign(new FulfilmentRequestFile(), {
+    const mockFulfilmentRequestFile1 = Object.assign(new FulfilmentRequestFile(), {
       fileName: 'EAFF202006180001.json',
       date: '2020-06-18T11:47:32.982Z',
       notes: 'The fulfilment file finished exporting at 2020-06-18T11:47:32.982Z',
       numberOfRequests: 2,
       status: await getOptionSetEntry(FULFILMENT_FILE_STATUS_OPTIONSET, 'Exported')
     })
-    executeQuery.mockResolvedValue([{ entity: mockFulfilmentRequestFile }])
-    readS3PartFiles.mockImplementation(jest.fn(async () => [Readable.from(['{"part": 0}']), Readable.from(['{"part": 1}'])]))
-    const s3DataStream = createTestableStream()
-    const ftpDataStream = createTestableStream()
-    createS3WriteStream.mockReturnValueOnce({ s3WriteStream: s3DataStream, managedUpload: Promise.resolve() })
-    createFtpWriteStream.mockReturnValueOnce({ ftpWriteStream: ftpDataStream, managedUpload: Promise.resolve() })
-    const s3HashStream = createTestableStream()
-    const ftpHashStream = createTestableStream()
-    createS3WriteStream.mockReturnValueOnce({ s3WriteStream: s3HashStream, managedUpload: Promise.resolve() })
-    createFtpWriteStream.mockReturnValueOnce({ ftpWriteStream: ftpHashStream, managedUpload: Promise.resolve() })
+    const mockFulfilmentRequestFile2 = Object.assign(new FulfilmentRequestFile(), {
+      fileName: 'EAFF202006180002.json',
+      date: '2020-06-18T11:47:33.982Z',
+      notes: 'The fulfilment file finished exporting at 2020-06-18T11:47:33.982Z',
+      numberOfRequests: 2,
+      status: await getOptionSetEntry(FULFILMENT_FILE_STATUS_OPTIONSET, 'Exported')
+    })
+    // Reverse order to ensure files are sent in ascending order according to their sequence number
+    executeQuery.mockResolvedValue([{ entity: mockFulfilmentRequestFile2 }, { entity: mockFulfilmentRequestFile1 }])
 
+    // Part file data for all files
+    readS3PartFiles.mockImplementation(jest.fn(async () => [Readable.from(['{"part": 0}']), Readable.from(['{"part": 1}'])]))
+
+    // Streams for file1
+    const s3DataStreamFile1 = createTestableStream()
+    const ftpDataStreamFile1 = createTestableStream()
+    createS3WriteStream.mockReturnValueOnce({ s3WriteStream: s3DataStreamFile1, managedUpload: Promise.resolve() })
+    createFtpWriteStream.mockReturnValueOnce({ ftpWriteStream: ftpDataStreamFile1, managedUpload: Promise.resolve() })
+    const s3HashStreamFile1 = createTestableStream()
+    const ftpHashStreamFile1 = createTestableStream()
+    createS3WriteStream.mockReturnValueOnce({ s3WriteStream: s3HashStreamFile1, managedUpload: Promise.resolve() })
+    createFtpWriteStream.mockReturnValueOnce({ ftpWriteStream: ftpHashStreamFile1, managedUpload: Promise.resolve() })
+
+    // Streams for file2
+    const s3DataStreamFile2 = createTestableStream()
+    const ftpDataStreamFile2 = createTestableStream()
+    createS3WriteStream.mockReturnValueOnce({ s3WriteStream: s3DataStreamFile2, managedUpload: Promise.resolve() })
+    createFtpWriteStream.mockReturnValueOnce({ ftpWriteStream: ftpDataStreamFile2, managedUpload: Promise.resolve() })
+    const s3HashStreamFile2 = createTestableStream()
+    const ftpHashStreamFile2 = createTestableStream()
+    createS3WriteStream.mockReturnValueOnce({ s3WriteStream: s3HashStreamFile2, managedUpload: Promise.resolve() })
+    createFtpWriteStream.mockReturnValueOnce({ ftpWriteStream: ftpHashStreamFile2, managedUpload: Promise.resolve() })
+
+    // Run the delivery
     await expect(deliverFulfilmentFiles()).resolves.toBeUndefined()
 
-    expect(readS3PartFiles).toHaveBeenCalledWith(mockFulfilmentRequestFile)
+    expect(readS3PartFiles).toHaveBeenCalledWith(mockFulfilmentRequestFile1)
+
+    // File 1 expectations
     expect(createS3WriteStream).toHaveBeenNthCalledWith(1, 'EAFF202006180001.json')
     expect(createS3WriteStream).toHaveBeenNthCalledWith(2, 'EAFF202006180001.json.sha256')
     expect(createFtpWriteStream).toHaveBeenNthCalledWith(1, 'EAFF202006180001.json')
     expect(createFtpWriteStream).toHaveBeenNthCalledWith(2, 'EAFF202006180001.json.sha256')
-    expect(JSON.parse(s3DataStream.dataProcessed)).toEqual({ licences: [{ part: 0 }, { part: 1 }] })
-    expect(JSON.parse(ftpDataStream.dataProcessed)).toEqual({ licences: [{ part: 0 }, { part: 1 }] })
-    expect(s3HashStream.dataProcessed).toEqual('f89f5dd268a8b02758e08d3b806d0695da94b84978954e281ccaba7eb838791a') // validated
-    expect(ftpHashStream.dataProcessed).toEqual('f89f5dd268a8b02758e08d3b806d0695da94b84978954e281ccaba7eb838791a') // validated
-    expect(persist).toHaveBeenCalledWith(
+    expect(JSON.parse(s3DataStreamFile1.dataProcessed)).toEqual({ licences: [{ part: 0 }, { part: 1 }] })
+    expect(JSON.parse(ftpDataStreamFile1.dataProcessed)).toEqual({ licences: [{ part: 0 }, { part: 1 }] })
+    expect(s3HashStreamFile1.dataProcessed).toEqual('f89f5dd268a8b02758e08d3b806d0695da94b84978954e281ccaba7eb838791a') // validated
+    expect(ftpHashStreamFile1.dataProcessed).toEqual('f89f5dd268a8b02758e08d3b806d0695da94b84978954e281ccaba7eb838791a') // validated
+
+    // File 2 expectations
+    expect(createS3WriteStream).toHaveBeenNthCalledWith(3, 'EAFF202006180002.json')
+    expect(createS3WriteStream).toHaveBeenNthCalledWith(4, 'EAFF202006180002.json.sha256')
+    expect(createFtpWriteStream).toHaveBeenNthCalledWith(3, 'EAFF202006180002.json')
+    expect(createFtpWriteStream).toHaveBeenNthCalledWith(4, 'EAFF202006180002.json.sha256')
+    expect(JSON.parse(s3DataStreamFile2.dataProcessed)).toEqual({ licences: [{ part: 0 }, { part: 1 }] })
+    expect(JSON.parse(ftpDataStreamFile2.dataProcessed)).toEqual({ licences: [{ part: 0 }, { part: 1 }] })
+    expect(s3HashStreamFile2.dataProcessed).toEqual('f89f5dd268a8b02758e08d3b806d0695da94b84978954e281ccaba7eb838791a') // validated
+    expect(ftpHashStreamFile2.dataProcessed).toEqual('f89f5dd268a8b02758e08d3b806d0695da94b84978954e281ccaba7eb838791a') // validated
+
+    // Persist to dynamics for file 1
+    expect(persist).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         fileName: 'EAFF202006180001.json',
         date: '2020-06-18T11:47:32.982Z',
+        deliveryTimestamp: expect.any(String),
+        notes: expect.stringMatching(/The fulfilment file was successfully delivered at .+/),
+        numberOfRequests: 2,
+        status: expect.objectContaining({
+          description: 'Delivered',
+          id: 910400001,
+          label: 'Delivered'
+        })
+      })
+    )
+    // Persist to dynamics for file 2
+    expect(persist).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        fileName: 'EAFF202006180002.json',
+        date: '2020-06-18T11:47:33.982Z',
         deliveryTimestamp: expect.any(String),
         notes: expect.stringMatching(/The fulfilment file was successfully delivered at .+/),
         numberOfRequests: 2,

--- a/packages/fulfilment-job/src/staging/create-part-files.js
+++ b/packages/fulfilment-job/src/staging/create-part-files.js
@@ -79,7 +79,7 @@ const getTargetFulfilmentFile = async () => {
   let targetFile = files.find(file => file.status.label === 'Pending')
   if (!targetFile) {
     targetFile = new FulfilmentRequestFile()
-    targetFile.fileName = `EAFF${EXECUTION_DATE.format('YYYYMMDD')}${String(files.length + 1).padStart(4, '0')}.json`
+    targetFile.fileName = `EAFF${EXECUTION_DATE.format('YYYYMMDD')}${String(getNextInSequence(files)).padStart(4, '0')}.json`
     targetFile.date = EXECUTION_DATE
     targetFile.status = await getOptionSetEntry(FULFILMENT_FILE_STATUS_OPTIONSET, 'Pending')
     targetFile.notes = 'The fulfilment file is currently being populated prior to exporting.'
@@ -90,5 +90,14 @@ const getTargetFulfilmentFile = async () => {
   }
   return targetFile
 }
+
+/**
+ * Calculate the next sequence number based on any existing files.
+ *
+ * @param files the existing fileset
+ * @returns {number} the next sequence number to be used
+ */
+const getNextInSequence = files =>
+  files.reduce((acc, file) => Math.max(acc, 1 + Number.parseInt(/^EAFF\d{8}0*(?<seq>\d+).json$/.exec(file.fileName).groups.seq)), 1)
 
 const getFulfilmentFiles = async () => (await executeQuery(findFulfilmentFiles({ date: EXECUTION_DATE }))).map(r => r.entity)

--- a/packages/fulfilment-job/src/staging/deliver-fulfilment-files.js
+++ b/packages/fulfilment-job/src/staging/deliver-fulfilment-files.js
@@ -19,6 +19,7 @@ const pipelinePromise = promisify(pipeline)
 export const deliverFulfilmentFiles = async () => {
   debug('Aggregating fulfilment part files')
   const results = await executeQuery(findFulfilmentFiles({ status: await getOptionSetEntry(FULFILMENT_FILE_STATUS_OPTIONSET, 'Exported') }))
+  results.sort((a, b) => a.entity.fileName.localeCompare(b.entity.fileName))
   for (const { entity: file } of results) {
     await deliver(file.fileName, await createDataReadStream(file))
     await deliver(`${file.fileName}.sha256`, await createDataReadStream(file), createHash('sha256').setEncoding('hex'))

--- a/packages/payment-mop-up-job/src/payment-mop-up-job.js
+++ b/packages/payment-mop-up-job/src/payment-mop-up-job.js
@@ -11,6 +11,10 @@ lock
     onLockObtained: async () => {
       await execute(incompletePurchaseAgeMinutes, scanDurationHours)
     },
+    onLockError: async e => {
+      console.log('Unable to obtain a lock for the payment mop-up job, skipping execution.', e)
+      process.exit(0)
+    },
     maxWaitSeconds: 0
   })
   .catch(console.error)

--- a/packages/pocl-job/src/__tests__/pocl-processor.spec.js
+++ b/packages/pocl-job/src/__tests__/pocl-processor.spec.js
@@ -4,15 +4,26 @@ import { ftpToS3 } from '../transport/ftp-to-s3.js'
 import { s3ToLocal } from '../transport/s3-to-local.js'
 import { getFileRecords } from '../io/db.js'
 import { stage } from '../staging/pocl-data-staging.js'
-import { DistributedLock } from '@defra-fish/connectors-lib'
 
+global.simulateLockError = false
+global.lockReleased = false
 jest.mock('@defra-fish/connectors-lib', () => ({
   ...jest.requireActual('@defra-fish/connectors-lib'),
   DistributedLock: jest.fn().mockReturnValue({
-    obtainAndExecute: jest.fn(async ({ onLockObtained }) => {
-      await onLockObtained()
+    obtainAndExecute: jest.fn(async ({ onLockObtained, onLockError }) => {
+      if (global.simulateLockError) {
+        await onLockError(new Error('Test error'))
+      } else {
+        try {
+          await onLockObtained()
+        } finally {
+          global.lockReleased = true
+        }
+      }
     }),
-    release: jest.fn()
+    release: jest.fn(async () => {
+      global.lockReleased = true
+    })
   })
 }))
 
@@ -23,6 +34,12 @@ jest.mock('../io/db.js')
 jest.mock('../staging/pocl-data-staging.js')
 
 describe('pocl-processor', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    global.simulateLockError = false
+    global.lockReleased = false
+  })
+
   it('runs all stages to retrieve data from SFTP and stage into the Sales API', async () => {
     getFileRecords.mockResolvedValue([{ s3Key: 's3path/1' }, { s3Key: 's3path/2' }])
     s3ToLocal.mockResolvedValueOnce('local/1')
@@ -36,13 +53,24 @@ describe('pocl-processor', () => {
     expect(s3ToLocal).toHaveBeenNthCalledWith(2, 's3path/2')
     expect(stage).toHaveBeenNthCalledWith(1, 'local/1')
     expect(stage).toHaveBeenNthCalledWith(2, 'local/2')
+    expect(global.lockReleased).toEqual(true)
+  })
+
+  it('outputs a warning and exits with code 0 if the lock cannot be obtained', async () => {
+    global.simulateLockError = true
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn())
+    const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(jest.fn())
+    await expect(execute()).resolves.toBeUndefined()
+    expect(config.initialise).not.toHaveBeenCalled()
+    expect(consoleLogSpy).toHaveBeenCalledWith('Unable to obtain a lock for the pocl job, skipping execution.', expect.any(Error))
+    expect(processExitSpy).toHaveBeenCalledWith(0)
   })
 
   it.each(['SIGINT', 'SIGTERM'])('implements a shutdown handler to respond to the %s signal', async signal => {
     const processStopSpy = jest.spyOn(process, 'exit').mockImplementation(() => {})
     await process.emit(signal)
     expect(processStopSpy).toHaveBeenCalledWith(0)
-    expect(DistributedLock.mock.results[0].value.release).toHaveBeenCalled()
+    expect(global.lockReleased).toEqual(true)
     jest.restoreAllMocks()
   })
 })


### PR DESCRIPTION
**Improve behaviour of ETL jobs with regard to locking and shutdown**
- Fix issue with fulfilment job not shutting down due to cache manager in dynamics-lib
- Ensure ETL tasks output a message and then exit with code 0 if process already locked

**Fulfilment: Fix sequence no. generator and deliver files in sequence**
- Sequence number generator now uses the filename to determine the next sequence number
- Fulfilment files are now delivered in sequence number order