### PR TITLE
Fix: Use serial number as Payment id for POCL transactions

### DIFF
--- a/packages/pocl-job/src/staging/create-transactions.js
+++ b/packages/pocl-job/src/staging/create-transactions.js
@@ -72,7 +72,7 @@ const createTransactionsInSalesApi = async (filename, state) => {
   if (state.buffer.length) {
     debug({buffer: state.buffer[0].createTransactionPayload})
     const createResults = await salesApi.createTransactions(state.buffer.map(item => item.createTransactionPayload))
-    debug({createResults: createResults.response})
+    debug({createResults: createResults[0].response})
     const succeeded = []
     const failed = []
     state.buffer.forEach((record, idx) => {

--- a/packages/pocl-job/src/staging/create-transactions.js
+++ b/packages/pocl-job/src/staging/create-transactions.js
@@ -70,9 +70,9 @@ const getInitialState = async filename => {
  */
 const createTransactionsInSalesApi = async (filename, state) => {
   if (state.buffer.length) {
-    debug({buffer:state.buffer})
+    debug({buffer: state.buffer[0].createTransactionPayload})
     const createResults = await salesApi.createTransactions(state.buffer.map(item => item.createTransactionPayload))
-    debug({createResults})
+    debug({createResults: createResults.response})
     const succeeded = []
     const failed = []
     state.buffer.forEach((record, idx) => {

--- a/packages/pocl-job/src/staging/create-transactions.js
+++ b/packages/pocl-job/src/staging/create-transactions.js
@@ -70,8 +70,9 @@ const getInitialState = async filename => {
  */
 const createTransactionsInSalesApi = async (filename, state) => {
   if (state.buffer.length) {
+    debug({buffer:state.buffer})
     const createResults = await salesApi.createTransactions(state.buffer.map(item => item.createTransactionPayload))
-
+    debug({createResults})
     const succeeded = []
     const failed = []
     state.buffer.forEach((record, idx) => {

--- a/packages/pocl-job/src/transform/bindings/pocl/transaction/__tests__/__snapshots__/transaction.bindings.spec.js.snap
+++ b/packages/pocl-job/src/transform/bindings/pocl/transaction/__tests__/__snapshots__/transaction.bindings.spec.js.snap
@@ -26,6 +26,7 @@ Object {
         "startDate": "2020-01-01T00:01:00.000Z",
       },
     ],
+    "serialNumber": "559136-2-27950",
   },
   "finaliseTransactionPayload": Object {
     "payment": Object {
@@ -75,6 +76,7 @@ Object {
         "startDate": "2020-05-31T23:01:00.000Z",
       },
     ],
+    "serialNumber": "559136-2-27950",
   },
   "finaliseTransactionPayload": Object {
     "payment": Object {
@@ -123,6 +125,7 @@ Object {
         "startDate": "2020-01-01T00:01:00.000Z",
       },
     ],
+    "serialNumber": "559136-2-27950",
   },
   "finaliseTransactionPayload": Object {
     "payment": Object {
@@ -171,6 +174,7 @@ Object {
         "startDate": "2020-01-01T00:01:00.000Z",
       },
     ],
+    "serialNumber": "559136-2-27950",
   },
   "finaliseTransactionPayload": Object {
     "payment": Object {
@@ -221,6 +225,7 @@ Object {
         "startDate": "2020-01-01T00:01:00.000Z",
       },
     ],
+    "serialNumber": "559136-2-27950",
   },
   "finaliseTransactionPayload": Object {
     "payment": Object {
@@ -261,6 +266,7 @@ Object {
         "startDate": "2020-01-01T00:01:00.000Z",
       },
     ],
+    "serialNumber": "559136-2-27950",
   },
   "finaliseTransactionPayload": Object {
     "payment": Object {

--- a/packages/pocl-job/src/transform/bindings/pocl/transaction/transaction.bindings.js
+++ b/packages/pocl-job/src/transform/bindings/pocl/transaction/transaction.bindings.js
@@ -102,11 +102,13 @@ export const Transaction = new Binding({
     )
     const dataSource = getDataSource(children)
     const paymentSource = dataSource === DIRECT_DEBIT_DATASOURCE ? DIRECT_DEBIT_PAYMENTSOURCE : POST_OFFICE_DATASOURCE
-
+    const serialNumber = children[SerialNumber.element]
+    
     return {
-      id: children[SerialNumber.element],
+      id: serialNumber,
       createTransactionPayload: {
         dataSource,
+        serialNumber,
         permissions: [
           {
             licensee: {

--- a/packages/sales-api-service/src/__mocks__/test-data.js
+++ b/packages/sales-api-service/src/__mocks__/test-data.js
@@ -68,6 +68,7 @@ export const mockPermissionPayload = () => ({
 
 export const mockTransactionPayload = () => ({
   permissions: [mockPermissionPayload()],
+  serialNumber: '559136-2-27950',
   dataSource: 'Web Sales'
 })
 
@@ -88,6 +89,7 @@ export const mockStagedTransactionRecord = () => ({
 
 export const mockFinalisedTransactionRecord = () => ({
   id: 'b364c12f-ce62-4c62-b4bd-4a06fd57e256',
+  serialNumber: '559136-2-27950',
   expires: 1586512428,
   permissions: [mockFinalisedPermissionRecord()],
   cost: 30,

--- a/packages/sales-api-service/src/schema/transaction.schema.js
+++ b/packages/sales-api-service/src/schema/transaction.schema.js
@@ -27,6 +27,9 @@ const createTransactionRequestSchemaContent = {
     .required()
     .label('create-transaction-request-permissions'),
   dataSource: buildJoiOptionSetValidator('defra_datasource', 'Web Sales'),
+  serialNumber: Joi.string()
+    .trim()
+    .required(),
   createdBy: Joi.string().optional()
 }
 

--- a/packages/sales-api-service/src/schema/transaction.schema.js
+++ b/packages/sales-api-service/src/schema/transaction.schema.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { PoclFile } from '@defra-fish/dynamics-lib'
 import { finalisePermissionResponseSchema, stagedPermissionSchema } from './permission.schema.js'
 import { contactRequestSchema } from './contact.schema.js'
-import { createAlternateKeyValidator, buildJoiOptionSetValidator, createPermitConcessionValidator } from './validators/validators.js'
+import { createAlternateKeyValidator, buildJoiOptionSetValidator, createPermitConcessionValidator, serialNumberValidator } from './validators/validators.js'
 import { MAX_PERMISSIONS_PER_TRANSACTION } from '@defra-fish/business-rules-lib'
 
 import { v4 as uuidv4 } from 'uuid'
@@ -27,9 +27,7 @@ const createTransactionRequestSchemaContent = {
     .required()
     .label('create-transaction-request-permissions'),
   dataSource: buildJoiOptionSetValidator('defra_datasource', 'Web Sales'),
-  serialNumber: Joi.string()
-    .trim()
-    .required(),
+  serialNumber: serialNumberValidator,
   createdBy: Joi.string().optional()
 }
 

--- a/packages/sales-api-service/src/schema/transaction.schema.js
+++ b/packages/sales-api-service/src/schema/transaction.schema.js
@@ -27,7 +27,13 @@ const createTransactionRequestSchemaContent = {
     .required()
     .label('create-transaction-request-permissions'),
   dataSource: buildJoiOptionSetValidator('defra_datasource', 'Web Sales'),
-  serialNumber: serialNumberValidator,
+  serialNumber: Joi.when('dataSource', {
+    is: Joi.valid('Post Office Sales', 'DDE File'),
+    then: Joi.string()
+      .trim()
+      .pattern(/^\w{6}-\w-\w{7}$/)
+      .required()
+  }),
   createdBy: Joi.string().optional()
 }
 

--- a/packages/sales-api-service/src/schema/validators/validators.js
+++ b/packages/sales-api-service/src/schema/validators/validators.js
@@ -163,3 +163,12 @@ const validateConcessionList = (permission, concessionsRequiredForPermit) => {
     }
   })
 }
+
+export function serialNumberValidator () {
+  return Joi.when('dataSource', {
+  is: Joi.valid('Post Office Sales', 'DDE File'),
+  then: Joi.string()
+    .trim()
+    .pattern(/^\w{6}-\w-\w{7}$/)
+    .required()
+})}

--- a/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
@@ -1,4 +1,4 @@
-import { processQueue } from '../process-transaction-queue.js'
+import { processQueue, getTransactionJournalRefNumber } from '../process-transaction-queue.js'
 import {
   persist,
   findById,
@@ -196,6 +196,36 @@ describe('transaction service', () => {
         expect(e.message).toEqual('A transaction for the specified identifier was not found')
         expect(e.output.statusCode).toEqual(404)
       }
+    })
+  })
+
+  describe('.getTransactionJournalRefNumber', () => {
+    let mockRecord
+    beforeAll(() => {
+      mockRecord = mockFinalisedTransactionRecord()
+    }) 
+    describe('when the transaction type is "Payment"', () => {
+      it('and the serial number is present, returns serial number', () => {
+        const refNumber = getTransactionJournalRefNumber(mockRecord, 'Payment')
+        expect(refNumber).toBe(mockRecord.serialNumber)
+      })
+
+      it('and the serial number is not present, returns id', () => {
+        const refNumber = getTransactionJournalRefNumber({ ...mockRecord, serialNumber: null }, 'Payment')
+        expect(refNumber).toBe(mockRecord.id)
+      })
+    })
+
+    describe('when the transaction type is "Charge"', () => {
+      it('and the serial number is present, returns id', () => {
+        const refNumber = getTransactionJournalRefNumber(mockRecord, 'Charge')
+        expect(refNumber).toBe(mockRecord.id)
+      })
+
+      it('and the serial number is not present, returns id', () => {
+        const refNumber = getTransactionJournalRefNumber({ ...mockRecord, serialNumber: null }, 'Charge')
+        expect(refNumber).toBe(mockRecord.id)
+      })
     })
   })
 })

--- a/packages/sales-api-service/src/services/transactions/finalise-transaction.js
+++ b/packages/sales-api-service/src/services/transactions/finalise-transaction.js
@@ -13,7 +13,7 @@ const debug = db('sales:transactions')
 export async function finaliseTransaction ({ id, ...payload }) {
   debug('Finalising transaction %s', id)
   const transactionRecord = await retrieveStagedTransaction(id)
-
+  debug({payload})
   if (transactionRecord.status?.id === TRANSACTION_STATUS.FINALISED) {
     throw Boom.resourceGone('The transaction has already been finalised', transactionRecord)
   }

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -144,6 +144,13 @@ const createTransactionEntities = async transactionRecord => {
   return { transaction, chargeJournal, paymentJournal }
 }
 
+const getTransactionJournalRefNumber = (transactionRecord, type) => {
+  if (type === 'Payment' && !!transactionRecord.serialNumber) {
+    return transactionRecord.serialNumber
+  }
+  return transactionRecord.id
+}
+
 /**
  * Create a TransactionJournal entity for the given parameters
  *
@@ -155,8 +162,7 @@ const createTransactionEntities = async transactionRecord => {
  */
 const createTransactionJournal = async (transactionRecord, transactionEntity, type, currency) => {
   const journal = new TransactionJournal()
-  debug({transactionRecord})
-  journal.referenceNumber = type === 'Payment' ? transactionRecord.serialNumber : transactionRecord.id
+  journal.referenceNumber = getTransactionJournalRefNumber(transactionRecord, type)
   journal.description = `${type} for ${transactionRecord.permissions.length} permission(s) recorded on ${transactionRecord.payment.timestamp}`
   journal.timestamp = transactionRecord.payment.timestamp
   journal.type = await getGlobalOptionSetValue(TransactionJournal.definition.mappings.type.ref, type)

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -146,8 +146,8 @@ const createTransactionEntities = async transactionRecord => {
 
 export const getTransactionJournalRefNumber = (transactionRecord, type) => {
   debug({transactionRecord})
-  if (type === 'Payment' && !!transactionRecord.serialNumber) {
-    return transactionRecord.serialNumber
+  if (type === 'Payment') {
+    return transactionRecord.serialNumber || transactionRecord.id
   }
   return transactionRecord.id
 }

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -155,7 +155,8 @@ const createTransactionEntities = async transactionRecord => {
  */
 const createTransactionJournal = async (transactionRecord, transactionEntity, type, currency) => {
   const journal = new TransactionJournal()
-  journal.referenceNumber = transactionRecord.id
+  debug({transactionRecord})
+  journal.referenceNumber = type === 'Payment' ? transactionRecord.serialNumber : transactionRecord.id
   journal.description = `${type} for ${transactionRecord.permissions.length} permission(s) recorded on ${transactionRecord.payment.timestamp}`
   journal.timestamp = transactionRecord.payment.timestamp
   journal.type = await getGlobalOptionSetValue(TransactionJournal.definition.mappings.type.ref, type)

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -144,7 +144,8 @@ const createTransactionEntities = async transactionRecord => {
   return { transaction, chargeJournal, paymentJournal }
 }
 
-const getTransactionJournalRefNumber = (transactionRecord, type) => {
+export const getTransactionJournalRefNumber = (transactionRecord, type) => {
+  debug({transactionRecord})
   if (type === 'Payment' && !!transactionRecord.serialNumber) {
     return transactionRecord.serialNumber
   }


### PR DESCRIPTION
IWTF-2137

* Adds serial number to transaction payload in POCL transform stream
* Updates creation of Transaction Journal to use serial number for reference id when type is 'payment'
* Adds serialNumber to createTransaction schema