### PR TITLE
Fix for incorrect title on confirmation method page

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -269,7 +269,7 @@
   "licence_confirm_method_error_choose": "Choose how we should send the licence",
   "licence_confirm_method_how_body_item": "I will make a note of the licence number",
   "licence_confirm_method_how_body_text": "This is where we will send confirmation of the fishing licence",
-  "licence_confirm_method_how_title_other": "Licence information will be sent by email or text message only. We will not send a licence card.",
+  "licence_confirm_method_how_title_other": "How do they want their fishing licence confirmation?",
   "licence_confirm_method_how_title_you": "How do you want your fishing licence confirmation?",
   "licence_confirm_method_where_body_hint_other": "Licence information will be sent by email or text message only. We will not send a licence card.",
   "licence_confirm_method_where_body_hint_you": "You will receive your licence information by email or text message only. You will not receive a licence card.",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -263,7 +263,7 @@
   "licence_confirm_method_error_choose": "Choose how we should send the licence",
   "licence_confirm_method_how_body_item": "I will make a note of the licence number",
   "licence_confirm_method_how_body_text": "This is where we will send confirmation of the fishing licence",
-  "licence_confirm_method_how_title_other": "Licence information will be sent by email or text message only. We will not send a licence card.",
+  "licence_confirm_method_how_title_other": "How do they want their fishing licence confirmation?",
   "licence_confirm_method_how_title_you": "How do you want your fishing licence confirmation?",
   "licence_confirm_method_where_body_hint_other": "Licence information will be sent by email or text message only. We will not send a licence card.",
   "licence_confirm_method_where_body_hint_you": "You will receive your licence information by email or text message only. You will not receive a licence card.",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2778

Confirmation method page has incorrect title when buying for someone else.