### PR TITLE
When logging in with one permission and going back and entering anoth…

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
@@ -94,7 +94,7 @@ describe('renewals-write-cache', () => {
     })
 
     it('should set start and end dates, if renewal has not expired', async () => {
-      const endDate = moment().add(5, 'days');
+      const endDate = moment().add(5, 'days')
       const mockDateAuthResult = {
         permission: {
           ...authenticationResult.permission,
@@ -114,7 +114,7 @@ describe('renewals-write-cache', () => {
     })
 
     it('should set start and end dates, if renewal has expired', async () => {
-      const endDate = moment().subtract(5, 'days');
+      const endDate = moment().subtract(5, 'days')
       const mockDateAuthResult = {
         permission: {
           ...authenticationResult.permission,
@@ -140,12 +140,12 @@ describe('renewals-write-cache', () => {
           licensee: expect.objectContaining({
             birthDate: '2004-01-13',
             countryCode: 'GB-ENG',
-            email: "email@gmail.com",
-            firstName: "Negativetwelve",
-            lastName: "Test",
-            postcode: "SN15 3PG",
-            "street": "Blackthorn Mews",
-            "town": "Chippenham"
+            email: 'email@gmail.com',
+            firstName: 'Negativetwelve',
+            lastName: 'Test',
+            postcode: 'SN15 3PG',
+            street: 'Blackthorn Mews',
+            town: 'Chippenham'
           })
         })
       )
@@ -196,7 +196,7 @@ describe('renewals-write-cache', () => {
       await setUpCacheFromAuthenticationResult(mockRequest, mockConccessionAuthResult)
       expect(mockTransactionCacheSet).toHaveBeenCalledWith(
         expect.objectContaining({
-          concessions: [{ "proof": { "referenceNumber": "1233", "type": "Blue Badge" }, "type": "Disabled" }]
+          concessions: [{ proof: { referenceNumber: '1233', type: 'Blue Badge' }, type: 'Disabled' }]
         })
       )
     })

--- a/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
@@ -1,7 +1,8 @@
 import { salesApi } from '@defra-fish/connectors-lib'
+import moment from 'moment'
+
 import { setUpCacheFromAuthenticationResult } from '../renewals-write-cache'
 import mockConcessions from '../../__mocks__/data/concessions'
-import mockTransaction from '../../services/payment/__test__/data/mock-transaction'
 
 jest.mock('@defra-fish/connectors-lib')
 salesApi.concessions.getAll.mockResolvedValue(mockConcessions)
@@ -30,26 +31,38 @@ describe('renewals-write-cache', () => {
       permission: {
         referenceNumber: 'abc',
         licensee: {
-          birthDate: "2004-01-13",
+          birthDate: '2004-01-13',
           country: {
-            id: "910400000",
-            label: "England",
-            description: "GB-ENG"
+            id: '910400000',
+            label: 'England',
+            description: 'GB-ENG'
           },
-          email: "email@gmail.com",
-          firstName: "Negativetwelve",
-          lastName: "Test",
-          postcode: "SN15 3PG",
-          preferredMethodOfConfirmation: "Email",
-          preferredMethodOfNewsletter: "Prefer not to be contacted",
-          preferredMethodOfReminder: "Email",
-          street: "Blackthorn Mews",
-          town: "Chippenham"
+          email: 'email@gmail.com',
+          firstName: 'Negativetwelve',
+          lastName: 'Test',
+          postcode: 'SN15 3PG',
+          preferredMethodOfConfirmation: {
+            id: 910400002,
+            label: 'Text',
+            description: 'Text'
+          },
+          preferredMethodOfNewsletter: {
+            id: 910400000,
+            label: 'Email',
+            description: 'Email'
+          },
+          preferredMethodOfReminder: {
+            id: 910400002,
+            label: 'Text',
+            description: 'Text'
+          },
+          street: 'Blackthorn Mews',
+          town: 'Chippenham'
         },
         concessions: [],
         permit: {
           permitSubtype: {
-            label: "Salmon and sea trout"
+            label: 'Salmon and sea trout'
           },
           numberOfRods: 1
         }
@@ -65,7 +78,125 @@ describe('renewals-write-cache', () => {
       await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
       expect(mockTransactionCacheSet).toHaveBeenCalledWith(
         expect.objectContaining({
-          licenceLength: '12M',
+          licenceLength: '12M'
+        })
+      )
+    })
+
+    it('should set licence type and number of rods to the values in the permit', async () => {
+      await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          licenceType: 'Salmon and sea trout',
+          numberOfRods: '1'
+        })
+      )
+    })
+
+    it('should set start and end dates, if renewal has not expired', async () => {
+      const endDate = moment().add(5, 'days');
+      const mockDateAuthResult = {
+        permission: {
+          ...authenticationResult.permission,
+          endDate
+        }
+      }
+      await setUpCacheFromAuthenticationResult(mockRequest, mockDateAuthResult)
+      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          licenceToStart: 'another-date',
+          licenceStartDate: endDate.format('YYYY-MM-DD'),
+          licenceStartTime: endDate.hours(),
+          renewedEndDate: endDate.toISOString(),
+          renewedHasExpired: false
+        })
+      )
+    })
+
+    it('should set start and end dates, if renewal has expired', async () => {
+      const endDate = moment().subtract(5, 'days');
+      const mockDateAuthResult = {
+        permission: {
+          ...authenticationResult.permission,
+          endDate
+        }
+      }
+      await setUpCacheFromAuthenticationResult(mockRequest, mockDateAuthResult)
+      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          licenceToStart: 'after-payment',
+          licenceStartDate: moment().format('YYYY-MM-DD'),
+          licenceStartTime: 0,
+          renewedEndDate: endDate.toISOString(),
+          renewedHasExpired: true
+        })
+      )
+    })
+
+    it('should map the licensee object correctly', async () => {
+      await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          licensee: expect.objectContaining({
+            birthDate: '2004-01-13',
+            countryCode: 'GB-ENG',
+            email: "email@gmail.com",
+            firstName: "Negativetwelve",
+            lastName: "Test",
+            postcode: "SN15 3PG",
+            "street": "Blackthorn Mews",
+            "town": "Chippenham"
+          })
+        })
+      )
+    })
+
+    it('should map the contact preferences correctly', async () => {
+      await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          licensee: expect.objectContaining({
+            preferredMethodOfNewsletter: 'Email',
+            preferredMethodOfConfirmation: 'Text',
+            preferredMethodOfReminder: 'Text'
+          })
+        })
+      )
+    })
+
+    it('should have an empty array if no concessions are present', async () => {
+      await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          concessions: []
+        })
+      )
+    })
+
+    it('should have an array of concessions if they are present', async () => {
+      const mockConccessionAuthResult = {
+        permission: {
+          ...authenticationResult.permission,
+          concessions: [
+            {
+              id: 'd1ece997-ef65-e611-80dc-c4346bad4004',
+              proof: {
+                id: 'concession-proof-id',
+                referenceNumber: '1233',
+                type: {
+                  id: 910400000,
+                  label: 'Blue Badge',
+                  description: 'Blue Badge'
+                }
+              }
+            }
+          ]
+        }
+      }
+      await setUpCacheFromAuthenticationResult(mockRequest, mockConccessionAuthResult)
+      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          concessions: [{ "proof": { "referenceNumber": "1233", "type": "Blue Badge" }, "type": "Disabled" }]
         })
       )
     })

