### PR TITLE
Where should we send the fishing licence

### DIFF
--- a/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/licence-confirmation-method.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/licence-confirmation-method.njk
@@ -114,7 +114,7 @@
 {% else %}
     {% set title = mssgs.licence_confirm_method_where_title_you if data.isLicenceForYou else mssgs.licence_confirm_method_where_title_other %}
     {% set bodyText = mssgs.licence_confirm_method_where_body_text %}
-    {% set hintText = mssgs.licence_confirm_method_where_body_hint_you if data.isLicenceForYou else mssgs.licence_confirm_method_how_title_other %}
+    {% set hintText = mssgs.licence_confirm_method_where_body_hint_you if data.isLicenceForYou else mssgs.licence_confirm_method_where_body_hint_other %}
 {% endif %}
 
 {% block pageContent %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2803

As an Angler buying for some one else and having chosen the paperless option,
I want the ability to determine how the fishing licence is delivered
So that I can choose how the licence is received.