### PR TITLE
Fix localstack to last working version

### DIFF
--- a/docker/infrastructure.yml
+++ b/docker/infrastructure.yml
@@ -9,7 +9,7 @@ services:
   # - CloudFormation (http port 4581)
   #######################################################
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:0.12.12
     ports:
       - '4563-4599:4563-4599'
       - '${PORT_WEB_UI-4080}:${PORT_WEB_UI-8080}'


### PR DESCRIPTION
Localstack has started throwing errors on redirect to GovPay, this rolls us back to a version where this still worked