### PR TITLE
Restore localstack to latest release

### DIFF
--- a/docker/infrastructure.yml
+++ b/docker/infrastructure.yml
@@ -9,7 +9,7 @@ services:
   # - CloudFormation (http port 4581)
   #######################################################
   localstack:
-    image: localstack/localstack:0.12.12
+    image: localstack/localstack:latest
     ports:
       - '4563-4599:4563-4599'
       - '${PORT_WEB_UI-4080}:${PORT_WEB_UI-8080}'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2268

We pinned localstack to v0.12.12 as we started to hit problems. It looks like these have been fixed, so we can go back to using the latest version now