### PR TITLE
Back button takes back to the Contact summary page instead of digital license pages

### DIFF
--- a/packages/gafl-webapp-service/src/routes/__tests__/back-links.spec.js
+++ b/packages/gafl-webapp-service/src/routes/__tests__/back-links.spec.js
@@ -131,6 +131,10 @@ describe('The licence-confirmation page', () => {
     const n = journeyDefinition.find(n => n.current.page === LICENCE_CONFIRMATION_METHOD.page)
     expect(n.backLink({})).toBe(LICENCE_FULFILMENT.uri)
   })
+  it('has a back-link to the licence-fulfilment page if the contact summary has been seen and the last sumbitted page is licence fulfilment', () => {
+    const n = journeyDefinition.find(n => n.current.page === LICENCE_CONFIRMATION_METHOD.page)
+    expect(n.backLink({ currentPage: LICENCE_FULFILMENT.page })).toBe(LICENCE_FULFILMENT.uri)
+  })
   it('has a back-link to the contact-summary page if the contact-summary is seen', () => {
     const n = journeyDefinition.find(n => n.current.page === LICENCE_CONFIRMATION_METHOD.page)
     expect(n.backLink({ fromSummary: CONTACT_SUMMARY_SEEN })).toBe(CONTACT_SUMMARY.uri)
@@ -144,6 +148,9 @@ describe('The contact page', () => {
   })
   it('has a back-link to the licence confirmation method page if the contact summary has not been seen and is a physical licence', () => {
     expect(n.backLink({}, { licenceLength: '12M' })).toBe(LICENCE_CONFIRMATION_METHOD.uri)
+  })
+  it('has a back-link to the licence confirmation method page if the contact summary has been seen and the last submitted page is licence confirmation method', () => {
+    expect(n.backLink({}, { currentPage: LICENCE_CONFIRMATION_METHOD.page, licenceLength: '12M' })).toBe(LICENCE_CONFIRMATION_METHOD.uri)
   })
   it('has a back-link to the contact-summary page if the contact-summary is seen', () => {
     expect(n.backLink({ fromSummary: CONTACT_SUMMARY_SEEN })).toBe(CONTACT_SUMMARY.uri)

--- a/packages/gafl-webapp-service/src/routes/journey-definition.js
+++ b/packages/gafl-webapp-service/src/routes/journey-definition.js
@@ -260,7 +260,14 @@ export default [
         page: CONTACT
       }
     },
-    backLink: s => (s.fromSummary === CONTACT_SUMMARY_SEEN ? CONTACT_SUMMARY.uri : LICENCE_FULFILMENT.uri)
+    backLink: s => {
+      if((s.currentPage === LICENCE_FULFILMENT.page && s.fromSummary === CONTACT_SUMMARY_SEEN)
+       || s.fromSummary !== CONTACT_SUMMARY_SEEN) {
+        return LICENCE_FULFILMENT.uri
+      } else {
+        return CONTACT_SUMMARY.uri
+      }
+    }
   },
   {
     current: CHECK_CONFIRMATION_CONTACT,
@@ -282,7 +289,9 @@ export default [
       }
     },
     backLink: (status, transaction) => {
-      if (status.fromSummary === CONTACT_SUMMARY_SEEN) {
+      if(status.currentPage === LICENCE_CONFIRMATION_METHOD.page && status.fromSummary === CONTACT_SUMMARY_SEEN) {
+        return LICENCE_CONFIRMATION_METHOD.uri
+      } else if (status.fromSummary === CONTACT_SUMMARY_SEEN) {
         return CONTACT_SUMMARY.uri
       } else if (isPhysical(transaction)) {
         return LICENCE_CONFIRMATION_METHOD.uri


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2481

Back button takes back to the Contact summary page instead of digital license pages