--- a/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
@@ -8,6 +8,8 @@ jest.mock('@defra-fish/connectors-lib')
 salesApi.concessions.getAll.mockResolvedValue(mockConcessions)
 
 describe('renewals-write-cache', () => {
+  beforeEach(jest.clearAllMocks)
+
   describe('setUpCacheFromAuthenticationResult', () => {
     const mockStatusCacheSet = jest.fn()
     const mockTransactionCacheGet = jest.fn()
@@ -70,7 +72,6 @@ describe('renewals-write-cache', () => {
     }
 
     beforeEach(() => {
-      jest.clearAllMocks()
       mockTransactionCacheGet.mockImplementationOnce(() => ({}))
     })
 

--- a/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
@@ -1,0 +1,73 @@
+import { salesApi } from '@defra-fish/connectors-lib'
+import { setUpCacheFromAuthenticationResult } from '../renewals-write-cache'
+import mockConcessions from '../../__mocks__/data/concessions'
+import mockTransaction from '../../services/payment/__test__/data/mock-transaction'
+
+jest.mock('@defra-fish/connectors-lib')
+salesApi.concessions.getAll.mockResolvedValue(mockConcessions)
+
+describe('renewals-write-cache', () => {
+  describe('setUpCacheFromAuthenticationResult', () => {
+    const mockStatusCacheSet = jest.fn()
+    const mockTransactionCacheGet = jest.fn()
+    const mockTransactionCacheSet = jest.fn()
+
+    const mockRequest = {
+      cache: () => ({
+        helpers: {
+          status: {
+            setCurrentPermission: mockStatusCacheSet
+          },
+          transaction: {
+            getCurrentPermission: mockTransactionCacheGet,
+            setCurrentPermission: mockTransactionCacheSet
+          }
+        }
+      })
+    }
+
+    const authenticationResult = {
+      permission: {
+        referenceNumber: 'abc',
+        licensee: {
+          birthDate: "2004-01-13",
+          country: {
+            id: "910400000",
+            label: "England",
+            description: "GB-ENG"
+          },
+          email: "email@gmail.com",
+          firstName: "Negativetwelve",
+          lastName: "Test",
+          postcode: "SN15 3PG",
+          preferredMethodOfConfirmation: "Email",
+          preferredMethodOfNewsletter: "Prefer not to be contacted",
+          preferredMethodOfReminder: "Email",
+          street: "Blackthorn Mews",
+          town: "Chippenham"
+        },
+        concessions: [],
+        permit: {
+          permitSubtype: {
+            label: "Salmon and sea trout"
+          },
+          numberOfRods: 1
+        }
+      }
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      mockTransactionCacheGet.mockImplementationOnce(() => ({}))
+    })
+
+    it('should set licence length to 12M, as only 12 month licences can be renewed', async () => {
+      await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          licenceLength: '12M',
+        })
+      )
+    })
+  })
+})

--- a/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
@@ -201,5 +201,14 @@ describe('renewals-write-cache', () => {
         })
       )
     })
+
+    it('should set renewal and fromSummary on the status cache', async () => {
+      await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+      expect(mockStatusCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          renewal: true, fromSummary: 'contact-summary'
+        })
+      )
+    })
   })
 })

--- a/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
+++ b/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
@@ -55,6 +55,7 @@ export const setUpCacheFromAuthenticationResult = async (request, authentication
 
   // Add in concession proofs
   const concessions = await salesApi.concessions.getAll()
+  permission.concessions = []
   authenticationResult.permission.concessions.forEach(concessionProof => {
     const concessionReference = concessions.find(c => c.id === concessionProof.id)
     if (concessionReference && concessionReference.name === constants.CONCESSION.DISABLED) {


### PR DESCRIPTION
…er permission, the old concession data is cached

https://eaflood.atlassian.net/browse/IWTF-2350

When logging in with one permission and going back and entering another permission, the old concession data is cached