### PR TITLE
Fix for missing translation on BOBO date of birth page

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -186,7 +186,7 @@
   "dob_error_format_max": "Mae'n rhaid i’r dyddiad geni fod yn y gorffennol",
   "dob_error_format_min": "Nodwch eich dyddiad geni a chynnwys y diwrnod, y mis a’r flwyddyn",
   "dob_error_format": "Nodwch ddyddiad geni deiliad y drwydded a chynnwys diwrnod, mis a blwyddyn",
-  "dob_error": "Nodwch eich dyddiad geni",
+  "dob_error": "Rhowch y dyddiad geni",
   "dob_month": "Mis",
   "dob_privacy_link_prefix": "Darllenwch am ",
   "dob_privacy_link": "sut rydym yn defnyddio gwybodaeth bersonol",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2822

BOBO date of birth requires additional translation that is missing.