### PR TITLE
Fix: Links open in new tab announced

### DIFF
--- a/packages/gafl-webapp-service/src/pages/guidance/privacy-policy.njk
+++ b/packages/gafl-webapp-service/src/pages/guidance/privacy-policy.njk
@@ -16,7 +16,7 @@
         <h1 class="govuk-heading-l">Get a rod fishing licence privacy policy</h1>
 
         <p class="govuk-body">We are the Environment Agency and we run the Get A Fishing Licence service. We are the data controller for this service. A data controller determines how and why personal data (personal information) is processed.</p>
-        <p class="govuk-body">Our <a class="govuk-link" target="_blank" href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter/">personal information charter</a> explains your rights and how we deal with your personal information. You can access the charter using the link or go to GOV.UK and search 'Environment Agency personal information charter’.</p>
+        <p class="govuk-body">Our <a class="govuk-link" href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter/">personal information charter</a> explains your rights and how we deal with your personal information. You can access the charter using the link or go to GOV.UK and search 'Environment Agency personal information charter’.</p>
 
         <h1 class="govuk-heading-m">The data we need</h1>
         <p class="govuk-body">The personal data we collect about you includes:</p>
@@ -57,8 +57,8 @@
 
         <p class="govuk-body">Email: <a class="govuk-link" href="mailto:dataprotection@environment-agency.gov.uk">dataprotection@environment-agency.gov.uk</a></p>
 
-        <p class="govuk-body">The Information Commissioner's Office (ICO) is the supervisory authority for data protection legislation. The <a class="govuk-link" target="_blank" href="https://ico.org.uk/your-data-matters">ICO website</a> has a full list of your rights under data protection legislation.</p>
-        <p class="govuk-body">You have the right to <a class="govuk-link" target="_blank" href="https://ico.org.uk/make-a-complaint">lodge a complaint</a> with the ICO at any time.</p>
+        <p class="govuk-body">The Information Commissioner's Office (ICO) is the supervisory authority for data protection legislation. The <a class="govuk-link" href="https://ico.org.uk/your-data-matters">ICO website</a> has a full list of your rights under data protection legislation.</p>
+        <p class="govuk-body">You have the right to <a class="govuk-link" href="https://ico.org.uk/make-a-complaint">lodge a complaint</a> with the ICO at any time.</p>
 
         <p class="govuk-body-s">This notice was last updated on the 8th October 2020.</p>
     </div>

--- a/packages/gafl-webapp-service/src/pages/layout/layout.njk
+++ b/packages/gafl-webapp-service/src/pages/layout/layout.njk
@@ -88,7 +88,7 @@
     <div class="no-print">
         <p class="govuk-!-margin-top-5 govuk-!-margin-bottom-0">Environment Agency Helpline: <a class="govuk-link" href="tel:+443448005386">0344 800 5386</a></p>
         <p class="govuk-!-margin-top-0">Monday to Friday, 8am to 6pm</p>
-        <p class="govuk-!-margin-top-0"><a class="govuk-link" href="https://www.gov.uk/call-charges" target="_blank">Find out about call charges</a></p>
+        <p class="govuk-!-margin-top-0"><a class="govuk-link" href="https://www.gov.uk/call-charges">Find out about call charges</a></p>
         <ul class="govuk-footer__inline-list">
             <li class="govuk-footer__inline-list-item">
                 <a class="govuk-link" href="{{ _uri.refunds }}">

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-type/licence-type.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-type/licence-type.njk
@@ -14,11 +14,23 @@
 %}
 
 {% set troutAndCoarse2Rod %}
-    <p class="govuk-body-m">The 2 rods coarse licence is the simplest rod licence. This will cover you for all the forms of fishing with a rod and let you fish non-migratory trout and coarse fish. It will allow you to fish with 1 or 2 rods at the same time (subject to the <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules</a> and <a target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws</a>).</p>
+    <p class="govuk-body-m">
+        The 2 rods coarse licence is the simplest rod licence. 
+        This will cover you for all the forms of fishing with a rod and let you fish non-migratory trout and coarse fish. 
+        It will allow you to fish with 1 or 2 rods at the same time 
+        (subject to the <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
+        and <a class="govuk-link" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>).
+    </p>
 {% endset -%}
 
 {% set troutAndCoarse3Rod %}
