### PR TITLE
Add airbrake support all services

### DIFF
--- a/packages/connectors-lib/package-lock.json
+++ b/packages/connectors-lib/package-lock.json
@@ -4,6 +4,66 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@airbrake/browser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@airbrake/browser/-/browser-1.4.1.tgz",
+      "integrity": "sha512-4KChn2eGDllwqYJ4c6MFqIiJ2RZgg49inYiIsdpAj5MLtOpZRlPF8MsOSLGHxkEDX6u5M9KRidUfktuQ/C9lKA==",
+      "requires": {
+        "@types/promise-polyfill": "^6.0.3",
+        "@types/request": "2.48.5",
+        "cross-fetch": "^3.0.4",
+        "error-stack-parser": "^2.0.4",
+        "promise-polyfill": "^8.1.3",
+        "tdigest": "^0.1.1"
+      }
+    },
+    "@airbrake/node": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@airbrake/node/-/node-1.4.1.tgz",
+      "integrity": "sha512-8K9S4mDLgMXOGM4iMJt4qXeV4wfK8L7siIxR+IS0x9O92xUsyjIfc17NRxwkAzx+sEn8IBRjCXX9Og1Va831Wg==",
+      "requires": {
+        "@airbrake/browser": "^1.4.1",
+        "cross-fetch": "^3.0.4",
+        "error-stack-parser": "^2.0.4",
+        "tdigest": "^0.1.1"
+      }
+    },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+    },
+    "@types/node": {
+      "version": "14.11.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
+      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw=="
+    },
+    "@types/promise-polyfill": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.3.tgz",
+      "integrity": "sha512-f/BFgF9a+cgsMseC7rpv9+9TAE3YNjhfYrtwCo/pIeCDDfQtE6PY0b5bao2eIIEpZCBUy8Y5ToXd4ObjPSJuFw=="
+    },
+    "@types/request": {
+      "version": "2.48.5",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "aws-sdk": {
       "version": "2.771.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.771.0.tgz",
@@ -25,6 +85,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -45,6 +110,22 @@
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
       "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -53,15 +134,38 @@
         "ms": "2.1.2"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "denque": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
       "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
     },
     "ieee754": {
       "version": "1.1.13",
@@ -104,6 +208,19 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -113,6 +230,11 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
     },
     "punycode": {
       "version": "1.3.2",
@@ -155,10 +277,23 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
     "standard-as-callback": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.0.1.tgz",
       "integrity": "sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg=="
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
+      }
     },
     "url": {
       "version": "0.10.3",

--- a/packages/connectors-lib/package.json
+++ b/packages/connectors-lib/package.json
@@ -34,6 +34,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
+    "@airbrake/node": "^1.4.1",
     "aws-sdk": "^2.771.0",
     "debug": "^4.2.0",
     "ioredis": "^4.17.3",

--- a/packages/connectors-lib/src/__tests__/airbrake.spec.js
+++ b/packages/connectors-lib/src/__tests__/airbrake.spec.js
@@ -1,0 +1,166 @@
+import { Notifier } from '@airbrake/node'
+jest.mock('@airbrake/node')
+
+const nativeConsoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn())
+const nativeConsoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn())
+
+expect.extend({
+  errorWithMessageMatching (received, ...matchers) {
+    try {
+      expect(received).toBeInstanceOf(Error)
+      for (const matcher of matchers) {
+        if (!matcher.asymmetricMatch(received.message)) {
+          return { message: () => `expected ${matcher.toString()} to pass`, pass: false }
+        }
+      }
+      return { pass: true }
+    } catch (e) {
+      return { message: () => e.message, pass: false }
+    }
+  }
+})
+
+describe('airbrake', () => {
+  beforeEach(jest.resetAllMocks)
+
+  it('does not initialise airbrake if the required environment variables are missing', done => {
+    jest.isolateModules(async () => {
+      try {
+        delete process.env.AIRBRAKE_HOST
+        delete process.env.AIRBRAKE_PROJECT_KEY
+        const airbrake = require('../airbrake.js')
+        expect(airbrake.initialise()).toEqual(false)
+        console.error(new Error('Test'))
+        await expect(airbrake.flush()).resolves.toBeUndefined()
+        expect(Notifier.prototype.notify).not.toHaveBeenCalled()
+        expect(Notifier.prototype.flush).not.toHaveBeenCalled()
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
+  })
+
+  it('initialises airbrake if the required environment variables are present', done => {
+    jest.isolateModules(async () => {
+      try {
+        process.env.AIRBRAKE_HOST = 'https://test-airbrake.com'
+        process.env.AIRBRAKE_PROJECT_KEY = '123'
+        const airbrake = require('../airbrake.js')
+        expect(airbrake.initialise()).toEqual(true)
+        const testError = new Error('Test')
+        console.error(testError)
+        await expect(airbrake.flush()).resolves.toBeUndefined()
+        expect(Notifier.prototype.notify).toHaveBeenCalledWith(expect.objectContaining({ error: testError }))
+        expect(Notifier.prototype.flush).toHaveBeenCalled()
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
+  })
+
+  it('intercepts console.warn and console.error calls and notifies airbrake', done => {
+    jest.isolateModules(async () => {
+      try {
+        process.env.AIRBRAKE_HOST = 'https://test-airbrake.com'
+        process.env.AIRBRAKE_PROJECT_KEY = '123'
+        process.env.name = 'Test PM2 process name'
+        const airbrake = require('../airbrake.js')
+        expect(airbrake.initialise()).toEqual(true)
+
+        console.error('An error')
+        expect(nativeConsoleErrorSpy).toHaveBeenLastCalledWith('An error')
+        expect(Notifier.prototype.notify).toHaveBeenLastCalledWith({
+          error: expect.errorWithMessageMatching(expect.stringMatching('An error')),
+          params: expect.objectContaining({
+            consoleInvocationDetails: {
+              arguments: { 0: "'An error'" },
+              method: 'error'
+            }
+          }),
+          environment: {
+            name: 'Test PM2 process name'
+          }
+        })
+        console.warn('A warning')
+        expect(nativeConsoleWarnSpy).toHaveBeenLastCalledWith('A warning')
+        expect(Notifier.prototype.notify).toHaveBeenLastCalledWith({
+          error: expect.errorWithMessageMatching(expect.stringMatching('A warning')),
+          params: expect.objectContaining({
+            consoleInvocationDetails: {
+              arguments: { 0: "'A warning'" },
+              method: 'warn'
+            }
+          }),
+          environment: {
+            name: 'Test PM2 process name'
+          }
+        })
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
+  })
+
+  describe.each([
+    [['A single string'], 'A single string'],
+    [['A string with %d %s arguments', 2, 'formatting'], 'A string with 2 formatting arguments'],
+    [['Test', 'multiple', 'strings', 'with', 'no', 'format'], 'Test multiple strings with no format'],
+    [[new Error('Test error pos 1'), 'another string'], 'Test error pos 1'],
+    [['another string', new Error('Test error pos 2')], 'Test error pos 2']
+  ])('formats the error message in a consistent manner with the native console.error call: test %#', (input, output) => {
+    it(`[${input}] === ${output}`, done => {
+      jest.isolateModules(async () => {
+        try {
+          process.env.AIRBRAKE_HOST = 'https://test-airbrake.com'
+          process.env.AIRBRAKE_PROJECT_KEY = '123'
+          const airbrake = require('../airbrake.js')
+          expect(airbrake.initialise()).toEqual(true)
+
+          console.error(...input)
+          expect(nativeConsoleErrorSpy).toHaveBeenLastCalledWith(...input)
+          expect(Notifier.prototype.notify).toHaveBeenLastCalledWith({
+            error: expect.errorWithMessageMatching(expect.stringMatching(output)),
+            params: expect.objectContaining({
+              consoleInvocationDetails: {
+                arguments: expect.any(Object),
+                method: 'error'
+              }
+            }),
+            environment: expect.any(Object)
+          })
+          done()
+        } catch (e) {
+          done(e)
+        }
+      })
+    })
+  })
+
+  it('hooks the process for uncaughtExceptions and unhandledRejections', done => {
+    jest.isolateModules(async () => {
+      try {
+        const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(jest.fn())
+        process.env.AIRBRAKE_HOST = 'https://test-airbrake.com'
+        process.env.AIRBRAKE_PROJECT_KEY = '123'
+        const airbrake = require('../airbrake.js')
+        expect(airbrake.initialise()).toEqual(true)
+
+        const testError = new Error('Test error')
+        process.emit('uncaughtExceptionMonitor', testError)
+        process.emit('unhandledRejection', testError)
+
+        process.nextTick(() => {
+          expect(nativeConsoleErrorSpy).toHaveBeenLastCalledWith(testError)
+          expect(Notifier.prototype.flush).toHaveBeenCalled()
+          expect(processExitSpy).toHaveBeenCalledWith(1)
+          done()
+        })
+      } catch (e) {
+        done(e)
+      }
+    })
+  })
+})

--- a/packages/connectors-lib/src/airbrake.js
+++ b/packages/connectors-lib/src/airbrake.js
@@ -1,0 +1,61 @@
+import { Notifier } from '@airbrake/node'
+import { formatWithOptions, inspect } from 'util'
+const INSPECT_OPTS = { depth: null, maxStringLength: null, maxArrayLength: null, breakLength: null, compact: true, showHidden: true }
+
+let airbrake = null
+
+/**
+ * Initialise the airbrake client and intercept console.error and console.warn calls, notifying airbrake/errbit of any invocations.
+ * If the required environment variables are not set then airbrake will not be initialised.
+ *
+ * @returns {boolean} true if the client was initialised, false otherwise.
+ */
+export const initialise = () => {
+  if (!airbrake && process.env.AIRBRAKE_PROJECT_KEY && process.env.AIRBRAKE_HOST) {
+    airbrake = new Notifier({
+      projectId: 1,
+      projectKey: process.env.AIRBRAKE_PROJECT_KEY,
+      host: process.env.AIRBRAKE_HOST,
+      environment: process.env.NODE_ENV,
+      performanceStats: false
+    })
+
+    // Proxy the console.warn and console.error methods, notifying airbrake/errbit asynchronously
+    const nativeConsoleMethods = {}
+    ;['warn', 'error'].forEach(method => {
+      nativeConsoleMethods[method] = console[method].bind(console)
+      console[method] = (...args) => {
+        airbrake.notify({
+          error: args.find(arg => arg instanceof Error) ?? new Error(formatWithOptions(INSPECT_OPTS, ...args)),
+          params: { consoleInvocationDetails: { method, arguments: { ...args.map(arg => inspect(arg, INSPECT_OPTS)) } } },
+          environment: {
+            // Support for PM2 process.env.name
+            ...(process.env.name && { name: process.env.name })
+          }
+        })
+        nativeConsoleMethods[method](...args)
+      }
+    })
+
+    // Ensure uncaught exceptions/rejections are logged to the native console
+    process.on('uncaughtExceptionMonitor', err => nativeConsoleMethods.error(err))
+
+    // Override the @airbrake/node uncaughtException/unhandledRejection handlers with our own as errors were not flushing correctly.
+    const flushAndDie = async () => {
+      await airbrake.flush()
+      process.exit(1)
+    }
+    process.on('uncaughtException', flushAndDie)
+    process.on('unhandledRejection', flushAndDie)
+  }
+  return !!airbrake
+}
+
+/**
+ * Flush the buffer ensuring that any data waiting to be sent to airbrake/errbit is sent before returning
+ *
+ * @returns {Promise<void>}
+ */
+export const flush = async () => {
+  initialise() && (await airbrake.flush())
+}

--- a/packages/connectors-lib/src/connectors.js
+++ b/packages/connectors-lib/src/connectors.js
@@ -1,5 +1,6 @@
 import AWS from './aws.js'
 import * as salesApi from './sales-api-connector.js'
+import * as airbrake from './airbrake.js'
 import * as govUkPayApi from './govuk-pay-api.js'
 import { DistributedLock } from './distributed-lock.js'
-export { AWS, salesApi, govUkPayApi, DistributedLock }
+export { AWS, salesApi, govUkPayApi, DistributedLock, airbrake }

--- a/packages/fulfilment-job/src/fulfilment-processor.js
+++ b/packages/fulfilment-job/src/fulfilment-processor.js
@@ -1,7 +1,7 @@
 import config from './config.js'
 import { createPartFiles } from './staging/create-part-files.js'
 import { deliverFulfilmentFiles } from './staging/deliver-fulfilment-files.js'
-import { DistributedLock } from '@defra-fish/connectors-lib'
+import { DistributedLock, airbrake } from '@defra-fish/connectors-lib'
 import { terminateCacheManager } from '@defra-fish/dynamics-lib'
 
 /**
@@ -17,6 +17,8 @@ const lock = new DistributedLock('fulfilment-etl', 5 * 60 * 1000)
  * @returns {Promise<void>}
  */
 export const processFulfilment = async () => {
+  airbrake.initialise()
+
   try {
     await lock.obtainAndExecute({
       onLockObtained: async () => {
@@ -32,10 +34,12 @@ export const processFulfilment = async () => {
     })
   } finally {
     await terminateCacheManager()
+    await airbrake.flush()
   }
 }
 
 const shutdown = async () => {
+  await airbrake.flush()
   await lock.release()
   process.exit(0)
 }

--- a/packages/gafl-webapp-service/src/__tests__/gafl-webapp-service.spec.js
+++ b/packages/gafl-webapp-service/src/__tests__/gafl-webapp-service.spec.js
@@ -1,19 +1,19 @@
 describe('gafl-web-service', () => {
   it('runs initialisation', done => {
-    jest.isolateModules(async () => {
+    jest.isolateModules(() => {
       try {
         jest.mock('../server.js')
         const { createServer, init, shutdownBehavior } = require('../server.js')
         createServer.mockImplementation(() => {})
         init.mockImplementation(() => Promise.resolve())
         shutdownBehavior.mockImplementation(() => {})
-        await (async () => {
-          require('../gafl-webapp-service')
-        })()
-        expect(createServer).toHaveBeenCalled()
-        expect(init).toHaveBeenCalled()
-        expect(shutdownBehavior).toHaveBeenCalled()
-        done()
+        require('../gafl-webapp-service')
+        setImmediate(() => {
+          expect(createServer).toHaveBeenCalled()
+          expect(init).toHaveBeenCalled()
+          expect(shutdownBehavior).toHaveBeenCalled()
+          done()
+        })
       } catch (e) {
         done(e)
       }
@@ -21,7 +21,7 @@ describe('gafl-web-service', () => {
   })
 
   it('has initialisation failure', done => {
-    jest.isolateModules(async () => {
+    jest.isolateModules(() => {
       try {
         jest.mock('../server.js')
         const { createServer, init, shutdownBehavior } = require('../server.js')
@@ -29,14 +29,14 @@ describe('gafl-web-service', () => {
         init.mockImplementation(() => Promise.reject(new Error()))
         shutdownBehavior.mockImplementation(() => {})
         const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(code => {})
-        await (async () => {
-          require('../gafl-webapp-service')
-        })().catch()
-        expect(init).toHaveBeenCalled()
-        expect(createServer).toHaveBeenCalled()
-        expect(shutdownBehavior).not.toHaveBeenCalled()
-        expect(processExitSpy).toHaveBeenCalledWith(1)
-        done()
+        require('../gafl-webapp-service')
+        setImmediate(() => {
+          expect(init).toHaveBeenCalled()
+          expect(createServer).toHaveBeenCalled()
+          expect(shutdownBehavior).not.toHaveBeenCalled()
+          expect(processExitSpy).toHaveBeenCalledWith(1)
+          done()
+        })
       } catch (e) {
         done(e)
       }

--- a/packages/gafl-webapp-service/src/__tests__/server.spec.js
+++ b/packages/gafl-webapp-service/src/__tests__/server.spec.js
@@ -1,6 +1,8 @@
 import { createServer, init, server } from '../server.js'
 import CatboxMemory from '@hapi/catbox-memory'
 
+jest.mock('@defra-fish/connectors-lib')
+
 export const catboxOptions = {
   port: 1234,
   cache: [
@@ -50,15 +52,16 @@ describe('The server', () => {
           shutdownBehavior()
           const serverStopSpy = jest.spyOn(server, 'stop').mockImplementation(jest.fn())
           const processStopSpy = jest.spyOn(process, 'exit').mockImplementation(jest.fn())
-          await process.emit(signal)
-          expect(serverStopSpy).toHaveBeenCalled()
-          expect(processStopSpy).toHaveBeenCalledWith(0)
-          jest.restoreAllMocks()
-          done()
+          process.emit(signal)
+          setImmediate(async () => {
+            expect(serverStopSpy).toHaveBeenCalled()
+            expect(processStopSpy).toHaveBeenCalledWith(0)
+            jest.restoreAllMocks()
+            await server.stop()
+            done()
+          })
         } catch (e) {
           done(e)
-        } finally {
-          await server.stop()
         }
       })
     })

--- a/packages/gafl-webapp-service/src/handlers/error-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/error-handler.js
@@ -25,10 +25,9 @@ export const errorHandler = async (request, h) => {
   } else {
     /*
      * 5xx server errors and are logged.
-     * The response stacktrace and message are hidden from the console so copy the objects
      */
-    const { stack, message, output } = request.response
-    console.error(JSON.stringify(Object.assign({}, { stack, message, output }), null, 4))
+    const requestDetail = { path: request.path, query: request.query, params: request.params, payload: request.payload }
+    console.error('Error processing request. Request: %j, Exception: %o', requestDetail, request.response)
 
     return h
       .view(SERVER_ERROR.page, {

--- a/packages/gafl-webapp-service/src/server.js
+++ b/packages/gafl-webapp-service/src/server.js
@@ -24,7 +24,8 @@ import { cacheDecorator } from './session-cache/cache-decorator.js'
 import { errorHandler } from './handlers/error-handler.js'
 import { initialise as initialiseOIDC } from './handlers/oidc-handler.js'
 import { getPlugins } from './plugins.js'
-
+import { airbrake } from '@defra-fish/connectors-lib'
+airbrake.initialise()
 let server
 
 const createServer = options => {
@@ -186,6 +187,7 @@ const shutdownBehavior = () => {
   const shutdown = async (code = 0) => {
     console.log(`Server is shutdown with ${code}`)
     await server.stop()
+    await airbrake.flush()
     process.exit(code)
   }
   process.on('SIGINT', shutdown)

--- a/packages/pocl-job/src/pocl-processor.js
+++ b/packages/pocl-job/src/pocl-processor.js
@@ -1,5 +1,5 @@
 import config from './config.js'
-import { DistributedLock } from '@defra-fish/connectors-lib'
+import { DistributedLock, airbrake } from '@defra-fish/connectors-lib'
 import { ftpToS3 } from './transport/ftp-to-s3.js'
 import { s3ToLocal } from './transport/s3-to-local.js'
 import { getFileRecords } from './io/db.js'
@@ -24,6 +24,8 @@ const lock = new DistributedLock('pocl-etl', 5 * 60 * 1000)
  * @returns {Promise<void>}
  */
 export async function execute () {
+  airbrake.initialise()
+
   await lock.obtainAndExecute({
     onLockObtained: async () => {
       try {
@@ -45,9 +47,11 @@ export async function execute () {
     },
     maxWaitSeconds: 0
   })
+  await airbrake.flush()
 }
 
 const shutdown = async () => {
+  await airbrake.flush()
   await lock.release()
   process.exit(0)
 }

--- a/packages/sales-api-service/src/server/server.js
+++ b/packages/sales-api-service/src/server/server.js
@@ -7,8 +7,11 @@ import Routes from './routes/index.js'
 import Boom from '@hapi/boom'
 import { SERVER } from '../config.js'
 import moment from 'moment'
+import { airbrake } from '@defra-fish/connectors-lib'
 
 export default async (opts = { port: SERVER.Port }) => {
+  airbrake.initialise()
+
   const server = new Hapi.Server(
     Object.assign(
       {
@@ -50,6 +53,7 @@ export default async (opts = { port: SERVER.Port }) => {
 
   const shutdown = async (code = 0) => {
     await server.stop()
+    await airbrake.flush()
     process.exit(code)
   }
 

--- a/packages/sqs-receiver-service/ecosystem.config.yml
+++ b/packages/sqs-receiver-service/ecosystem.config.yml
@@ -4,19 +4,19 @@ apps:
     name: 'Transactions Queue'
     env:
       RECEIVER_PREFIX: TRANSACTION_QUEUE
-    exec_mode: cluster
-    instances: 1
+    exec_mode: fork
+    kill_timeout: 180000
     autorestart: true
-    max_restarts: 5
-    restart_delay: 1000
+    max_restarts: 3
+    restart_delay: 5000
 
   - script: ./src/sqs-receiver-service.js
     interpreter_args: '--unhandled-rejections=strict'
     name: 'Transactions DLQ'
     env:
       RECEIVER_PREFIX: TRANSACTION_DLQ
-    exec_mode: cluster
-    instances: 1
+    exec_mode: fork
+    kill_timeout: 180000
     autorestart: true
-    max_restarts: 5
-    restart_delay: 1000
+    max_restarts: 3
+    restart_delay: 5000

--- a/packages/sqs-receiver-service/src/__tests__/sqs-receiver-service.spec.js
+++ b/packages/sqs-receiver-service/src/__tests__/sqs-receiver-service.spec.js
@@ -1,14 +1,47 @@
-import '../sqs-receiver-service.js'
+import receiver from '../receiver.js'
+jest.mock('@defra-fish/connectors-lib')
 jest.mock('../receiver.js', () => {
   return jest.fn(async () => {
     global.receiverInitialised = true
-    throw new Error('Simulated')
+    if (global.throwReceiverError) {
+      throw new Error('Simulated')
+    }
+    await new Promise(resolve => setTimeout(resolve, 100))
   })
 })
-const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+const consoleError = jest.spyOn(console, 'error').mockImplementation(jest.fn())
+const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(jest.fn())
 describe('sqs-receiver-service', () => {
-  it('initialises', () => {
-    expect(global.receiverInitialised).toBeTruthy()
-    expect(consoleError).toHaveBeenCalled()
+  it('executes until interrupted', done => {
+    jest.isolateModules(() => {
+      global.throwReceiverError = false
+      require('../sqs-receiver-service.js')
+      setImmediate(() => {
+        expect(receiver).toHaveBeenCalled()
+        expect(global.receiverInitialised).toBeTruthy()
+        expect(consoleError).not.toHaveBeenCalled()
+        expect(processExitSpy).not.toHaveBeenCalled()
+
+        process.emit('SIGINT')
+
+        global.throwReceiverError = true
+        setImmediate(() => {
+          expect(processExitSpy).not.toHaveBeenCalledWith(0)
+          done()
+        })
+      })
+    })
+  })
+  it('logs and errors and exits the process', done => {
+    jest.isolateModules(() => {
+      global.throwReceiverError = true
+      require('../sqs-receiver-service.js')
+      setImmediate(() => {
+        expect(global.receiverInitialised).toBeTruthy()
+        expect(consoleError).toHaveBeenCalled()
+        expect(processExitSpy).toHaveBeenCalledWith(1)
+        done()
+      })
+    })
   })
 })

--- a/packages/sqs-receiver-service/src/sqs-receiver-service.js
+++ b/packages/sqs-receiver-service/src/sqs-receiver-service.js
@@ -1,19 +1,31 @@
 'use strict'
+import { airbrake } from '@defra-fish/connectors-lib'
 /**
  * Initializes and starts the receiver loop
  */
 import receiver from './receiver.js'
 
+let exitCode = 0
+
 /**
  * Start the receiver
  */
 ;(async () => {
-  while (true) {
+  airbrake.initialise()
+  while (!exitCode) {
     try {
       await receiver()
-    } catch (err) {
-      console.error(err)
-      break
+    } catch (e) {
+      console.error(e)
+      exitCode = 1
     }
   }
+  await airbrake.flush()
+  process.exit(exitCode)
 })()
+
+const stopService = () => {
+  exitCode = 0
+}
+process.on('SIGINT', stopService)
+process.on('SIGTERM', stopService)


### PR DESCRIPTION
- connectors-lib now provides airbrake support to services
- console.error & console.warn now send notifications to airbrake
- all services updated to initialise airbrake on startup
- all services updated to flush airbrake notifications on shutdown
- issue with sqs receiver not shutting down gracefully fixed
- sqs receiver pm2 configuration changed to allow current operations to complete