### PR TITLE
Update button text for licence terms page

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -572,7 +572,7 @@
   "terms_conds_error": "Nid ydych wedi cytuno i amodau a thelerau’r drwydded.",
   "terms_conds_item_agree": "Rwy'n cytuno â'r amodau a thelerau",
   "terms_conds_pay_button_1": "Talu am y drwydded",
-  "terms_conds_pay_button_2": "Get the licence",
+  "terms_conds_pay_button_2": "Cael y drwydded",
   "terms_conds_pay_on_gov_uk": "ar wefan talu diogel GOV.UK",
   "terms_conds_title": "Amodau’r drwydded",
   "terms_conds_warning": "Rhybudd Peidiwch â chau'r porwr na defnyddio'r botwm yn ôl pan fyddwch yn talu",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2905

This button is shown when the user doesn't need to pay for the licence. This change adds the Welsh translation.