### PR TITLE
Explicitly set the path for the banner cookie

### DIFF
--- a/packages/gafl-webapp-service/src/pages/layout/layout.njk
+++ b/packages/gafl-webapp-service/src/pages/layout/layout.njk
@@ -42,7 +42,7 @@
                 document.getElementById('close-global-cookie-message').addEventListener('click', function() {
                     var expiry = new Date()
                     expiry.setDate(expiry.getDate() + 90)
-                    document.cookie = ' seen_cookie_message=true; expires=' + expiry.toUTCString()
+                    document.cookie = 'seen_cookie_message=true; expires=' + expiry.toUTCString() + '; path=/;'
                     removeCookieMessage()
                 })
             }


### PR DESCRIPTION
Fixes the issue where the cookie banner has been dismissed with the ‘Close' button but reappears when opening the guidance pages.