### PR TITLE
Open footer link to OS terms in same window

### DIFF
--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -79,7 +79,7 @@
   "address_lookup_content_info": "This is where we will send the licence card. A bankside enforcement officer may ask for this information if the licence is checked.",
   "address_lookup_crown_copyright_new_tab": "OS (opens in a new tab)",
   "address_lookup_crown_copyright_ref": "100024198.",
-  "address_lookup_crown_copyright_terms_link": "terms and conditions (opens in a new tab)",
+  "address_lookup_crown_copyright_terms_link": "terms and conditions",
   "address_lookup_crown_copyright_terms": "Use of this addressing data is subject to the ",
   "address_lookup_crown_copyright": "© Crown copyright and database rights 2022 ",
   "address_lookup_error_empty_name_num": "Enter a building number or name",

--- a/packages/gafl-webapp-service/src/pages/layout/layout.njk
+++ b/packages/gafl-webapp-service/src/pages/layout/layout.njk
@@ -101,7 +101,7 @@
     <div class="no-print">
         {% if (title === mssgs.address_lookup_title_you) or (title === mssgs.address_lookup_title_other) %}
             <p class="govuk-body-s">{{ mssgs.address_lookup_crown_copyright }}<a class="govuk-link" href="http://www.ordnancesurvey.co.uk" rel="noreferrer noopener" target="_blank">{{ mssgs.address_lookup_crown_copyright_new_tab }}</a> {{ mssgs.address_lookup_crown_copyright_ref }}
-            <br>{{ mssgs.address_lookup_crown_copyright_terms }} <a class="govuk-link" href="{{ data.uri.osTerms }}" rel="noreferrer noopener" target="_blank">{{ mssgs.address_lookup_crown_copyright_terms_link }}</a></p>
+            <br>{{ mssgs.address_lookup_crown_copyright_terms }} <a class="govuk-link" href="{{ data.uri.osTerms }}">{{ mssgs.address_lookup_crown_copyright_terms_link }}</a></p>
         {% endif %}
         <p class="govuk-!-margin-top-5 govuk-!-margin-bottom-0">{{ mssgs.footer_ea_helpline }} <a class="govuk-link" href="tel:+443448005386">0344 800 5386</a></p>
         <p class="govuk-!-margin-top-0">{{ mssgs.footer_ea_helpline_opening_hours }}</p>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2850

This undoes the changes from https://github.com/DEFRA/rod-licensing/pull/1329 as the AC has now changed.

Note that the Welsh translations have not been modified as we were missing the translation for "opens in a new tab" anyway.