### PR TITLE
Fulfilment encryption utf encoding bug

### DIFF
--- a/packages/fulfilment-job/src/staging/create-part-files.js
+++ b/packages/fulfilment-job/src/staging/create-part-files.js
@@ -50,25 +50,12 @@ const processQueryPage = async page => {
     const fulfilmentFile = await getTargetFulfilmentFile()
     const partNumber = Math.floor(fulfilmentFile.numberOfRequests / config.file.partFileSize)
     const partFileSize = Math.min(config.file.partFileSize, config.file.size - fulfilmentFile.numberOfRequests)
-    // const itemsToWrite = page.splice(0, partFileSize).map(result => ({
-    //   fulfilmentRequest: result.entity,
-    //   permission: result.expanded.permission.entity,
-    //   licensee: result.expanded.permission.expanded.licensee.entity,
-    //   permit: result.expanded.permission.expanded.permit.entity
-    // }))
-    const itemsToWrite = page.splice(0, partFileSize).map(result => {
-      try {
-        return {
-          fulfilmentRequest: result.entity,
-          permission: result.expanded.permission.entity,
-          licensee: result.expanded.permission.expanded.licensee.entity,
-          permit: result.expanded.permission.expanded.permit.entity
-        }
-      } catch (e) {
-        console.log(e.message, JSON.stringify(result))
-        throw e
-      }
-    })
+    const itemsToWrite = page.splice(0, partFileSize).map(result => ({
+      fulfilmentRequest: result.entity,
+      permission: result.expanded.permission.entity,
+      licensee: result.expanded.permission.expanded.licensee.entity,
+      permit: result.expanded.permission.expanded.permit.entity
+    }))
     await writeS3PartFile(fulfilmentFile, partNumber, itemsToWrite)
 
     fulfilmentFile.numberOfRequests += itemsToWrite.length

--- a/packages/fulfilment-job/src/staging/create-part-files.js
+++ b/packages/fulfilment-job/src/staging/create-part-files.js
@@ -50,12 +50,25 @@ const processQueryPage = async page => {
     const fulfilmentFile = await getTargetFulfilmentFile()
     const partNumber = Math.floor(fulfilmentFile.numberOfRequests / config.file.partFileSize)
     const partFileSize = Math.min(config.file.partFileSize, config.file.size - fulfilmentFile.numberOfRequests)
-    const itemsToWrite = page.splice(0, partFileSize).map(result => ({
-      fulfilmentRequest: result.entity,
-      permission: result.expanded.permission.entity,
-      licensee: result.expanded.permission.expanded.licensee.entity,
-      permit: result.expanded.permission.expanded.permit.entity
-    }))
+    // const itemsToWrite = page.splice(0, partFileSize).map(result => ({
+    //   fulfilmentRequest: result.entity,
+    //   permission: result.expanded.permission.entity,
+    //   licensee: result.expanded.permission.expanded.licensee.entity,
+    //   permit: result.expanded.permission.expanded.permit.entity
+    // }))
+    const itemsToWrite = page.splice(0, partFileSize).map(result => {
+      try {
+        return {
+          fulfilmentRequest: result.entity,
+          permission: result.expanded.permission.entity,
+          licensee: result.expanded.permission.expanded.licensee.entity,
+          permit: result.expanded.permission.expanded.permit.entity
+        }
+      } catch (e) {
+        console.log(e.message, JSON.stringify(result))
+        throw e
+      }
+    })
     await writeS3PartFile(fulfilmentFile, partNumber, itemsToWrite)
 
     fulfilmentFile.numberOfRequests += itemsToWrite.length

--- a/packages/fulfilment-job/src/transport/__tests__/s3.spec.js
+++ b/packages/fulfilment-job/src/transport/__tests__/s3.spec.js
@@ -43,8 +43,8 @@ describe('s3', () => {
 
   describe('readS3PartFiles', () => {
     it('reads all part files for a given file and returns a stream for each', async () => {
-      const mockCreateReadStream1 = jest.fn(() => 'mockStream1')
-      const mockCreateReadStream2 = jest.fn(() => 'mockStream2')
+      const mockCreateReadStream1 = createMockReadStream()
+      const mockCreateReadStream2 = createMockReadStream()
       AwsMock.S3.__setResponse('listObjectsV2', {
         Contents: [{ Key: '/example.json/part0' }, { Key: '/example.json/part1' }]
       })
@@ -52,11 +52,28 @@ describe('s3', () => {
       AwsMock.S3.mockedMethods.getObject.mockImplementationOnce(() => ({ createReadStream: mockCreateReadStream2 }))
 
       const testFile = Object.assign(new FulfilmentRequestFile(), { fileName: 'example.json' })
-      const streams = await readS3PartFiles(testFile)
-      expect(streams).toStrictEqual(['mockStream1', 'mockStream2'])
+      const [stream1, stream2] = await readS3PartFiles(testFile)
+
+      expect(mockCreateReadStream1.mock.results[0].value).toBe(stream1)
+      expect(mockCreateReadStream2.mock.results[0].value).toBe(stream2)
       expect(AwsMock.S3.mockedMethods.getObject).toHaveBeenNthCalledWith(1, { Bucket: 'testbucket', Key: '/example.json/part0' })
       expect(AwsMock.S3.mockedMethods.getObject).toHaveBeenNthCalledWith(2, { Bucket: 'testbucket', Key: '/example.json/part1' })
     })
+
+    it('sets encoding on readable stream', async () => {
+      const mockCreateReadStream = createMockReadStream()
+      AwsMock.S3.__setResponse('listObjectsV2', {
+        Contents: [{ Key: '/example.json/part0' }]
+      })
+      AwsMock.S3.mockedMethods.getObject.mockImplementationOnce(() => ({ createReadStream: mockCreateReadStream }))
+      const testFile = Object.assign(new FulfilmentRequestFile(), { fileName: 'example.json' })
+      const [readStream] = await readS3PartFiles(testFile)
+      expect(readStream.setEncoding).toHaveBeenCalledWith('utf8')
+    })
+
+    const createMockReadStream = () => jest.fn(() => ({
+      setEncoding: jest.fn()
+    }))
   })
 
   describe('createS3WriteStream', () => {

--- a/packages/fulfilment-job/src/transport/__tests__/s3.spec.js
+++ b/packages/fulfilment-job/src/transport/__tests__/s3.spec.js
@@ -43,19 +43,17 @@ describe('s3', () => {
 
   describe('readS3PartFiles', () => {
     it('reads all part files for a given file and returns a stream for each', async () => {
-      const mockCreateReadStream1 = createMockReadStream()
-      const mockCreateReadStream2 = createMockReadStream()
+      const mockCreateReadStream = createMockReadStream()
       AwsMock.S3.__setResponse('listObjectsV2', {
         Contents: [{ Key: '/example.json/part0' }, { Key: '/example.json/part1' }]
       })
-      AwsMock.S3.mockedMethods.getObject.mockImplementationOnce(() => ({ createReadStream: mockCreateReadStream1 }))
-      AwsMock.S3.mockedMethods.getObject.mockImplementationOnce(() => ({ createReadStream: mockCreateReadStream2 }))
+      AwsMock.S3.mockedMethods.getObject.mockImplementation(() => ({ createReadStream: mockCreateReadStream }))
 
       const testFile = Object.assign(new FulfilmentRequestFile(), { fileName: 'example.json' })
       const [stream1, stream2] = await readS3PartFiles(testFile)
 
-      expect(mockCreateReadStream1.mock.results[0].value).toBe(stream1)
-      expect(mockCreateReadStream2.mock.results[0].value).toBe(stream2)
+      expect(mockCreateReadStream.mock.results[0].value).toBe(stream1)
+      expect(mockCreateReadStream.mock.results[1].value).toBe(stream2)
       expect(AwsMock.S3.mockedMethods.getObject).toHaveBeenNthCalledWith(1, { Bucket: 'testbucket', Key: '/example.json/part0' })
       expect(AwsMock.S3.mockedMethods.getObject).toHaveBeenNthCalledWith(2, { Bucket: 'testbucket', Key: '/example.json/part1' })
     })
@@ -65,7 +63,7 @@ describe('s3', () => {
       AwsMock.S3.__setResponse('listObjectsV2', {
         Contents: [{ Key: '/example.json/part0' }]
       })
-      AwsMock.S3.mockedMethods.getObject.mockImplementationOnce(() => ({ createReadStream: mockCreateReadStream }))
+      AwsMock.S3.mockedMethods.getObject.mockImplementation(() => ({ createReadStream: mockCreateReadStream }))
       const testFile = Object.assign(new FulfilmentRequestFile(), { fileName: 'example.json' })
       const [readStream] = await readS3PartFiles(testFile)
       expect(readStream.setEncoding).toHaveBeenCalledWith('utf8')

--- a/packages/fulfilment-job/src/transport/s3.js
+++ b/packages/fulfilment-job/src/transport/s3.js
@@ -31,7 +31,11 @@ export const writeS3PartFile = async (fulfilmentRequestFile, partNumber, data) =
  */
 export async function readS3PartFiles (fulfilmentRequestFile) {
   const { Contents: files } = await s3.listObjectsV2({ Bucket: config.s3.bucket, Prefix: `${fulfilmentRequestFile.fileName}/` }).promise()
-  return files.filter(f => /part\d+$/.test(f.Key)).map(f => s3.getObject({ Bucket: config.s3.bucket, Key: f.Key }).createReadStream())
+  return files.filter(f => /part\d+$/.test(f.Key)).map(f => {
+    const s3rs = s3.getObject({ Bucket: config.s3.bucket, Key: f.Key }).createReadStream()
+    s3rs.setEncoding('utf8')
+    return s3rs
+  })
 }
 
 /**


### PR DESCRIPTION
When decrypting the encrypted fulfilment file, we were ending up with the utf character codes rather than the actual characters. It turns out this is because the encoding hadn't been set on the readable stream - somehow we've got away with this so far, but when the readable stream is fed into openpgp to be transformed into an encrypted readable stream, this will end up with just the utf codes in the stream rather than the characters.