### PR TITLE
Fix: update POCL validation errors payload schema

### DIFF
--- a/packages/sales-api-service/src/schema/staging-exception.schema.js
+++ b/packages/sales-api-service/src/schema/staging-exception.schema.js
@@ -5,6 +5,7 @@ import { optionSetOption } from './option-set.schema.js'
 import { concessionProofSchema } from './concession-proof.schema.js'
 import { buildJoiOptionSetValidator, createAlternateKeyValidator } from './validators/validators.js'
 import { PoclFile, PoclStagingException } from '@defra-fish/dynamics-lib'
+import { validation, POCL_TRANSACTION_SOURCES } from '@defra-fish/business-rules-lib'
 
 const dateSchema = Joi.string()
   .isoDate()
@@ -109,6 +110,7 @@ export const poclValidationErrorParamsSchema = Joi.object({
     .example(uuidv4())
 })
 
+// There may be further issues in the record data at this point
 export const updatePoclValidationErrorPayload = Joi.object({
   poclValidationErrorId: Joi.string()
     .trim()
@@ -120,13 +122,7 @@ export const updatePoclValidationErrorPayload = Joi.object({
     dataSource: Joi.string().optional(),
     serialNumber: Joi.string().trim().required(),
     permissions: Joi.array().items(Joi.object({
-      licensee: Joi.object({
-        ...commonContactSchema,
-        country: Joi.string().optional(),
-        preferredMethodOfConfirmation: Joi.string().optional(),
-        preferredMethodOfNewsletter: Joi.string().optional(),
-        preferredMethodOfReminder: Joi.string().optional()
-      }),
+      licensee: Joi.object(),
       issueDate: TRANSACTION_DATE,
       startDate: dateSchema.description('An ISO8601 compatible date string defining when the permission commences'),
       permitId: Joi.string().guid().required(),

--- a/packages/sales-api-service/src/schema/staging-exception.schema.js
+++ b/packages/sales-api-service/src/schema/staging-exception.schema.js
@@ -5,7 +5,6 @@ import { optionSetOption } from './option-set.schema.js'
 import { concessionProofSchema } from './concession-proof.schema.js'
 import { buildJoiOptionSetValidator, createAlternateKeyValidator } from './validators/validators.js'
 import { PoclFile, PoclStagingException } from '@defra-fish/dynamics-lib'
-import { validation, POCL_TRANSACTION_SOURCES } from '@defra-fish/business-rules-lib'
 
 const dateSchema = Joi.string()
   .isoDate()


### PR DESCRIPTION
IWTF-2175

* Loosens validators in updatePoclValidationError payload schema to allow errors in data