### PR TITLE
Pass through telesales user ids to sales api

### DIFF
--- a/packages/dynamics-lib/src/client/entity-manager.js
+++ b/packages/dynamics-lib/src/client/entity-manager.js
@@ -4,10 +4,12 @@ import { CacheableOperation } from './cache.js'
 /**
  * Persist the provided entities.  Uses a create or update request as appropriate based on the state of the entity.
  *
- * @param {...Object<BaseEntity>} entities the entities which shall be persisted
+ * @param {Object<BaseEntity[]>} entities the entities which shall be persisted
+ * @param {string} createdBy the oid of the active directory user that is creating the entities
  * @returns {Promise<string[]>} resolving to the ids of the persisted entities
  */
-export async function persist (...entities) {
+export async function persist(entities, createdBy) {
+
   try {
     dynamicsClient.startBatch()
     entities.forEach(entity => {
@@ -17,7 +19,9 @@ export async function persist (...entities) {
         dynamicsClient.updateRequest(entity.toPersistRequest())
       }
     })
-    return await dynamicsClient.executeBatch()
+    return await dynamicsClient.executeBatch({
+      impersonateAAD: createdBy
+    })
   } catch (e) {
     const error = e.length ? e[0] : e
     const requestDetails = entities.map(entity => ({ [entity.isNew() ? 'createRequest' : 'updateRequest']: entity.toPersistRequest() }))
@@ -48,7 +52,7 @@ const retrieveMultipleFetchOperation = async entityClasses => {
  * @param {typeof BaseEntity} entityClasses the entity classes to perform a retrieve operation on
  * @returns {CacheableOperation}
  */
-export function retrieveMultiple (...entityClasses) {
+export function retrieveMultiple(...entityClasses) {
   const entityClsKeys = entityClasses.map(e => e.definition.localCollection).join('_')
   return new CacheableOperation(
     `dynamics_${entityClsKeys}`,
@@ -69,7 +73,7 @@ export function retrieveMultiple (...entityClasses) {
  * @param {typeof BaseEntity} entityClasses the entity classes to perform a retrieve operation on
  * @returns {CacheableOperation}
  */
-export function retrieveMultipleAsMap (...entityClasses) {
+export function retrieveMultipleAsMap(...entityClasses) {
   const entityClsKeys = entityClasses.map(e => e.definition.localCollection).join('_')
   return new CacheableOperation(
     `dynamics_${entityClsKeys}`,
@@ -89,7 +93,7 @@ export function retrieveMultipleAsMap (...entityClasses) {
  *
  * @returns {CacheableOperation}
  */
-export function retrieveGlobalOptionSets () {
+export function retrieveGlobalOptionSets() {
   return new CacheableOperation(
     'dynamics_optionsetmap',
     async () => {
@@ -126,7 +130,7 @@ export function retrieveGlobalOptionSets () {
  * @param {string} key the ID of the record to retrieve
  * @returns {Promise<T>} the record matching the given id or null if not found
  */
-export async function findById (entityType, key) {
+export async function findById(entityType, key) {
   try {
     const record = await dynamicsClient.retrieveRequest({ key: key, ...entityType.definition.toRetrieveRequest(null) })
     const optionSetData = await retrieveGlobalOptionSets().cached()
@@ -149,7 +153,7 @@ export async function findById (entityType, key) {
  * @param {string} alternateKey the alternate key value to use to retrieve the corresponding entity
  * @returns {Promise<T>} the record matching the given id or null if not found
  */
-export async function findByAlternateKey (entityType, alternateKey) {
+export async function findByAlternateKey(entityType, alternateKey) {
   return findById(entityType, `${entityType.definition.alternateKey}='${escapeODataStringValue(alternateKey)}'`)
 }
 
@@ -161,7 +165,7 @@ export async function findByAlternateKey (entityType, alternateKey) {
  * @param {T} entity the example entity to construct a query from
  * @returns {Promise<Array<T>>} an array of matching records
  */
-export async function findByExample (entity) {
+export async function findByExample(entity) {
   try {
     const filter = [
       ...(entity.constructor.definition.defaultFilter ? [entity.constructor.definition.defaultFilter] : []),
@@ -193,7 +197,7 @@ export async function findByExample (entity) {
  *
  * @template {!BaseEntity} T
  */
-export async function executeQuery (query) {
+export async function executeQuery(query) {
   try {
     const response = await dynamicsClient.retrieveMultipleRequest(query.toRetrieveRequest())
     const optionSetData = await retrieveGlobalOptionSets().cached()
@@ -216,7 +220,7 @@ export async function executeQuery (query) {
  * @param {number} [maxPages} limit the number of pages that will be retrieved
  * @returns {Promise<number>} the count of records that were processed
  */
-export async function executePagedQuery (query, onPageReceived, maxPages) {
+export async function executePagedQuery(query, onPageReceived, maxPages) {
   let processed = 0
   try {
     const optionSetData = await retrieveGlobalOptionSets().cached()

--- a/packages/fulfilment-job/src/staging/__tests__/create-part-files.spec.js
+++ b/packages/fulfilment-job/src/staging/__tests__/create-part-files.spec.js
@@ -85,7 +85,7 @@ describe('createPartFiles', () => {
       ])
     )
     expect(persist).toHaveBeenCalledTimes(1)
-    expect(persist).toHaveBeenCalledWith(fulfilmentFileExpectations, fulfilmentRequestExpectations)
+    expect(persist).toHaveBeenCalledWith([fulfilmentFileExpectations, fulfilmentRequestExpectations])
   })
 
   it('calculates the next file in the sequence correctly', async () => {
@@ -126,7 +126,7 @@ describe('createPartFiles', () => {
       ])
     )
     expect(persist).toHaveBeenCalledTimes(1)
-    expect(persist).toHaveBeenCalledWith(fulfilmentFileExpectations, fulfilmentRequestExpectations)
+    expect(persist).toHaveBeenCalledWith([fulfilmentFileExpectations, fulfilmentRequestExpectations])
   })
 
   it('will write multiple part files as necessary', async () => {
@@ -188,35 +188,41 @@ describe('createPartFiles', () => {
     )
     expect(persist).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({
-        fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0001.json`,
-        date: expect.anything(),
-        notes: expect.stringMatching(/^The fulfilment file is currently being populated prior to exporting.$/),
-        numberOfRequests: 1,
-        status: expect.objectContaining({ id: 910400000, label: 'Pending', description: 'Pending' })
-      }),
-      fulfilmentRequestExpectations
+      [
+        expect.objectContaining({
+          fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0001.json`,
+          date: expect.anything(),
+          notes: expect.stringMatching(/^The fulfilment file is currently being populated prior to exporting.$/),
+          numberOfRequests: 1,
+          status: expect.objectContaining({ id: 910400000, label: 'Pending', description: 'Pending' })
+        }),
+        fulfilmentRequestExpectations
+      ]
     )
     expect(persist).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({
-        fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0001.json`,
-        date: expect.anything(),
-        notes: expect.stringMatching(/^The fulfilment file finished exporting at .+/),
-        numberOfRequests: 2,
-        status: expect.objectContaining({ id: 910400004, label: 'Exported', description: 'Exported' })
-      }),
-      fulfilmentRequestExpectations
+      [
+        expect.objectContaining({
+          fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0001.json`,
+          date: expect.anything(),
+          notes: expect.stringMatching(/^The fulfilment file finished exporting at .+/),
+          numberOfRequests: 2,
+          status: expect.objectContaining({ id: 910400004, label: 'Exported', description: 'Exported' })
+        }),
+        fulfilmentRequestExpectations
+      ]
     )
     expect(persist).toHaveBeenNthCalledWith(
       3,
-      expect.objectContaining({
-        fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0001.json`,
-        date: expect.anything(),
-        notes: expect.stringMatching(/^The fulfilment file finished exporting at .+/),
-        numberOfRequests: 2,
-        status: expect.objectContaining({ id: 910400004, label: 'Exported', description: 'Exported' })
-      })
+      [
+        expect.objectContaining({
+          fileName: `EAFF${EXECUTION_DATE.format('YYYYMMDD')}0001.json`,
+          date: expect.anything(),
+          notes: expect.stringMatching(/^The fulfilment file finished exporting at .+/),
+          numberOfRequests: 2,
+          status: expect.objectContaining({ id: 910400004, label: 'Exported', description: 'Exported' })
+        })
+      ]
     )
   })
 })

--- a/packages/fulfilment-job/src/staging/__tests__/deliver-fulfilment-files.spec.js
+++ b/packages/fulfilment-job/src/staging/__tests__/deliver-fulfilment-files.spec.js
@@ -86,34 +86,38 @@ describe('deliverFulfilmentFiles', () => {
     // Persist to dynamics for file 1
     expect(persist).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({
-        fileName: 'EAFF202006180001.json',
-        date: '2020-06-18T11:47:32.982Z',
-        deliveryTimestamp: expect.any(String),
-        notes: expect.stringMatching(/The fulfilment file was successfully delivered at .+/),
-        numberOfRequests: 2,
-        status: expect.objectContaining({
-          description: 'Delivered',
-          id: 910400001,
-          label: 'Delivered'
+      [
+        expect.objectContaining({
+          fileName: 'EAFF202006180001.json',
+          date: '2020-06-18T11:47:32.982Z',
+          deliveryTimestamp: expect.any(String),
+          notes: expect.stringMatching(/The fulfilment file was successfully delivered at .+/),
+          numberOfRequests: 2,
+          status: expect.objectContaining({
+            description: 'Delivered',
+            id: 910400001,
+            label: 'Delivered'
+          })
         })
-      })
+      ]
     )
     // Persist to dynamics for file 2
     expect(persist).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({
-        fileName: 'EAFF202006180002.json',
-        date: '2020-06-18T11:47:33.982Z',
-        deliveryTimestamp: expect.any(String),
-        notes: expect.stringMatching(/The fulfilment file was successfully delivered at .+/),
-        numberOfRequests: 2,
-        status: expect.objectContaining({
-          description: 'Delivered',
-          id: 910400001,
-          label: 'Delivered'
+      [
+        expect.objectContaining({
+          fileName: 'EAFF202006180002.json',
+          date: '2020-06-18T11:47:33.982Z',
+          deliveryTimestamp: expect.any(String),
+          notes: expect.stringMatching(/The fulfilment file was successfully delivered at .+/),
+          numberOfRequests: 2,
+          status: expect.objectContaining({
+            description: 'Delivered',
+            id: 910400001,
+            label: 'Delivered'
+          })
         })
-      })
+      ]
     )
   })
 })

--- a/packages/fulfilment-job/src/staging/create-part-files.js
+++ b/packages/fulfilment-job/src/staging/create-part-files.js
@@ -33,7 +33,7 @@ export const createPartFiles = async () => {
       fulfilmentFile.status = await getOptionSetEntry(FULFILMENT_FILE_STATUS_OPTIONSET, 'Exported')
       fulfilmentFile.notes = `The fulfilment file finished exporting at ${moment().toISOString()}`
     }
-    await persist(...toMarkAsExported)
+    await persist(toMarkAsExported)
   }
 }
 
@@ -70,7 +70,7 @@ const processQueryPage = async page => {
       return item.fulfilmentRequest
     })
     debug('Persisting updates to Dynamics')
-    await persist(fulfilmentFile, ...fulfilmentRequestUpdates)
+    await persist([fulfilmentFile, ...fulfilmentRequestUpdates])
   }
 }
 

--- a/packages/fulfilment-job/src/staging/deliver-fulfilment-files.js
+++ b/packages/fulfilment-job/src/staging/deliver-fulfilment-files.js
@@ -26,7 +26,7 @@ export const deliverFulfilmentFiles = async () => {
     file.deliveryTimestamp = moment().toISOString()
     file.status = await getOptionSetEntry(FULFILMENT_FILE_STATUS_OPTIONSET, 'Delivered')
     file.notes = `The fulfilment file was successfully delivered at ${file.deliveryTimestamp}`
-    await persist(file)
+    await persist([file])
   }
 }
 

--- a/packages/gafl-webapp-service/src/processors/api-transaction.js
+++ b/packages/gafl-webapp-service/src/processors/api-transaction.js
@@ -58,7 +58,8 @@ export const prepareApiTransactionPayload = async request => {
       }
 
       return permission
-    })
+    }),
+    createdBy: request.state && request.state.oidc ? request.state.oidc.oid : undefined
   }
 }
 

--- a/packages/sales-api-service/src/schema/transaction.schema.js
+++ b/packages/sales-api-service/src/schema/transaction.schema.js
@@ -26,7 +26,9 @@ const createTransactionRequestSchemaContent = {
     .items(stagedPermissionSchema)
     .required()
     .label('create-transaction-request-permissions'),
-  dataSource: buildJoiOptionSetValidator('defra_datasource', 'Web Sales')
+  dataSource: buildJoiOptionSetValidator('defra_datasource', 'Web Sales'),
+  createdBy: Joi.string().optional(),
+
 }
 
 /**
@@ -72,7 +74,7 @@ const createTransactionResponseSchemaContent = {
   status: Joi.object({
     id: Joi.string()
       .valid('STAGED')
-      .required()
+      .required(),
   })
     .label('create-transaction-status')
     .required()

--- a/packages/sales-api-service/src/server/routes/__tests__/transaction-files.spec.js
+++ b/packages/sales-api-service/src/server/routes/__tests__/transaction-files.spec.js
@@ -65,11 +65,13 @@ describe('transaction files handler', () => {
         fileSize: '5 KB'
       })
       expect(persist).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fileName: 'testnew.xml',
-          fileSize: '5 KB',
-          status: expect.objectContaining(await getGlobalOptionSetValue(PoclFile.definition.mappings.status.ref, 'Received and Pending'))
-        })
+        [
+          expect.objectContaining({
+            fileName: 'testnew.xml',
+            fileSize: '5 KB',
+            status: expect.objectContaining(await getGlobalOptionSetValue(PoclFile.definition.mappings.status.ref, 'Received and Pending'))
+          })
+        ]
       )
     })
 
@@ -84,7 +86,7 @@ describe('transaction files handler', () => {
         fileName: 'test.xml',
         fileSize: '5 KB'
       })
-      expect(persist).toHaveBeenCalledWith(testPoclFile)
+      expect(persist).toHaveBeenCalledWith([testPoclFile])
     })
 
     it('throws 422 errors if the payload was invalid', async () => {

--- a/packages/sales-api-service/src/server/routes/transaction-files.js
+++ b/packages/sales-api-service/src/server/routes/transaction-files.js
@@ -54,7 +54,7 @@ export default [
         payload.status = await getGlobalOptionSetValue(PoclFile.definition.mappings.status.ref, payload.status)
 
         const transactionFile = Object.assign(file, payload, { fileName: request.params.fileName })
-        await persist(transactionFile)
+        await persist([transactionFile])
         return h.response(transactionFile).code(200)
       },
       description: 'Create or update an transaction file header with the given identifier',

--- a/packages/sales-api-service/src/services/exceptions/__tests__/exceptions.service.spec.js
+++ b/packages/sales-api-service/src/services/exceptions/__tests__/exceptions.service.spec.js
@@ -7,7 +7,7 @@ jest.mock('@defra-fish/dynamics-lib', () => ({
 }))
 
 expect.extend({
-  jsonMatching (received, ...matchers) {
+  jsonMatching(received, ...matchers) {
     try {
       const obj = JSON.parse(received)
       for (const matcher of matchers) {
@@ -40,7 +40,7 @@ describe('payment-journals service', () => {
         exceptionJson: 'string'
       }
       const result = await createStagingException(stagingException)
-      expect(persist).toHaveBeenCalledWith(expect.objectContaining(stagingException))
+      expect(persist).toHaveBeenCalledWith([expect.objectContaining(stagingException)])
       expect(result).toBeInstanceOf(StagingException)
     })
   })
@@ -52,16 +52,18 @@ describe('payment-journals service', () => {
       const testTransaction = { some: 'data' }
       const result = await createStagingExceptionFromError('testStagingId', testError, testTransaction)
       expect(persist).toHaveBeenCalledWith(
-        expect.objectContaining({
-          stagingId: 'testStagingId',
-          description: expectedErrorMessage,
-          transactionJson: expect.jsonMatching(expect.objectContaining(testTransaction)),
-          exceptionJson: expect.jsonMatching(
-            expect.objectContaining({
-              stack: expect.arrayContaining([expectedErrorMessage, ...testError.stack.split('\n')])
-            })
-          )
-        })
+        [
+          expect.objectContaining({
+            stagingId: 'testStagingId',
+            description: expectedErrorMessage,
+            transactionJson: expect.jsonMatching(expect.objectContaining(testTransaction)),
+            exceptionJson: expect.jsonMatching(
+              expect.objectContaining({
+                stack: expect.arrayContaining([expectedErrorMessage, ...testError.stack.split('\n')])
+              })
+            )
+          })
+        ]
       )
       expect(result).toBeInstanceOf(StagingException)
     })
@@ -71,7 +73,7 @@ describe('payment-journals service', () => {
       const testError = Object.assign(new Error(), { error: { message: expectedErrorMessage } })
       const testTransaction = { some: 'data' }
       const result = await createStagingExceptionFromError('testStagingId', testError, testTransaction)
-      expect(persist).toHaveBeenCalledWith(
+      expect(persist).toHaveBeenCalledWith([
         expect.objectContaining({
           stagingId: 'testStagingId',
           description: expectedErrorMessage,
@@ -83,6 +85,7 @@ describe('payment-journals service', () => {
             })
           )
         })
+      ]
       )
       expect(result).toBeInstanceOf(StagingException)
     })
@@ -100,12 +103,13 @@ describe('payment-journals service', () => {
         permissionId: 'string'
       }
       const result = await createTransactionFileException(transactionFileException)
-      expect(persist).toHaveBeenCalledWith(
+      expect(persist).toHaveBeenCalledWith([
         expect.objectContaining({
           ...transactionFileException,
           type: expect.objectContaining({ id: 910400001, label: 'Failure', description: 'Failure' }),
           status: expect.objectContaining({ id: 910400000, label: 'Open', description: 'Open' })
         })
+      ]
       )
       expect(result).toBeInstanceOf(PoclStagingException)
     })

--- a/packages/sales-api-service/src/services/exceptions/exceptions.service.js
+++ b/packages/sales-api-service/src/services/exceptions/exceptions.service.js
@@ -18,7 +18,7 @@ const debug = db('sales:exceptions')
 export const createStagingException = async exceptionData => {
   debug('Adding staging exception: %o', exceptionData)
   const exception = Object.assign(new StagingException(), exceptionData)
-  await persist(exception)
+  await persist([exception])
   return exception
 }
 
@@ -59,6 +59,6 @@ export const createTransactionFileException = async transactionFileError => {
     status: await getGlobalOptionSetValue(PoclStagingException.definition.mappings.status.ref, 'Open')
   })
   stagingException.bindToAlternateKey(PoclStagingException.definition.relationships.poclFile, transactionFileError.transactionFile)
-  await persist(stagingException)
+  await persist([stagingException])
   return stagingException
 }

--- a/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
@@ -144,7 +144,7 @@ describe('transaction service', () => {
         AwsMock.DynamoDB.DocumentClient.__setResponse('get', { Item: mockRecord })
         const result = await processQueue({ id: mockRecord.id })
         expect(result).toBeUndefined()
-        expect(persist).toBeCalledWith(...entityExpectations)
+        expect(persist).toBeCalledWith(entityExpectations, undefined)
         expect(AwsMock.DynamoDB.DocumentClient.mockedMethods.get).toBeCalledWith(
           expect.objectContaining({
             TableName: TRANSACTION_STAGING_TABLE.TableName,

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -29,7 +29,7 @@ const debug = db('sales:transactions')
  * @param id
  * @returns {Promise<void>}
  */
-export async function processQueue ({ id }) {
+export async function processQueue({ id }) {
   debug('Processing message from queue for staging id %s', id)
   const entities = []
   const transactionRecord = await retrieveStagedTransaction(id)
@@ -83,7 +83,7 @@ export async function processQueue ({ id }) {
   paymentJournal.total = totalTransactionValue
 
   debug('Persisting %d entities for staging id %s', entities.length, id)
-  await persist(...entities)
+  await persist(entities, transactionRecord.createdBy)
   debug('Moving staging data to history table for staging id %s', id)
   await docClient.delete({ TableName: TRANSACTION_STAGING_TABLE.TableName, Key: { id } }).promise()
   await docClient


### PR DESCRIPTION
When a telesales user creates a new licence, their oid (dynamics user ID) will be passed through to the sales API in the 'createdBy' field, which will allow our dynamics code to impersonate that user when creating the licence and associated objects. The oid will be stored with the transaction on the SQS queue and then in dynamodb, before being used to impersonate the user when calling dynamics. Any records without a createdBy field will call dynamics in the normal way.

This change allows us to have an audit trail for telesales transactions.