### PR TITLE
Relax validation rules for Post Office sales

### DIFF
--- a/packages/sales-api-service/src/schema/__tests__/transaction.schema.spec.js
+++ b/packages/sales-api-service/src/schema/__tests__/transaction.schema.spec.js
@@ -19,7 +19,21 @@ describe('createTransactionSchema', () => {
   it('validates successfully when issueDate and startDate are null', async () => {
     const mockPayload = mockTransactionPayload()
     mockPayload.permissions.map(p => ({ ...p, issueDate: null, startDate: null }))
-    const result = await createTransactionSchema.validateAsync(mockTransactionPayload())
+    const result = await createTransactionSchema.validateAsync(mockPayload)
+    expect(result).toBeInstanceOf(Object)
+  })
+
+  it('requires a licensee postcode for web-sales but not for post-office sales', async () => {
+    const mockPayload = mockTransactionPayload()
+    mockPayload.permissions.forEach(p => {
+      p.licensee.postcode = ''
+    })
+    await expect(createTransactionSchema.validateAsync(mockPayload)).rejects.toThrow(
+      '"permissions[0].licensee.postcode" is not allowed to be empty'
+    )
+
+    mockPayload.dataSource = 'Post Office Sales'
+    const result = await createTransactionSchema.validateAsync(mockPayload)
     expect(result).toBeInstanceOf(Object)
   })
 })