-    <p class="govuk-body-m">You will only need a 3 rod licence if you plan to fish with 3 rods at the same time. This may be for specialist carp fishing for example. This will cover you for all the forms of fishing with a rod and let you fish non-migratory trout and coarse fish (subject to the <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules</a> and <a class="govuk-link" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws</a>).</p>
+    <p class="govuk-body-m">
+        You will only need a 3 rod licence if you plan to fish with 3 rods at the same time. 
+        This may be for specialist carp fishing for example. 
+        This will cover you for all the forms of fishing with a rod and let you fish non-migratory trout and coarse fish 
+        (subject to the <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
+        and <a class="govuk-link" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>).
+    </p>
 {% endset -%}
 
 {% set salmonAndSeaTrout %}
@@ -28,7 +40,9 @@
       iconFallbackText: "Warning",
       classes: "govuk-!-margin-top-6"
     }) }}
-    <p class="govuk-body-m">You must by law <a class="govuk-link" target="_blank" href="https://www.gov.uk/catch-return">report a catch return</a> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</p>
+    <p class="govuk-body-m">
+        You must by law <a class="govuk-link" target="_blank" href="https://www.gov.uk/catch-return">report a catch return (opens in a new tab)</a> 
+        of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</p>
 {% endset -%}
 
 {% set items = [

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-type/licence-type.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-type/licence-type.njk
@@ -17,9 +17,9 @@
     <p class="govuk-body-m">
         The 2 rods coarse licence is the simplest rod licence. 
         This will cover you for all the forms of fishing with a rod and let you fish non-migratory trout and coarse fish. 
-        It will allow you to fish with 1 or 2 rods at the same time 
-        (subject to the <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
-        and <a class="govuk-link" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>).
+        It will allow you to fish with 1 or 2 rods at the same time, subject to the 
+        <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
+        and <a class="govuk-link" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>.
     </p>
 {% endset -%}
 
@@ -27,9 +27,9 @@
     <p class="govuk-body-m">
         You will only need a 3 rod licence if you plan to fish with 3 rods at the same time. 
         This may be for specialist carp fishing for example. 
-        This will cover you for all the forms of fishing with a rod and let you fish non-migratory trout and coarse fish 
-        (subject to the <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
-        and <a class="govuk-link" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>).
+        This will cover you for all the forms of fishing with a rod and let you fish non-migratory trout and coarse fish, subject to the 
+        <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
+        and <a class="govuk-link" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>.
     </p>
 {% endset -%}
 

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-type/licence-type.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-type/licence-type.njk
@@ -18,8 +18,8 @@
         The 2 rods coarse licence is the simplest rod licence. 
         This will cover you for all the forms of fishing with a rod and let you fish non-migratory trout and coarse fish. 
         It will allow you to fish with 1 or 2 rods at the same time, subject to the 
-        <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
-        and <a class="govuk-link" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>.
+        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
+        and <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>.
     </p>
 {% endset -%}
 
@@ -28,8 +28,8 @@
         You will only need a 3 rod licence if you plan to fish with 3 rods at the same time. 
         This may be for specialist carp fishing for example. 
         This will cover you for all the forms of fishing with a rod and let you fish non-migratory trout and coarse fish, subject to the 
-        <a class="govuk-link" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
-        and <a class="govuk-link" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>.
+        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">rod fishing rules (opens in a new tab)</a> 
+        and <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{{ data.uri.localByelaws }}">local fishing byelaws (opens in a new tab)</a>.
     </p>
 {% endset -%}
 
@@ -41,7 +41,7 @@
       classes: "govuk-!-margin-top-6"
     }) }}
     <p class="govuk-body-m">
-        You must by law <a class="govuk-link" target="_blank" href="https://www.gov.uk/catch-return">report a catch return (opens in a new tab)</a> 
+        You must by law <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/catch-return">report a catch return (opens in a new tab)</a> 
         of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</p>
 {% endset -%}
 

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete.njk
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete.njk
@@ -72,18 +72,18 @@
               classes: "govuk-!-margin-top-6"
             }) }}
             <p class="govuk-body" class="no-print">Get a <a class="govuk-link" href="{{ data.uri.pdf }}">PDF copy of your licence details</a>. If you gave us your email address, you’ll get a confirmation message that includes your licence number.</p>
