### PR TITLE
Fix version script when commit message contains single quotes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,6 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
       - name: Run versioning script
-        run: COMMIT_MESSAGE='${{github.event.head_commit.message}}' BRANCH='${{ steps.extract_branch.outputs.branch }}' . ./scripts/github/deploy.sh
+        run: COMMIT_MESSAGE=($'${{github.event.head_commit.message}}') BRANCH='${{ steps.extract_branch.outputs.branch }}' . ./scripts/github/deploy.sh
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The versioning script that runs on a commit to develop doesn't seem to handle single quote characters in the commit message