### PR TITLE
Fix for back button from address lookup page

### DIFF
--- a/packages/gafl-webapp-service/src/routes/__tests__/back-links.spec.js
+++ b/packages/gafl-webapp-service/src/routes/__tests__/back-links.spec.js
@@ -101,8 +101,8 @@ describe('The name page', () => {
 
 describe('The address-lookup page', () => {
   const n = journeyDefinition.find(n => n.current.page === ADDRESS_LOOKUP.page)
-  it('has a back-link to the name page if the contact summary has not been seen', () => {
-    expect(n.backLink({})).toBe(NAME.uri)
+  it('has a back-link to the licence-summary page if the contact summary has not been seen', () => {
+    expect(n.backLink({})).toBe(LICENCE_SUMMARY.uri)
   })
   it('has a back-link to the contact-summary page if the contact-summary is seen', () => {
     expect(n.backLink({ fromSummary: CONTACT_SUMMARY_SEEN })).toBe(CONTACT_SUMMARY.uri)

--- a/packages/gafl-webapp-service/src/routes/journey-definition.js
+++ b/packages/gafl-webapp-service/src/routes/journey-definition.js
@@ -199,7 +199,7 @@ export default [
         page: ADDRESS_ENTRY
       }
     },
-    backLink: s => (s.fromSummary === CONTACT_SUMMARY_SEEN ? CONTACT_SUMMARY.uri : NAME.uri)
+    backLink: s => (s.fromSummary === CONTACT_SUMMARY_SEEN ? CONTACT_SUMMARY.uri : LICENCE_SUMMARY.uri)
   },
 
   {


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/IWTF/boards/440?modal=detail&selectedIssue=IWTF-2726

This fixes an issue where the back button from the address lookup page goes back to the name page where it should go to licence summary.