### PR TITLE
Reinstate home countries in address entry

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/refdata-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/refdata-helper.spec.js
@@ -28,22 +28,14 @@ describe('Countries list', () => {
       expect.objectContaining({ code: 'GB-ENG', name: 'England' }),
       expect.objectContaining({ code: 'GB-WLS', name: 'Wales' }),
       expect.objectContaining({ code: 'GB-SCT', name: 'Scotland' }),
-      expect.objectContaining({ code: 'GB-NIR', name: 'Northern Ireland' })
+      expect.objectContaining({ code: 'GB-NIR', name: 'Northern Ireland' }),
+      expect.objectContaining({ code: 'GB', name: 'United Kingdom' })
     ]
     expect(c).toEqual(expect.arrayContaining(homeNations))
   })
 
-  it('Excludes UK', async () => {
-    const c = await countries.getAll()
-    expect(c).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ code: 'GB' })
-      ])
-    )
-  })
-
   it('Lists countries in correct order', async () => {
-    const [first, second, third, fourth] = await countries.getAll()
+    const [first, second, third, fourth, fifth] = await countries.getAll()
     expect(first).toEqual(
       expect.objectContaining({ code: 'GB-ENG', name: 'England' })
     )
@@ -55,6 +47,9 @@ describe('Countries list', () => {
     )
     expect(fourth).toEqual(
       expect.objectContaining({ code: 'GB-NIR', name: 'Northern Ireland' })
+    )
+    expect(fifth).toEqual(
+      expect.objectContaining({ code: 'GB', name: 'United Kingdom' })
     )
   })
 })

--- a/packages/gafl-webapp-service/src/processors/__tests__/refdata-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/refdata-helper.spec.js
@@ -1,0 +1,60 @@
+import { salesApi } from '@defra-fish/connectors-lib'
+import { countries } from '../refdata-helper.js'
+
+jest.mock('@defra-fish/connectors-lib', () => ({
+  salesApi: {
+    countries: {
+      getAll: async () => ({
+        options: {
+          DE: { description: 'DE', label: 'Germany' },
+          NRI: { description: 'GB-NIR', label: 'Northern Ireland' },
+          FR: { description: 'FR', label: 'France' },
+          SCO: { description: 'GB-SCT', label: 'Scotland' },
+          WAL: { description: 'GB-WLS', label: 'Wales' },
+          GB: { description: 'GB', label: 'United Kingdom' },
+          ENG: { description: 'GB-ENG', label: 'England' },
+          IT: { description: 'IT', label: 'Italy' },
+          ES: { description: 'ES', label: 'Spain' }
+        }
+      })
+    }
+  }
+}))
+
+describe('Countries list', () => {
+  it('includes home nations', async () => {
+    const c = await countries.getAll()
+    const homeNations = [
+      expect.objectContaining({ code: 'GB-ENG', name: 'England' }),
+      expect.objectContaining({ code: 'GB-WLS', name: 'Wales' }),
+      expect.objectContaining({ code: 'GB-SCT', name: 'Scotland' }),
+      expect.objectContaining({ code: 'GB-NIR', name: 'Northern Ireland' })
+    ]
+    expect(c).toEqual(expect.arrayContaining(homeNations))
+  })
+
+  it('Excludes UK', async () => {
+    const c = await countries.getAll()
+    expect(c).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'GB' })
+      ])
+    )
+  })
+
+  it('Lists countries in correct order', async () => {
+    const [first, second, third, fourth] = await countries.getAll()
+    expect(first).toEqual(
+      expect.objectContaining({ code: 'GB-ENG', name: 'England' })
+    )
+    expect(second).toEqual(
+      expect.objectContaining({ code: 'GB-WLS', name: 'Wales' })
+    )
+    expect(third).toEqual(
+      expect.objectContaining({ code: 'GB-SCT', name: 'Scotland' })
+    )
+    expect(fourth).toEqual(
+      expect.objectContaining({ code: 'GB-NIR', name: 'Northern Ireland' })
+    )
+  })
+})

--- a/packages/gafl-webapp-service/src/processors/refdata-helper.js
+++ b/packages/gafl-webapp-service/src/processors/refdata-helper.js
@@ -10,7 +10,17 @@ const local = {}
 
 const fetch = async () =>
   optionProc(await salesApi.countries.getAll())
-    .sort(a => (a.code.startsWith('GB') ? -1 : 0))
+    .filter(c => c.code !== 'GB')
+    .sort((a, b) => {
+      const order = ['GB-ENG', 'GB-WLS', 'GB-SCT', 'GB-NIR']
+      if (a.code.startsWith('GB')) {
+        if (b.code.startsWith('GB')) {
+          return order.indexOf(a.code) - order.indexOf(b.code)
+        }
+        return -1
+      }
+      return 0
+    })
 
 // Process the country code option set into a useful form - once
 export const countries = {

--- a/packages/gafl-webapp-service/src/processors/refdata-helper.js
+++ b/packages/gafl-webapp-service/src/processors/refdata-helper.js
@@ -28,7 +28,6 @@ export const countries = {
     return local.countries
   },
   nameFromCode: async code => {
-    console.log('nameFromCode', code)
     local.countries = local.countries || (await fetch())
     return local.countries.find(c => c.code === code).name
   }

--- a/packages/gafl-webapp-service/src/processors/refdata-helper.js
+++ b/packages/gafl-webapp-service/src/processors/refdata-helper.js
@@ -10,8 +10,7 @@ const local = {}
 
 const fetch = async () =>
   optionProc(await salesApi.countries.getAll())
-    .filter(c => !['GB-ENG', 'GB-WLS', 'GB-SCT', 'GB-NIR'].includes(c.code))
-    .sort(a => (a.code === 'GB' ? -1 : 0))
+    .sort(a => (a.code.startsWith('GB') ? -1 : 0))
 
 // Process the country code option set into a useful form - once
 export const countries = {

--- a/packages/gafl-webapp-service/src/processors/refdata-helper.js
+++ b/packages/gafl-webapp-service/src/processors/refdata-helper.js
@@ -10,9 +10,8 @@ const local = {}
 
 const fetch = async () =>
   optionProc(await salesApi.countries.getAll())
-    .filter(c => c.code !== 'GB')
     .sort((a, b) => {
-      const order = ['GB-ENG', 'GB-WLS', 'GB-SCT', 'GB-NIR']
+      const order = ['GB-ENG', 'GB-WLS', 'GB-SCT', 'GB-NIR', 'GB']
       if (a.code.startsWith('GB')) {
         if (b.code.startsWith('GB')) {
           return order.indexOf(a.code) - order.indexOf(b.code)
@@ -29,6 +28,7 @@ export const countries = {
     return local.countries
   },
   nameFromCode: async code => {
+    console.log('nameFromCode', code)
     local.countries = local.countries || (await fetch())
     return local.countries.find(c => c.code === code).name
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2074

Paragon only send bilingual licences to licensees with the country field set to 'Wales'. This is set automatically when the postcode lookup is used, however many Welsh postcodes result in an error from the lookup service (see IWTF-2072). Therefore, customers living in Wales need to be able to select 'Wales' in the manual address entry and are forced to
choose 'United Kingdom', meaning they can never receive a bilingual licence