### PR TITLE
Show correct keyboard for email addresses

### DIFF
--- a/packages/gafl-webapp-service/src/pages/contact/contact/contact.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/contact/contact.njk
@@ -32,7 +32,7 @@
         {{ govukInput({
           id: "email",
           name: "email",
-          type: "text",
+          type: "email",
           classes: "govuk-!-width-two-thirds",
           autocomplete: "email",
           errorMessage: { text: 'Enter your email address in the correct format' } if error['email'],


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-1719

When buying a licence on mobile and entering a contact email address to send the licence to, we should show an "email" keyboard which contains an @ to help people enter their email address.