### PR TITLE
Update target branch for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: weekly
     open-pull-requests-limit: 20
     versioning-strategy: increase
+    target-branch: version-updates


### PR DESCRIPTION
As a part of developing a better strategy for keeping us up-to-date with dependabot pull requests, this will enable us to merge them to a version-updates branch that will run parallel to develop, but represent a sandbox so that we can run acceptance (and any other necessary) tests against updates and easily rollback without contaminating the commit history of the develop branch.