### PR TITLE
Use an upsert transaction for dynamics

### DIFF
--- a/packages/dynamics-lib/src/__mocks__/dynamics-web-api-mock-helper.js
+++ b/packages/dynamics-lib/src/__mocks__/dynamics-web-api-mock-helper.js
@@ -55,7 +55,7 @@ export const configureDynamicsWebApiMock = (DynamicsWebApi = jest.genMockFromMod
 
   DynamicsWebApi.prototype.retrieveRequest = jest.fn(async () => responseCapableMethod('retrieveRequest'))
   DynamicsWebApi.prototype.createRequest = jest.fn(async () => responseCapableMethod('createRequest'))
-  DynamicsWebApi.prototype.updateRequest = jest.fn(async () => responseCapableMethod('updateRequest'))
+  DynamicsWebApi.prototype.upsertRequest = jest.fn(async () => responseCapableMethod('upsertRequest'))
   DynamicsWebApi.prototype.retrieveMultipleRequest = jest.fn(async () => responseCapableMethod('retrieveMultipleRequest'))
   DynamicsWebApi.prototype.retrieveGlobalOptionSets = jest.fn(async () => responseCapableMethod('retrieveGlobalOptionSets'))
   DynamicsWebApi.prototype.executeUnboundFunction = jest.fn(async functionName => {

--- a/packages/dynamics-lib/src/client/__tests__/entity-manager.spec.js
+++ b/packages/dynamics-lib/src/client/__tests__/entity-manager.spec.js
@@ -33,7 +33,7 @@ describe('entity manager', () => {
       t.boolVal = true
 
       const result = await persist(t)
-      expect(MockDynamicsWebApi.prototype.createRequest).toHaveBeenCalled()
+      expect(MockDynamicsWebApi.prototype.upsertRequest).toHaveBeenCalled()
       expect(result).toHaveLength(1)
       expect(result[0]).toEqual(resultUuid)
     })
@@ -54,7 +54,7 @@ describe('entity manager', () => {
       )
 
       const result = await persist(t)
-      expect(MockDynamicsWebApi.prototype.updateRequest).toHaveBeenCalled()
+      expect(MockDynamicsWebApi.prototype.upsertRequest).toHaveBeenCalled()
       expect(result).toHaveLength(1)
       expect(result[0]).toEqual(resultUuid)
     })
@@ -74,16 +74,16 @@ describe('entity manager', () => {
         {}
       )
       await expect(persist(newEntity, existingEntity)).rejects.toThrow('Test error')
-      // Expect the console error to contain details of the batch data (one createRequest, one updateRequest plus the exception object)
+      // Expect the console error to contain details of the batch data (two upsertRequests plus the exception object)
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringMatching('Error persisting batch. Data: %j, Exception: %o'),
-        expect.arrayContaining([{ createRequest: expect.any(Object) }, { updateRequest: expect.any(Object) }]),
+        expect.arrayContaining([{ upsertRequest: expect.any(Object) }, { upsertRequest: expect.any(Object) }]),
         expect.any(Error)
       )
     })
 
     it('throws an error on implementation failure', async () => {
-      await expect(persist(null)).rejects.toThrow("Cannot read property 'isNew' of null")
+      await expect(persist(null)).rejects.toThrow("Cannot read property 'toPersistRequest' of null")
     })
   })
 

--- a/packages/dynamics-lib/src/client/entity-manager.js
+++ b/packages/dynamics-lib/src/client/entity-manager.js
@@ -11,16 +11,12 @@ export async function persist (...entities) {
   try {
     dynamicsClient.startBatch()
     entities.forEach(entity => {
-      if (entity.isNew()) {
-        dynamicsClient.createRequest(entity.toPersistRequest())
-      } else {
-        dynamicsClient.updateRequest(entity.toPersistRequest())
-      }
+      dynamicsClient.upsertRequest(entity.toPersistRequest())
     })
     return await dynamicsClient.executeBatch()
   } catch (e) {
     const error = e.length ? e[0] : e
-    const requestDetails = entities.map(entity => ({ [entity.isNew() ? 'createRequest' : 'updateRequest']: entity.toPersistRequest() }))
+    const requestDetails = entities.map(entity => ({ upsertRequest: entity.toPersistRequest() }))
     console.error('Error persisting batch. Data: %j, Exception: %o', requestDetails, error)
     throw error
   }


### PR DESCRIPTION
Instead of trying to calculate whether to do an insert or update call, we perform an upset to avoid duplicate key errors in dynamics.