-            <p class="govuk-body">You must follow the <a class="govuk-link" target="_blank" href="https://www.gov.uk/freshwater-rod-fishing-rules">rod fishing rules</a> and <a target="_blank" href="https://www.gov.uk/government/collections/local-fishing-byelaws">local fishing byelaws</a>.</p>
+            <p class="govuk-body">You must follow the <a class="govuk-link" target="_blank" href="https://www.gov.uk/freshwater-rod-fishing-rules">rod fishing rules (opens in a new tab)</a> and <a target="_blank" href="https://www.gov.uk/government/collections/local-fishing-byelaws">local fishing byelaws (opens in a new tab)</a>.</p>
          </div>
 
         {% if data.permission.licenceType === data.licenceTypes['salmon-and-sea-trout'] %}
             <div class="govuk-!-margin-top-8">
                 <h2 class="govuk-heading-m">Report your yearly catch return</h2>
-                <p class="govuk-body no-print">You must by law <span class="no-print"><a class="govuk-link" target="_blank" href="https://www.gov.uk/catch-return">report a catch return</a> (opens in a new window or tab) </span><span class="print-area">report a catch return</span> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</p>
+                <p class="govuk-body no-print">You must by law <span class="no-print"><a class="govuk-link" target="_blank" href="https://www.gov.uk/catch-return">report a catch return (opens in a new tab)</a> </span><span class="print-area">report a catch return</span> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</p>
                 <p class="govuk-body print-area">You must by law report a catch return of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</p>
             </div>
         {% endif %}
 
-        <p class="govuk-body"><a class="govuk-link" target="_blank" href="{{ data.uri.feedback }}">What did you think of the service</a> (takes 30 seconds)</p>
+        <p class="govuk-body"><a class="govuk-link" target="_blank" href="{{ data.uri.feedback }}">What did you think of the service (opens in a new tab)</a> (takes 30 seconds)</p>
 
         {{ govukButton({
             href: data.uri.new,

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete.njk
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete.njk
@@ -72,18 +72,18 @@
               classes: "govuk-!-margin-top-6"
             }) }}
             <p class="govuk-body" class="no-print">Get a <a class="govuk-link" href="{{ data.uri.pdf }}">PDF copy of your licence details</a>. If you gave us your email address, you’ll get a confirmation message that includes your licence number.</p>
-            <p class="govuk-body">You must follow the <a class="govuk-link" target="_blank" href="https://www.gov.uk/freshwater-rod-fishing-rules">rod fishing rules (opens in a new tab)</a> and <a target="_blank" href="https://www.gov.uk/government/collections/local-fishing-byelaws">local fishing byelaws (opens in a new tab)</a>.</p>
+            <p class="govuk-body">You must follow the <a class="govuk-link" href="https://www.gov.uk/freshwater-rod-fishing-rules">rod fishing rules</a> and <a href="https://www.gov.uk/government/collections/local-fishing-byelaws">local fishing byelaws</a>.</p>
          </div>
 
         {% if data.permission.licenceType === data.licenceTypes['salmon-and-sea-trout'] %}
             <div class="govuk-!-margin-top-8">
                 <h2 class="govuk-heading-m">Report your yearly catch return</h2>
-                <p class="govuk-body no-print">You must by law <span class="no-print"><a class="govuk-link" target="_blank" href="https://www.gov.uk/catch-return">report a catch return (opens in a new tab)</a> </span><span class="print-area">report a catch return</span> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</p>
+                <p class="govuk-body no-print">You must by law <span class="no-print"><a class="govuk-link" href="https://www.gov.uk/catch-return">report a catch return</a> </span><span class="print-area">report a catch return</span> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</p>
                 <p class="govuk-body print-area">You must by law report a catch return of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</p>
             </div>
         {% endif %}
 
