### PR TITLE
Enable x-domain analytics tracking & persist attribution between sessions

### DIFF
--- a/packages/gafl-webapp-service/src/__tests__/server-ga-integration.spec.js
+++ b/packages/gafl-webapp-service/src/__tests__/server-ga-integration.spec.js
@@ -58,10 +58,19 @@ describe('Server GA integration', () => {
 
   it('gets session id from cache', async () => {
     const cookieName = 'Bourbon-1272'
-    const request = generateRequestMock(undefined, { getId: () => cookieName })
+    const request = generateRequestMock({ gaClientId: undefined }, { getId: () => cookieName })
     await init()
     const hapiGapiPlugin = getHapiGapiPlugin()
-    expect(hapiGapiPlugin.options.sessionIdProducer(request)).toBe(cookieName)
+    await expect(hapiGapiPlugin.options.sessionIdProducer(request)).resolves.toEqual(cookieName)
+  })
+
+  it('uses the gaClientId in preference to the session id if it is set', async () => {
+    const cookieName = 'Bourbon-1272'
+    const gaClientId = 'Single-Malt'
+    const request = generateRequestMock({ gaClientId: gaClientId }, { getId: () => cookieName })
+    await init()
+    const hapiGapiPlugin = getHapiGapiPlugin()
+    await expect(hapiGapiPlugin.options.sessionIdProducer(request)).resolves.toEqual(gaClientId)
   })
 
   it("sessionIdProducer returns null if we're not using a session cookie", async () => {
@@ -69,7 +78,7 @@ describe('Server GA integration', () => {
     const request = generateRequestMock()
     await init()
     const hapiGapiPlugin = getHapiGapiPlugin()
-    expect(hapiGapiPlugin.options.sessionIdProducer(request)).toBe(null)
+    await expect(hapiGapiPlugin.options.sessionIdProducer(request)).resolves.toEqual(null)
   })
 
   it('returns an empty object if attribution is empty', async () => {

--- a/packages/gafl-webapp-service/src/handlers/__tests__/attribution-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/attribution-handler.spec.js
@@ -49,20 +49,6 @@ describe('The attribution handler', () => {
     delete process.env.ATTRIBUTION_REDIRECT
   })
 
-  it("generates a warning if campaign or source aren't set", async () => {
-    const query = {}
-    jest.spyOn(console, 'warn')
-    await attributionHandler(generateRequestMock(query), generateResponseToolkitMock())
-    expect(console.warn).toHaveBeenCalledWith('Campaign and source values should be set in attribution')
-  })
-
-  it("doesn't generate a warning if campaign and source are set", async () => {
-    const query = { [UTM.CAMPAIGN]: 'Gallic', [UTM.SOURCE]: 'brown' }
-    jest.spyOn(console, 'warn')
-    await attributionHandler(generateRequestMock(query), generateResponseToolkitMock())
-    expect(console.warn).not.toHaveBeenCalled()
-  })
-
   const generateRequestMock = (query, status = {}) => ({
     query,
     cache: jest.fn(() => ({

--- a/packages/gafl-webapp-service/src/handlers/attribution-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/attribution-handler.js
@@ -1,4 +1,5 @@
-import { UTM, ATTRIBUTION_REDIRECT_DEFAULT } from '../constants.js'
+import { ATTRIBUTION_REDIRECT_DEFAULT } from '../constants.js'
+import { initialiseAnalyticsSessionData } from '../processors/analytics.js'
 
 /**
  * Attribution route handler
@@ -7,19 +8,6 @@ import { UTM, ATTRIBUTION_REDIRECT_DEFAULT } from '../constants.js'
  * @returns {Promise}
  */
 export default async (request, h) => {
-  const redirectTarget = process.env.ATTRIBUTION_REDIRECT || ATTRIBUTION_REDIRECT_DEFAULT
-  const cache = request.cache()
-  if (!(request.query[UTM.CAMPAIGN] && request.query[UTM.SOURCE])) {
-    console.warn('Campaign and source values should be set in attribution')
-  }
-  await cache.helpers.status.set({
-    attribution: {
-      [UTM.CAMPAIGN]: request.query[UTM.CAMPAIGN],
-      [UTM.MEDIUM]: request.query[UTM.MEDIUM],
-      [UTM.CONTENT]: request.query[UTM.CONTENT],
-      [UTM.SOURCE]: request.query[UTM.SOURCE],
-      [UTM.TERM]: request.query[UTM.TERM]
-    }
-  })
-  return h.redirect(redirectTarget)
+  await initialiseAnalyticsSessionData(request)
+  return h.redirect(process.env.ATTRIBUTION_REDIRECT || ATTRIBUTION_REDIRECT_DEFAULT)
 }

--- a/packages/gafl-webapp-service/src/handlers/new-session-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/new-session-handler.js
@@ -1,0 +1,10 @@
+import { CONTROLLER } from '../uri.js'
+import { initialiseAnalyticsSessionData } from '../processors/analytics.js'
+
+export default async (request, h) => {
+  // The user may have an existing session, in which case we need to examine this for attribution and/or clientId
+  const existingCacheStatus = await request.cache().helpers.status.get()
+  await request.cache().initialize()
+  await initialiseAnalyticsSessionData(request, existingCacheStatus)
+  return h.redirect(CONTROLLER.uri)
+}

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -13,91 +13,95 @@ import { getCsrfTokenCookieName } from './server.js'
 // script. It needs the quotes.
 const scriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
 
-export const getPlugins = () => {
+const initialiseDisinfectPlugin = () => ({
+  plugin: Disinfect,
+  options: {
+    disinfectQuery: true,
+    disinfectParams: true,
+    disinfectPayload: true
+  }
+})
+
+const initialiseBlankiePlugin = () => ({
+  plugin: Blankie,
+  options: {
+    /*
+     * This defines the content security policy - which is as restrictive as possible
+     * It must allow web-fonts from 'fonts.gstatic.com'
+     */
+    fontSrc: ['self', 'fonts.gstatic.com', 'data:'],
+    scriptSrc: ['self', 'unsafe-inline', scriptHash],
+    generateNonces: true,
+    frameAncestors: 'none'
+  }
+})
+
+const initialiseCrumbPlugin = () => ({
+  plugin: Crumb,
+  options: {
+    key: getCsrfTokenCookieName(),
+    cookieOptions: {
+      isSecure: process.env.NODE_ENV !== 'development',
+      isHttpOnly: process.env.NODE_ENV !== 'development'
+    },
+    logUnauthorized: true
+  }
+})
+
+const initialiseHapiGapiPlugin = () => {
   const hapiGapiPropertySettings = []
   if (process.env.ANALYTICS_PRIMARY_PROPERTY) {
-    hapiGapiPropertySettings.push({
-      id: process.env.ANALYTICS_PRIMARY_PROPERTY,
-      hitTypes: ['pageview', 'event', 'ecommerce']
-    })
+    hapiGapiPropertySettings.push({ id: process.env.ANALYTICS_PRIMARY_PROPERTY, hitTypes: ['pageview', 'event', 'ecommerce'] })
   } else {
     console.warn("ANALYTICS_PRIMARY_PROPERTY not set, so Google Analytics won't track this")
   }
   if (process.env.ANALYTICS_XGOV_PROPERTY) {
-    hapiGapiPropertySettings.push({
-      id: process.env.ANALYTICS_XGOV_PROPERTY,
-      hitTypes: ['pageview']
-    })
+    hapiGapiPropertySettings.push({ id: process.env.ANALYTICS_XGOV_PROPERTY, hitTypes: ['pageview'] })
   } else {
     console.warn("ANALYTICS_XGOV_PROPERTY not set, so Google Analytics won't track this")
   }
 
+  return {
+    plugin: HapiGapi,
+    options: {
+      propertySettings: hapiGapiPropertySettings,
+      sessionIdProducer: async request => {
+        let sessionId = null
+        if (useSessionCookie(request)) {
+          const { gaClientId } = await request.cache().helpers.status.get()
+          sessionId = gaClientId ?? (await request.cache().getId())
+        }
+        return sessionId
+      },
+      attributionProducer: async request => {
+        if (useSessionCookie(request)) {
+          const { attribution } = await request.cache().helpers.status.get()
+
+          if (attribution) {
+            return {
+              campaign: attribution[UTM.CAMPAIGN],
+              content: attribution[UTM.CONTENT],
+              medium: attribution[UTM.MEDIUM],
+              source: attribution[UTM.SOURCE],
+              term: attribution[UTM.TERM]
+            }
+          }
+        }
+        return {}
+      }
+    }
+  }
+}
+
+export const getPlugins = () => {
   return [
     Inert,
     Vision,
     Scooter,
     Cookie,
-    {
-      plugin: Disinfect,
-      options: {
-        disinfectQuery: true,
-        disinfectParams: true,
-        disinfectPayload: true
-      }
-    },
-    {
-      plugin: Blankie,
-      options: {
-        /*
-         * This defines the content security policy - which is as restrictive as possible
-         * It must allow web-fonts from 'fonts.gstatic.com'
-         */
-        fontSrc: ['self', 'fonts.gstatic.com', 'data:'],
-        scriptSrc: ['self', 'unsafe-inline', scriptHash],
-        generateNonces: true,
-        frameAncestors: 'none'
-      }
-    },
-    {
-      plugin: Crumb,
-      options: {
-        key: getCsrfTokenCookieName(),
-        cookieOptions: {
-          isSecure: process.env.NODE_ENV !== 'development',
-          isHttpOnly: process.env.NODE_ENV !== 'development'
-        },
-        logUnauthorized: true
-      }
-    },
-    {
-      plugin: HapiGapi,
-      options: {
-        propertySettings: hapiGapiPropertySettings,
-        sessionIdProducer: async request => {
-          let sessionId = null
-          if (useSessionCookie(request)) {
-            const { gaClientId } = await request.cache().helpers.status.get()
-            sessionId = gaClientId ?? (await request.cache().getId())
-          }
-          return sessionId
-        },
-        attributionProducer: async request => {
-          if (useSessionCookie(request)) {
-            const { attribution } = await request.cache().helpers.status.get()
-
-            if (attribution) {
-              return {
-                campaign: attribution[UTM.CAMPAIGN],
-                content: attribution[UTM.CONTENT],
-                medium: attribution[UTM.MEDIUM],
-                source: attribution[UTM.SOURCE],
-                term: attribution[UTM.TERM]
-              }
-            }
-          }
-          return {}
-        }
-      }
-    }
+    initialiseDisinfectPlugin(),
+    initialiseBlankiePlugin(),
+    initialiseCrumbPlugin(),
+    initialiseHapiGapiPlugin()
   ]
 }

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -73,7 +73,14 @@ export const getPlugins = () => {
       plugin: HapiGapi,
       options: {
         propertySettings: hapiGapiPropertySettings,
-        sessionIdProducer: request => (useSessionCookie(request) ? request.cache().getId() : null),
+        sessionIdProducer: async request => {
+          let sessionId = null
+          if (useSessionCookie(request)) {
+            const { gaClientId } = await request.cache().helpers.status.get()
+            sessionId = gaClientId ?? (await request.cache().getId())
+          }
+          return sessionId
+        },
         attributionProducer: async request => {
           if (useSessionCookie(request)) {
             const { attribution } = await request.cache().helpers.status.get()

--- a/packages/gafl-webapp-service/src/processors/analytics.js
+++ b/packages/gafl-webapp-service/src/processors/analytics.js
@@ -1,3 +1,24 @@
+import { UTM } from '../constants.js'
+
+export const initialiseAnalyticsSessionData = async (request, previousSessionStatusData) => {
+  let clientId
+  // When redirecting from the landing page (which uses client side analytics) we need to establish the session identifier using the linker parameter
+  if (request.query._ga) {
+    clientId = /^.+-(?<clientId>.+)$/.exec(request.query._ga).groups.clientId
+  }
+  // The user may have an existing session, in which case we need to examine this for attribution and/or clientId
+  await request.cache().helpers.status.set({
+    gaClientId: previousSessionStatusData?.gaClientId || clientId,
+    attribution: previousSessionStatusData?.attribution || {
+      [UTM.CAMPAIGN]: request.query[UTM.CAMPAIGN],
+      [UTM.MEDIUM]: request.query[UTM.MEDIUM],
+      [UTM.CONTENT]: request.query[UTM.CONTENT],
+      [UTM.SOURCE]: request.query[UTM.SOURCE],
+      [UTM.TERM]: request.query[UTM.TERM]
+    }
+  })
+}
+
 export const getTrackingProductDetailsFromTransaction = ({ permissions }) =>
   permissions.map(({ permit }) => ({
     id: permit.description,

--- a/packages/gafl-webapp-service/src/routes/misc-routes.js
+++ b/packages/gafl-webapp-service/src/routes/misc-routes.js
@@ -18,6 +18,7 @@ import {
 import { SESSION_COOKIE_NAME_DEFAULT, CSRF_TOKEN_COOKIE_NAME_DEFAULT, ALB_COOKIE_NAME, ALBCORS_COOKIE_NAME } from '../constants.js'
 
 import addPermission from '../session-cache/add-permission.js'
+import newSessionHandler from '../handlers/new-session-handler.js'
 import agreedHandler from '../handlers/agreed-handler.js'
 import controllerHandler from '../handlers/controller-handler.js'
 import authenticationHandler from '../handlers/authentication-handler.js'
@@ -71,10 +72,7 @@ export default [
   {
     method: 'GET',
     path: NEW_TRANSACTION.uri,
-    handler: async (request, h) => {
-      await request.cache().initialize()
-      return h.redirect(CONTROLLER.uri)
-    }
+    handler: newSessionHandler
   },
   {
     method: 'GET',

--- a/packages/gafl-webapp-service/src/session-cache/session-manager.js
+++ b/packages/gafl-webapp-service/src/session-cache/session-manager.js
@@ -13,6 +13,7 @@ import {
   TEST_TRANSACTION,
   TEST_STATUS
 } from '../uri.js'
+import { initialiseAnalyticsSessionData } from '../processors/analytics.js'
 
 const debug = db('webapp:session-manager')
 
@@ -93,6 +94,7 @@ const sessionManager = sessionCookieName => async (request, h) => {
      * devices where a browser is woken up.
      */
     if (initialized) {
+      await initialiseAnalyticsSessionData(request)
       return h.redirect(CONTROLLER.uri).takeover()
     }
   }


### PR DESCRIPTION
- Ensure invocations of the `/buy/new` endpoint read the _ga parameter and store this data on the session to enable cross-domain tracking support (from the GOV.UK landing page)
- Ensure the session manager (onPreHandler) also respects the _ga parameter (and store this data on the session) as this will intercept invocations of `/buy/new` if a session doesn't already exist
- Ensure that the previous session's attribution data is copied to the new session when `/buy/new` is invoked
- Update the hapi-gapi plugin sessionIdProducer method to pass through the gaSessionId from the session data if available, else pass through the standard session identifier
- Remove console.warn calls when hitting the attribution endpoint without the required parameters as this is a client error and these will otherwise be logged to errbit