### PR TITLE
Update midnight start times

### DIFF
--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/licence-start-time.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/licence-start-time.njk
@@ -12,7 +12,7 @@
 %}
 
 {% set am = [
-    { text: "12am (midnight)", value: "0", checked: payload['licence-start-time'] === '0', disabled: true if data.minHour > 0 else false },
+    { text: "0am (first minute of the day)", value: "0", checked: payload['licence-start-time'] === '0', disabled: true if data.minHour > 0 else false },
     { text: "1am", value: "1", checked: payload['licence-start-time'] === '1', disabled: true if data.minHour > 1 else false },
     { text: "2am", value: "2", checked: payload['licence-start-time'] === '2', disabled: true if data.minHour > 2 else false },
     { text: "3am", value: "3", checked: payload['licence-start-time'] === '3', disabled: true if data.minHour > 3 else false },

--- a/packages/gafl-webapp-service/src/processors/__tests__/date-and-time-display.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/date-and-time-display.spec.js
@@ -3,11 +3,11 @@ import { displayStartTime, displayEndTime, displayExpiryDate } from '../date-and
 describe('displayStartTime', () => {
   it('displays the date in the correct format where no start time is set', () => {
     const startTime = displayStartTime({ licenceStartDate: '2021-01-01' })
-    expect(startTime).toEqual('12:00am (midnight) on 1 January 2021')
+    expect(startTime).toEqual('0.00am (first minute of the day) on 1 January 2021')
   })
   it('displays the date in the correct format where the start time is midnight', () => {
     const startTime = displayStartTime({ licenceStartDate: '2021-01-01', licenceStartTime: 0 })
-    expect(startTime).toEqual('12:00am (midnight) on 1 January 2021')
+    expect(startTime).toEqual('0.00am (first minute of the day) on 1 January 2021')
   })
   it('displays the date in the correct format where the start time is 12pm', () => {
     const startTime = displayStartTime({ licenceStartDate: '2021-01-01', licenceStartTime: '12' })
@@ -25,7 +25,7 @@ describe('displayStartTime', () => {
   it('displays the date in the correct format where the API start time is midnight', () => {
     // Tests that the API start time is used if the date/time has just rolled over (purchase completed at 11.59.59pm)
     const startTime = displayStartTime({ startDate: '2021-01-01T00:00:00.000Z', licenceStartDate: '2020-12-31' })
-    expect(startTime).toEqual('12:00am (midnight) on 1 January 2021')
+    expect(startTime).toEqual('0.00am (first minute of the day) on 1 January 2021')
   })
   it('displays the date in the correct where the API start time is 1 minute past midnight', () => {
     const startTime = displayStartTime({ startDate: '2020-01-01T00:01:00.000Z', licenceStartDate: '2020-01-01' })

--- a/packages/gafl-webapp-service/src/processors/date-and-time-display.js
+++ b/packages/gafl-webapp-service/src/processors/date-and-time-display.js
@@ -16,7 +16,7 @@ export const displayStartTime = permission => {
   const startMoment = permission.startDate ? moment.utc(permission.startDate).tz(SERVICE_LOCAL_TIME) : advancePurchaseDateMoment(permission)
   const timeComponent = startMoment
     .format('h:mma')
-    .replace('12:00am', '12:00am (midnight)')
+    .replace('12:00am', '0.00am (first minute of the day)')
     .replace('12:00pm', '12:00pm (midday)')
   return `${timeComponent} on ${startMoment.format(dateDisplayFormat)}`
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2465

We get comment from confused users about licence start times when the licence starts at the beginning of the day. Currently we say that licences start: '12:00am (midnight)'.

This task is to update the content of this specific start time so that it says: '0.00am (first minute of the day)' so that the time is clearer for users.