### PR TITLE
Fix how we obtain client tracking id

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/analytics.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/analytics.spec.js
@@ -38,7 +38,7 @@ describe('initialiseAnalyticsSessionData', () => {
     })
 
   it.each([
-    '!@£$%^&*()œ∑´®†¥¨^øåß∂ƒ©˙∆˚', '¡€#¢∞§¶•ªø^¨¥©˙∆˚˙©†ƒ®', '1$2$345$678', '1,2,345,678'
+    '!@£$%^&*()œ∑´®†¥¨^øåß∂ƒ©˙∆˚', '¡€#¢∞§¶•ªø^¨¥©˙∆˚˙©†ƒ®', '1$2$345$678', '1,2,345,678', '523510731.1602852296'
   ])('unexpected _ga formats fail gracefully', async _ga => {
     const fakeRequest = {
       query: { _ga },
@@ -54,7 +54,7 @@ describe('initialiseAnalyticsSessionData', () => {
   })
 
   it.each([
-    '!@£$%^&*()œ∑´®†¥¨^øåß∂ƒ©˙∆˚', '¡€#¢∞§¶•ªø^¨¥©˙∆˚˙©†ƒ®', '1$2$345$678', '1,2,345,678'
+    '!@£$%^&*()œ∑´®†¥¨^øåß∂ƒ©˙∆˚', '¡€#¢∞§¶•ªø^¨¥©˙∆˚˙©†ƒ®', '1$2$345$678', '1,2,345,678', '523510731.1602852296'
   ])('unexpected _ga formats are logged', async _ga => {
     const fakeRequest = {
       query: { _ga },

--- a/packages/gafl-webapp-service/src/processors/analytics.js
+++ b/packages/gafl-webapp-service/src/processors/analytics.js
@@ -1,9 +1,10 @@
 import { UTM } from '../constants.js'
 
-const getClientIdFromGACookie = (query) => {
+const getClientIdFromGACookie = query => {
   if (query._ga) {
     return query._ga.split('.')[2]
   }
+  return undefined
 }
 
 export const initialiseAnalyticsSessionData = async (request, previousSessionStatusData) => {

--- a/packages/gafl-webapp-service/src/processors/analytics.js
+++ b/packages/gafl-webapp-service/src/processors/analytics.js
@@ -1,8 +1,14 @@
 import { UTM } from '../constants.js'
+import db from 'debug'
+const debug = db('webapp:analytics-processor')
 
 const getClientIdFromGACookie = query => {
   if (query._ga) {
-    return query._ga.split('.')[2]
+    const clientId = query._ga.split('.')[2]
+    if (!clientId) {
+      debug(`Unexpected _ga cookie value: ${query._ga}`)
+    }
+    return clientId
   }
   return undefined
 }

--- a/packages/gafl-webapp-service/src/processors/analytics.js
+++ b/packages/gafl-webapp-service/src/processors/analytics.js
@@ -1,11 +1,14 @@
 import { UTM } from '../constants.js'
 
-export const initialiseAnalyticsSessionData = async (request, previousSessionStatusData) => {
-  let clientId
-  // When redirecting from the landing page (which uses client side analytics) we need to establish the session identifier using the linker parameter
-  if (request.query._ga) {
-    clientId = /^.+-(?<clientId>.+)$/.exec(request.query._ga).groups.clientId
+const getClientIdFromGACookie = (query) => {
+  if (query._ga) {
+    return query._ga.split('.')[2]
   }
+}
+
+export const initialiseAnalyticsSessionData = async (request, previousSessionStatusData) => {
+  // When redirecting from the landing page (which uses client side analytics) we need to establish the session identifier using the linker parameter
+  const clientId = getClientIdFromGACookie(request.query)
   await request.cache().helpers.status.set({
     gaClientId: previousSessionStatusData?.gaClientId || clientId,
     attribution: getAttribution(previousSessionStatusData, request)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2023

How we obtain the client id for tracking seems to be based on a misapprehension. We need to obtain the client id for tracking
correctly, but also in a manner that fails gracefully in case:

1) I'm wrong about how _ga is formatted
2) The way that _ga is put together should ever change in the future