### PR TITLE
Result function not called for licence for page

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/result-functions.js
+++ b/packages/gafl-webapp-service/src/handlers/result-functions.js
@@ -44,7 +44,7 @@ export default {
   [DISABILITY_CONCESSION.page]: disabilityConcession,
   [LICENCE_LENGTH.page]: licenceLength,
   [LICENCE_TYPE.page]: licenceType,
-  [LICENCE_FOR]: licenceFor,
+  [LICENCE_FOR.page]: licenceFor,
   [LICENCE_START_TIME.page]: licenceStartTime,
   [ADDRESS_LOOKUP.page]: addressLookup,
   [ADDRESS_ENTRY.page]: addressEntry,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2882

The result function called for licence for page by updating the result function handler