--- a/packages/sales-api-service/src/schema/contact.schema.js
+++ b/packages/sales-api-service/src/schema/contact.schema.js
@@ -26,11 +26,14 @@ const commonContactSchema = {
   street: validation.contact.createStreetValidator(Joi).allow(null),
   locality: validation.contact.createLocalityValidator(Joi).allow(null),
   town: validation.contact.createTownValidator(Joi),
-  postcode: Joi.alternatives().conditional('country', {
-    is: Joi.string().valid('GB', 'United Kingdom'),
-    then: validation.contact.createUKPostcodeValidator(Joi),
-    otherwise: validation.contact.createOverseasPostcodeValidator(Joi)
-  })
+  postcode: Joi.when(Joi.ref('/dataSource'), {
+    is: Joi.string().valid('Post Office Sales'),
+    otherwise: Joi.alternatives().conditional('country', {
+      is: Joi.string().valid('GB', 'United Kingdom'),
+      then: validation.contact.createUKPostcodeValidator(Joi),
+      otherwise: validation.contact.createOverseasPostcodeValidator(Joi)
+    })
+  }).example('AB12 3CD')
 }
 
 export const contactRequestSchema = Joi.object({

--- a/packages/sales-api-service/src/schema/permission.schema.js
+++ b/packages/sales-api-service/src/schema/permission.schema.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { contactRequestSchema } from './contact.schema.js'
 import { concessionProofSchema } from './concession-proof.schema.js'
 import { optionSetOption } from './option-set.schema.js'
-import { createReferenceDataEntityValidator, createPermitConcessionValidator } from './validators/validators.js'
+import { createReferenceDataEntityValidator } from './validators/validators.js'
 import { Permit } from '@defra-fish/dynamics-lib'
 import { validation } from '@defra-fish/business-rules-lib'
 import { v4 as uuid } from 'uuid'
@@ -36,9 +36,7 @@ export const stagedPermissionSchema = Joi.object({
   concessions: concessionProofSchema.optional(),
   issueDate: issueDateSchema.allow(null),
   startDate: startDateSchema.allow(null)
-})
-  .external(createPermitConcessionValidator())
-  .label('staged-permission')
+}).label('staged-permission')
 
 export const finalisedPermissionSchemaContent = {
   id: Joi.string()

--- a/packages/sales-api-service/src/schema/transaction.schema.js
+++ b/packages/sales-api-service/src/schema/transaction.schema.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { PoclFile } from '@defra-fish/dynamics-lib'
 import { finalisePermissionResponseSchema, stagedPermissionSchema } from './permission.schema.js'
 import { contactRequestSchema } from './contact.schema.js'
-import { createAlternateKeyValidator, buildJoiOptionSetValidator } from './validators/validators.js'
+import { createAlternateKeyValidator, buildJoiOptionSetValidator, createPermitConcessionValidator } from './validators/validators.js'
 import { MAX_PERMISSIONS_PER_TRANSACTION } from '@defra-fish/business-rules-lib'
 
 import { v4 as uuidv4 } from 'uuid'
@@ -33,7 +33,9 @@ const createTransactionRequestSchemaContent = {
  * Schema for the create transaction request
  * @type {Joi.AnySchema}
  */
-export const createTransactionSchema = Joi.object(createTransactionRequestSchemaContent).label('create-transaction-request')
+export const createTransactionSchema = Joi.object(createTransactionRequestSchemaContent)
+  .external(createPermitConcessionValidator())
+  .label('create-transaction-request')
 
 /**
  * Validates a request to create transactions in batch.

--- a/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
+++ b/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
@@ -199,10 +199,15 @@ describe('validators', () => {
       const validationFunction = createPermitConcessionValidator()
       await expect(
         validationFunction({
-          permitId: 'test-1',
-          concessions: [
+          dataSource: 'Web Sales',
+          permissions: [
             {
-              id: 'test-1'
+              permitId: 'test-1',
+              concessions: [
+                {
+                  id: 'test-1'
+                }
+              ]
             }
           ]
         })
@@ -220,10 +225,15 @@ describe('validators', () => {
       const validationFunction = createPermitConcessionValidator()
       await expect(
         validationFunction({
-          permitId: 'test-1',
-          concessions: [
+          dataSource: 'Web Sales',
+          permissions: [
             {
-              id: 'test-2'
+              permitId: 'test-1',
+              concessions: [
+                {
+                  id: 'test-2'
+                }
+              ]
             }
           ]
         })
@@ -236,10 +246,15 @@ describe('validators', () => {
       const validationFunction = createPermitConcessionValidator()
       await expect(
         validationFunction({
-          permitId: 'test-1',
-          concessions: [
+          dataSource: 'Web Sales',
+          permissions: [
             {
-              id: 'test-2'
+              permitId: 'test-1',
+              concessions: [
+                {
+                  id: 'test-2'
+                }
+              ]
             }
           ]
         })
@@ -255,8 +270,13 @@ describe('validators', () => {
       const validationFunction = createPermitConcessionValidator()
       await expect(
         validationFunction({
-          permitId: 'test-1',
-          concessions: [{ id: 'test-1' }, { id: 'test-1' }, { id: 'test-2' }, { id: 'test-2' }]
+          dataSource: 'Web Sales',
+          permissions: [
+            {
+              permitId: 'test-1',
+              concessions: [{ id: 'test-1' }, { id: 'test-1' }, { id: 'test-2' }, { id: 'test-2' }]
+            }
+          ]
         })
       ).rejects.toThrow("The concession ids 'test-1,test-2' appear more than once, duplicates are not permitted")
       expect(spy).toHaveBeenCalledWith(PermitConcession)
@@ -267,7 +287,12 @@ describe('validators', () => {
       const validationFunction = createPermitConcessionValidator()
       await expect(
         validationFunction({
-          permitId: 'test-1'
+          dataSource: 'Web Sales',
+          permissions: [
+            {
+              permitId: 'test-1'
+            }
+          ]
         })
       ).resolves.toEqual(undefined)
       expect(spy).toHaveBeenCalledWith(PermitConcession)
@@ -276,8 +301,13 @@ describe('validators', () => {
     it('returns a validation function which skips validation if the input value is undefined', async () => {
       const spy = jest.spyOn(referenceData, 'getReferenceDataForEntity').mockImplementation(async () => [
         {
-          permitId: 'test-1',
-          concessionId: 'test-1'
+          dataSource: 'Web Sales',
+          permissions: [
+            {
+              permitId: 'test-1',
+              concessionId: 'test-1'
+            }
+          ]
         }
       ])
       const validationFunction = createPermitConcessionValidator()
@@ -295,10 +325,36 @@ describe('validators', () => {
       const validationFunction = createPermitConcessionValidator()
       await expect(
         validationFunction({
-          permitId: 'test-1'
+          dataSource: 'Web Sales',
+          permissions: [
+            {
+              permitId: 'test-1'
+            }
+          ]
         })
       ).rejects.toThrow("The permit 'test-1' requires proof of concession however none were supplied")
       expect(spy).toHaveBeenCalledWith(PermitConcession)
+    })
+
+    it('returns a validation function which does not throw an error for Post Office Sales even if the permit requires a concession and none is supplied', async () => {
+      const spy = jest.spyOn(referenceData, 'getReferenceDataForEntity').mockImplementation(async () => [
+        {
+          permitId: 'test-1',
+          concessionId: 'test-1'
+        }
+      ])
+      const validationFunction = createPermitConcessionValidator()
+      await expect(
+        validationFunction({
+          dataSource: 'Post Office Sales',
+          permissions: [
+            {
+              permitId: 'test-1'
+            }
+          ]
+        })
+      ).resolves.toEqual(undefined)
+      expect(spy).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
+++ b/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
@@ -354,7 +354,7 @@ describe('validators', () => {
           ]
         })
       ).resolves.toEqual(undefined)
-      expect(spy).not.toHaveBeenCalled()
+      expect(spy).toHaveBeenCalledWith(PermitConcession)
     })
   })
 })

--- a/packages/sales-api-service/src/schema/validators/validators.js
+++ b/packages/sales-api-service/src/schema/validators/validators.js
@@ -105,21 +105,34 @@ export function createAlternateKeyValidator (entityType, { cache, negate } = { c
  * @returns {function(*): undefined}
  */
 export function createPermitConcessionValidator () {
-  return async permission => {
-    if (permission) {
-      const permitConcessions = await getReferenceDataForEntity(PermitConcession)
-      const concessionsRequiredForPermit = permitConcessions.filter(pc => pc.permitId === permission.permitId)
-      const hasConcessionProofs = permission.concessions && permission.concessions.length
-      // Check that the concession is valid for the given permitId and that if a permit requires a concession reference that one is defined
-      if (concessionsRequiredForPermit.length && !hasConcessionProofs) {
-        throw new Error(`The permit '${permission.permitId}' requires proof of concession however none were supplied`)
-      } else if (!concessionsRequiredForPermit.length && hasConcessionProofs) {
-        throw new Error(`The permit '${permission.permitId}' does not allow concessions but concession proofs were supplied`)
-      } else if (permission.concessions) {
-        validateConcessionList(permission, concessionsRequiredForPermit)
+  return async transaction => {
+    if (transaction && transaction.dataSource !== 'Post Office Sales') {
+      for (const permission of transaction.permissions) {
+        await validatePermissionConcession(permission)
       }
     }
     return undefined
+  }
+}
+
+/**
+ * Validate that a permission referencing a concession contains the required concession proof
+ *
+ * @param permission the permission to be validated
+ * @returns {Promise<void>}
+ * @throws {Error} on validation error
+ */
+const validatePermissionConcession = async permission => {
+  const permitConcessions = await getReferenceDataForEntity(PermitConcession)
+  const concessionsRequiredForPermit = permitConcessions.filter(pc => pc.permitId === permission.permitId)
+  const hasConcessionProofs = permission.concessions && permission.concessions.length
+  // Check that the concession is valid for the given permitId and that if a permit requires a concession reference that one is defined
+  if (concessionsRequiredForPermit.length && !hasConcessionProofs) {
+    throw new Error(`The permit '${permission.permitId}' requires proof of concession however none were supplied`)
+  } else if (!concessionsRequiredForPermit.length && hasConcessionProofs) {
+    throw new Error(`The permit '${permission.permitId}' does not allow concessions but concession proofs were supplied`)
+  } else if (permission.concessions) {
+    validateConcessionList(permission, concessionsRequiredForPermit)
   }
 }
 
@@ -128,7 +141,7 @@ export function createPermitConcessionValidator () {
  *
  * @param permission the permission containing the concessions to be validated
  * @param concessionsRequiredForPermit the concessions allowed for the target permit
- * @throws on validation error
+ * @throws {Error} on validation error
  */
 const validateConcessionList = (permission, concessionsRequiredForPermit) => {
   // Check list for duplicates


### PR DESCRIPTION
- No longer checks concession proof for P.O. sales
- No longer requires postcode for P.O. sales