-        <p class="govuk-body"><a class="govuk-link" target="_blank" href="{{ data.uri.feedback }}">What did you think of the service (opens in a new tab)</a> (takes 30 seconds)</p>
+        <p class="govuk-body"><a class="govuk-link" href="{{ data.uri.feedback }}">Tell us what you think of this service</a> (takes 30 seconds).</p>
 
         {{ govukButton({
             href: data.uri.new,

--- a/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
@@ -47,10 +47,10 @@
                     <li>the licence is only valid for the person named on it (the licence holder)</li>
                     <li>the licence holder must carry the necessary proof of licence when they go fishing and show it to our enforcement officers if asked. It is an offence not to do so</li>
                     <li>the licence does not give the right to fish, but gives the licence holder the right to use a fishing rod and line only. The permission from any owner of fishing rights is also required before commencing to fish</li>
-                    <li>the licence holder must read and comply with the <a class="govuk-link" href="https://www.gov.uk/freshwater-rod-fishing-rules" target="_blank">freshwater rod fishing byelaws</a> (opens in a new window or tab). It is an offence not to do so</li>
+                    <li>the licence holder must read and comply with the <a class="govuk-link" href="https://www.gov.uk/freshwater-rod-fishing-rules" target="_blank">freshwater rod fishing byelaws (opens in a new window or tab)</a>. It is an offence not to do so</li>
                     <li>the licence is only valid for the specified date and time period, number of rods and the species of fish</li>
                     {% if data.isSalmonAndSeaTrout %}
-                        <li>you will <a class="govuk-link" href="https://www.gov.uk/catch-return" target="_blank">report a catch return</a> (opens in a new window or tab) of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</li>
+                        <li>you will <a class="govuk-link" href="https://www.gov.uk/catch-return" target="_blank">report a catch return (opens in a new window or tab)</a> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</li>
                     {% endif %}
                 </ul>
             </div>

--- a/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
@@ -47,10 +47,10 @@
                     <li>the licence is only valid for the person named on it (the licence holder)</li>
                     <li>the licence holder must carry the necessary proof of licence when they go fishing and show it to our enforcement officers if asked. It is an offence not to do so</li>
                     <li>the licence does not give the right to fish, but gives the licence holder the right to use a fishing rod and line only. The permission from any owner of fishing rights is also required before commencing to fish</li>
-                    <li>the licence holder must read and comply with the <a class="govuk-link" href="https://www.gov.uk/freshwater-rod-fishing-rules" target="_blank">freshwater rod fishing byelaws (opens in a new tab)</a>. It is an offence not to do so</li>
+                    <li>the licence holder must read and comply with the <a class="govuk-link" href="https://www.gov.uk/freshwater-rod-fishing-rules" rel="noreferrer noopener" target="_blank">freshwater rod fishing byelaws (opens in a new tab)</a>. It is an offence not to do so</li>
                     <li>the licence is only valid for the specified date and time period, number of rods and the species of fish</li>
                     {% if data.isSalmonAndSeaTrout %}
-                        <li>you will <a class="govuk-link" href="https://www.gov.uk/catch-return" target="_blank">report a catch return (opens in a new tab)</a> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</li>
+                        <li>you will <a class="govuk-link" href="https://www.gov.uk/catch-return" rel="noreferrer noopener" target="_blank">report a catch return (opens in a new tab)</a> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</li>
                     {% endif %}
                 </ul>
             </div>

--- a/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
@@ -47,10 +47,10 @@
                     <li>the licence is only valid for the person named on it (the licence holder)</li>
                     <li>the licence holder must carry the necessary proof of licence when they go fishing and show it to our enforcement officers if asked. It is an offence not to do so</li>
                     <li>the licence does not give the right to fish, but gives the licence holder the right to use a fishing rod and line only. The permission from any owner of fishing rights is also required before commencing to fish</li>
-                    <li>the licence holder must read and comply with the <a class="govuk-link" href="https://www.gov.uk/freshwater-rod-fishing-rules" target="_blank">freshwater rod fishing byelaws (opens in a new window or tab)</a>. It is an offence not to do so</li>
+                    <li>the licence holder must read and comply with the <a class="govuk-link" href="https://www.gov.uk/freshwater-rod-fishing-rules" target="_blank">freshwater rod fishing byelaws (opens in a new tab)</a>. It is an offence not to do so</li>
                     <li>the licence is only valid for the specified date and time period, number of rods and the species of fish</li>
                     {% if data.isSalmonAndSeaTrout %}
-                        <li>you will <a class="govuk-link" href="https://www.gov.uk/catch-return" target="_blank">report a catch return (opens in a new window or tab)</a> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</li>
+                        <li>you will <a class="govuk-link" href="https://www.gov.uk/catch-return" target="_blank">report a catch return (opens in a new tab)</a> of your yearly salmon and sea trout fishing activity in England and Wales, even if you do not catch anything or do not fish.</li>
                     {% endif %}
                 </ul>
             </div>


### PR DESCRIPTION
IWTF-2148

* Updates links which open in new tab to include "(opens in a new tab)"
* Adds rel="noreferrer noopener" to links which open in new tabs
* Updates links on order-complete page to open in current tab
* Content tweaks to licence-type page
* Content tweaks to order-complete page
* Updates links on privacy-policy page to open in current tab
* Updates link in footer to open in current tab