### PR TITLE
Remove question mark from text

### DIFF
--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/licence-start-time.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/licence-start-time.njk
@@ -1,7 +1,7 @@
 {% extends "standard-form.njk" %}
 {% from "radios/macro.njk" import govukRadios %}
 
-{% set title = 'Choose when you would like the licence to start on ' + data.startDateStr + '?' %}
+{% set title = 'Choose when you would like the licence to start on ' + data.startDateStr %}
 
 {%
     set errorMap = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-1717

The heading reads "Choose when you would like the licence to start on Friday, 18th December, 2020?" This looks unprofessional and is grammatically incorrect