### PR TITLE
Include user's chosen language in GovPay return URL

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
@@ -13,6 +13,10 @@ import {
 import { COMPLETION_STATUS } from '../../constants.js'
 import { AGREED, TEST_TRANSACTION, TEST_STATUS, ORDER_COMPLETE } from '../../uri.js'
 import { PAYMENT_JOURNAL_STATUS_CODES } from '@defra-fish/business-rules-lib'
+import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
+
+jest.mock('../../processors/uri-helper.js')
+addLanguageCodeToUri.mockReturnValue('/buy/order-complete')
 
 beforeAll(() => {
   process.env.ANALYTICS_PRIMARY_PROPERTY = 'UA-123456789-0'
@@ -134,6 +138,7 @@ describe('The agreed handler', () => {
     const response = await injectWithCookies('GET', AGREED.uri)
     expect(response.statusCode).toBe(302)
     expect(response.headers.location).toBe(ORDER_COMPLETE.uri)
+    expect(addLanguageCodeToUri).toHaveBeenCalled()
     await injectWithCookies('GET', ORDER_COMPLETE.uri)
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
@@ -15,8 +15,9 @@ import { AGREED, TEST_TRANSACTION, TEST_STATUS, ORDER_COMPLETE } from '../../uri
 import { PAYMENT_JOURNAL_STATUS_CODES } from '@defra-fish/business-rules-lib'
 import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
 
-jest.mock('../../processors/uri-helper.js')
-addLanguageCodeToUri.mockReturnValue('/buy/order-complete')
+jest.mock('../../processors/uri-helper.js', () => ({
+  addLanguageCodeToUri: jest.fn(() => '/buy/order-complete')
+}))
 
 beforeAll(() => {
   process.env.ANALYTICS_PRIMARY_PROPERTY = 'UA-123456789-0'

--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
@@ -54,92 +54,226 @@ describe('The agreed handler', () => {
     expect(response.statusCode).toBe(403)
   })
 
-  it.each([
+  describe.each([
     ['adult full 1 day licence', ADULT_FULL_1_DAY_LICENCE],
     ['adult disabled 12 month licence', ADULT_DISABLED_12_MONTH_LICENCE],
     ['senior 12 month licence', SENIOR_12_MONTH_LICENCE]
-  ])('processes the series of steps necessary to complete a successful payment journey - %s', async (desc, journey) => {
-    await journey.setup()
+  ])('payment journey %s', (desc, journey) => {
+    beforeEach(async () => {
+      await journey.setup()
 
-    salesApi.createTransaction.mockResolvedValue(journey.transactionResponse)
-    salesApi.finaliseTransaction.mockResolvedValue(journey.transactionResponse)
-    govUkPayApi.createPayment.mockResolvedValue({ json: () => MOCK_PAYMENT_RESPONSE, ok: true, status: 201 })
-    govUkPayApi.fetchPaymentStatus.mockResolvedValue({ json: () => paymentStatusSuccess(journey.cost), ok: true, status: 201 })
-    salesApi.getPaymentJournal.mockResolvedValue(false)
-    salesApi.updatePaymentJournal.mockImplementation(jest.fn())
-    salesApi.createPaymentJournal.mockImplementation(jest.fn())
-
-    const response = await injectWithCookies('GET', AGREED.uri)
-    expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(MOCK_PAYMENT_RESPONSE._links.next_url.href)
-
-    // Check the journal creation
-    expect(salesApi.updatePaymentJournal).not.toHaveBeenCalled()
-    expect(salesApi.getPaymentJournal).toHaveBeenCalledWith(journey.transactionResponse.id)
-    expect(salesApi.createPaymentJournal).toHaveBeenCalledWith(journey.transactionResponse.id, {
-      paymentReference: MOCK_PAYMENT_RESPONSE.payment_id,
-      paymentTimestamp: MOCK_PAYMENT_RESPONSE.created_date,
-      paymentStatus: PAYMENT_JOURNAL_STATUS_CODES.InProgress
+      salesApi.createTransaction.mockResolvedValue(journey.transactionResponse)
+      salesApi.finaliseTransaction.mockResolvedValue(journey.transactionResponse)
+      govUkPayApi.createPayment.mockResolvedValue({ json: () => MOCK_PAYMENT_RESPONSE, ok: true, status: 201 })
+      govUkPayApi.fetchPaymentStatus.mockResolvedValue({ json: () => paymentStatusSuccess(journey.cost), ok: true, status: 201 })
+      salesApi.getPaymentJournal.mockResolvedValue(false)
+      salesApi.updatePaymentJournal.mockImplementation(jest.fn())
+      salesApi.createPaymentJournal.mockImplementation(jest.fn())
     })
 
-    // On return from the GOV.UK Payment pages
-    const response2 = await injectWithCookies('GET', AGREED.uri)
-    expect(response2.statusCode).toBe(302)
-    expect(response2.headers.location).toBe(ORDER_COMPLETE.uri)
-
-    // Check that the journal entry is updated with the complete status
-    // salesApi.updatePaymentJournal = jest.fn()
-    expect(salesApi.updatePaymentJournal).toHaveBeenCalledWith(journey.transactionResponse.id, {
-      paymentStatus: PAYMENT_JOURNAL_STATUS_CODES.Completed
+    it('gives a 302 response', async () => {
+      const response = await injectWithCookies('GET', AGREED.uri)
+      expect(response.statusCode).toBe(302)
     })
 
-    // Check the cache status
-    const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
-    expect(JSON.parse(payload).id).toBe(journey.transactionResponse.id)
-    const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
-    expect(JSON.parse(status)[COMPLETION_STATUS.agreed]).toBeTruthy()
-    expect(JSON.parse(status)[COMPLETION_STATUS.posted]).toBeTruthy()
-    expect(JSON.parse(status)[COMPLETION_STATUS.paymentCreated]).toBeTruthy()
-    expect(JSON.parse(status)[COMPLETION_STATUS.paymentCompleted]).toBeTruthy()
-    expect(JSON.parse(status)[COMPLETION_STATUS.finalised]).toBeTruthy()
+    it('redirects to the correct location', async () => {
+      const response = await injectWithCookies('GET', AGREED.uri)
+      expect(response.headers.location).toBe(MOCK_PAYMENT_RESPONSE._links.next_url.href)
+    })
 
-    const response3 = await injectWithCookies('GET', ORDER_COMPLETE.uri)
-    expect(response3.statusCode).toBe(200)
+    it('does not call updatePaymentJournal during journal creation', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      expect(salesApi.updatePaymentJournal).not.toHaveBeenCalled()
+    })
+
+    it('calls getPaymentJournal with the correct arguments during journal creation', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      expect(salesApi.getPaymentJournal).toHaveBeenCalledWith(journey.transactionResponse.id)
+    })
+
+    it('calls createPaymentJournal with the correct arguments during journal creation', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      expect(salesApi.createPaymentJournal).toHaveBeenCalledWith(journey.transactionResponse.id, {
+        paymentReference: MOCK_PAYMENT_RESPONSE.payment_id,
+        paymentTimestamp: MOCK_PAYMENT_RESPONSE.created_date,
+        paymentStatus: PAYMENT_JOURNAL_STATUS_CODES.InProgress
+      })
+    })
+
+    it('gives a 302 response on return from the GOV.UK Payment pages', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      const response = await injectWithCookies('GET', AGREED.uri)
+      expect(response.statusCode).toBe(302)
+    })
+
+    it('loads the order complete page on return from the GOV.UK Payment pages', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      const response = await injectWithCookies('GET', AGREED.uri)
+      expect(response.headers.location).toBe(ORDER_COMPLETE.uri)
+    })
+
+    it('updates the journal entry with the complete status', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', AGREED.uri)
+      expect(salesApi.updatePaymentJournal).toHaveBeenCalledWith(journey.transactionResponse.id, {
+        paymentStatus: PAYMENT_JOURNAL_STATUS_CODES.Completed
+      })
+    })
+
+    it('updates the cache', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', AGREED.uri)
+      const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      expect(JSON.parse(payload).id).toBe(journey.transactionResponse.id)
+    })
+
+    it('sets the completion status to agreed', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.agreed]).toBeTruthy()
+    })
+
+    it('sets the completion status to posted', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.posted]).toBeTruthy()
+    })
+
+    it('sets the completion status to payment created', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.paymentCreated]).toBeTruthy()
+    })
+
+    it('sets the completion status to payment completed', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.paymentCompleted]).toBeTruthy()
+    })
+
+    it('sets the completion status to finalised', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.finalised]).toBeTruthy()
+    })
+
+    it('returns a 200 status code when getting the order complete page', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      await injectWithCookies('GET', TEST_STATUS.uri)
+      const response = await injectWithCookies('GET', ORDER_COMPLETE.uri)
+      expect(response.statusCode).toBe(200)
+    })
   })
 
-  it.each([
+  describe.each([
     ['junior', JUNIOR_LICENCE],
     ['junior, disabled', JUNIOR_DISABLED_LICENCE]
-  ])('processes the series of steps necessary to complete a successful no-payment journey: %s', async (desc, journey) => {
-    await journey.setup()
-    salesApi.createTransaction.mockResolvedValue(journey.transactionResponse)
-    salesApi.finaliseTransaction.mockResolvedValue(journey.transactionResponse)
-    const response1 = await injectWithCookies('GET', AGREED.uri)
-    expect(response1.statusCode).toBe(302)
-    expect(response1.headers.location).toBe(ORDER_COMPLETE.uri)
-    const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
-    expect(JSON.parse(payload).id).toBe(JUNIOR_LICENCE.transactionResponse.id)
-    const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
-    expect(JSON.parse(status)[COMPLETION_STATUS.agreed]).toBeTruthy()
-    expect(JSON.parse(status)[COMPLETION_STATUS.posted]).toBeTruthy()
-    expect(JSON.parse(status)[COMPLETION_STATUS.paymentCreated]).not.toBeTruthy()
-    expect(JSON.parse(status)[COMPLETION_STATUS.paymentCompleted]).not.toBeTruthy()
-    expect(JSON.parse(status)[COMPLETION_STATUS.finalised]).toBeTruthy()
-    const response3 = await injectWithCookies('GET', ORDER_COMPLETE.uri)
-    expect(response3.statusCode).toBe(200)
+  ])('no-payment journey %s', (desc, journey) => {
+    beforeEach(async () => {
+      await journey.setup()
+      salesApi.createTransaction.mockResolvedValue(journey.transactionResponse)
+      salesApi.finaliseTransaction.mockResolvedValue(journey.transactionResponse)
+    })
+
+    it('returns a 302 status code', async () => {
+      const response = await injectWithCookies('GET', AGREED.uri)
+      expect(response.statusCode).toBe(302)
+    })
+
+    it('redirects to the order complete page', async () => {
+      const response = await injectWithCookies('GET', AGREED.uri)
+      expect(response.headers.location).toBe(ORDER_COMPLETE.uri)
+    })
+
+    it('updates the cache', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      expect(JSON.parse(payload).id).toBe(JUNIOR_LICENCE.transactionResponse.id)
+    })
+
+    it('sets the completion status to agreed', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.agreed]).toBeTruthy()
+    })
+
+    it('sets the completion status to posted', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.posted]).toBeTruthy()
+    })
+
+    it('does not set the completion status to payment created', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.paymentCreated]).not.toBeTruthy()
+    })
+
+    it('does not set the completion status to payment completed', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.paymentCompleted]).not.toBeTruthy()
+    })
+
+    it('sets the completion status to finalised', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      await injectWithCookies('GET', TEST_TRANSACTION.uri)
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.finalised]).toBeTruthy()
+    })
+
+    it('returns a 200 status code when getting the order complete page', async () => {
+      await injectWithCookies('GET', AGREED.uri)
+      const response = await injectWithCookies('GET', ORDER_COMPLETE.uri)
+      expect(response.statusCode).toBe(200)
+    })
   })
 
-  it('redirects to order-completed for finalized transactions', async () => {
-    await JUNIOR_LICENCE.setup()
-    salesApi.createTransaction.mockResolvedValue(JUNIOR_LICENCE.transactionResponse)
-    salesApi.finaliseTransaction.mockResolvedValue(JUNIOR_LICENCE.transactionResponse)
-    await injectWithCookies('GET', AGREED.uri)
-    const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
-    expect(JSON.parse(status)[COMPLETION_STATUS.finalised]).toBeTruthy()
-    const response = await injectWithCookies('GET', AGREED.uri)
-    expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ORDER_COMPLETE.uri)
-    expect(addLanguageCodeToUri).toHaveBeenCalled()
-    await injectWithCookies('GET', ORDER_COMPLETE.uri)
+  describe('finalised transactions', () => {
+    beforeEach(async () => {
+      await JUNIOR_LICENCE.setup()
+      salesApi.createTransaction.mockResolvedValue(JUNIOR_LICENCE.transactionResponse)
+      salesApi.finaliseTransaction.mockResolvedValue(JUNIOR_LICENCE.transactionResponse)
+      await injectWithCookies('GET', AGREED.uri)
+    })
+
+    it('sets the completion status to finalised', async () => {
+      const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
+      expect(JSON.parse(status)[COMPLETION_STATUS.finalised]).toBeTruthy()
+    })
+
+    it('returns a 302 status code', async () => {
+      await injectWithCookies('GET', TEST_STATUS.uri)
+      const response = await injectWithCookies('GET', AGREED.uri)
+      expect(response.statusCode).toBe(302)
+    })
+
+    it('loads the order complete page', async () => {
+      await injectWithCookies('GET', TEST_STATUS.uri)
+      const response = await injectWithCookies('GET', AGREED.uri)
+      expect(response.headers.location).toBe(ORDER_COMPLETE.uri)
+    })
+
+    it('calls addLanguageCodeToUri', async () => {
+      await injectWithCookies('GET', TEST_STATUS.uri)
+      await injectWithCookies('GET', AGREED.uri)
+      expect(addLanguageCodeToUri).toHaveBeenCalled()
+    })
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-payment-failure.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-payment-failure.spec.js
@@ -96,6 +96,51 @@ const paymentIncomplete = {
   }
 }
 
+const getMockRequest = () => ({
+  cache: () => ({
+    helpers: {
+      transaction: {
+        get: async () => ({
+          cost: 100,
+          payment: {
+            payment_id: 'abc-123'
+          }
+        })
+      },
+      status: {
+        get: async () => ({
+          [COMPLETION_STATUS.agreed]: true,
+          [COMPLETION_STATUS.posted]: true,
+          [COMPLETION_STATUS.paymentCreated]: true
+        }),
+        set: async () => ({})
+      }
+    }
+  }),
+  headers: { 'x-forwarded-proto': 'https' },
+  info: { host: 'localhost:1234' },
+  server: { info: { protocol: '' } }
+})
+
+const getRequestToolkit = () => ({
+  redirect: jest.fn()
+})
+
+const getSendPaymentMockImplementation = () => ({
+  payment_id: '',
+  created_date: '',
+  state: '',
+  payment_provider: '',
+  _links: {
+    next_url: {
+      href: ''
+    },
+    self: {
+      href: ''
+    }
+  }
+})
+
 describe('The agreed handler', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -170,36 +215,6 @@ describe('The agreed handler', () => {
   })
 
   describe('GOV.UK returns a failed response', () => {
-    const getMockRequest = () => ({
-      cache: () => ({
-        helpers: {
-          transaction: {
-            get: async () => ({
-              cost: 100,
-              payment: {
-                payment_id: 'abc-123'
-              }
-            })
-          },
-          status: {
-            get: async () => ({
-              [COMPLETION_STATUS.agreed]: true,
-              [COMPLETION_STATUS.posted]: true,
-              [COMPLETION_STATUS.paymentCreated]: true
-            }),
-            set: async () => ({})
-          }
-        }
-      }),
-      headers: { 'x-forwarded-proto': 'https' },
-      info: { host: 'localhost:1234' },
-      server: { info: { protocol: '' } }
-    })
-
-    const getRequestToolkit = () => ({
-      redirect: jest.fn()
-    })
-
     beforeEach(() => {
       getPaymentStatus.mockReturnValueOnce({
         state: {
@@ -222,20 +237,7 @@ describe('The agreed handler', () => {
 
     it('calls redirect correctly', async () => {
       preparePayment.mockImplementation(() => {})
-      sendPayment.mockImplementation(() => ({
-        payment_id: '',
-        created_date: '',
-        state: '',
-        payment_provider: '',
-        _links: {
-          next_url: {
-            href: ''
-          },
-          self: {
-            href: ''
-          }
-        }
-      }))
+      sendPayment.mockImplementation(() => getSendPaymentMockImplementation())
       const requestToolkit = getRequestToolkit()
       const expectedPath = Symbol('expected path')
       addLanguageCodeToUri.mockReturnValueOnce(expectedPath)
@@ -317,36 +319,6 @@ describe('The agreed handler', () => {
   })
 
   describe('GOV.UK returns a cancelled response', () => {
-    const getMockRequest = () => ({
-      cache: () => ({
-        helpers: {
-          transaction: {
-            get: async () => ({
-              cost: 100,
-              payment: {
-                payment_id: 'abc-123'
-              }
-            })
-          },
-          status: {
-            get: async () => ({
-              [COMPLETION_STATUS.agreed]: true,
-              [COMPLETION_STATUS.posted]: true,
-              [COMPLETION_STATUS.paymentCreated]: true
-            }),
-            set: async () => ({})
-          }
-        }
-      }),
-      headers: { 'x-forwarded-proto': 'https' },
-      info: { host: 'localhost:1234' },
-      server: { info: { protocol: '' } }
-    })
-
-    const getRequestToolkit = () => ({
-      redirect: jest.fn()
-    })
-
     beforeEach(() => {
       getPaymentStatus.mockReturnValueOnce({
         state: {
@@ -369,20 +341,7 @@ describe('The agreed handler', () => {
 
     it('calls redirect correctly', async () => {
       preparePayment.mockImplementation(() => {})
-      sendPayment.mockImplementation(() => ({
-        payment_id: '',
-        created_date: '',
-        state: '',
-        payment_provider: '',
-        _links: {
-          next_url: {
-            href: ''
-          },
-          self: {
-            href: ''
-          }
-        }
-      }))
+      sendPayment.mockImplementation(() => getSendPaymentMockImplementation())
       const requestToolkit = getRequestToolkit()
       const expectedPath = Symbol('expected path')
       addLanguageCodeToUri.mockReturnValueOnce(expectedPath)

--- a/packages/gafl-webapp-service/src/handlers/agreed-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/agreed-handler.js
@@ -18,6 +18,7 @@ import { preparePayment } from '../processors/payment.js'
 import { COMPLETION_STATUS } from '../constants.js'
 import { ORDER_COMPLETE, PAYMENT_CANCELLED, PAYMENT_FAILED } from '../uri.js'
 import { PAYMENT_JOURNAL_STATUS_CODES, GOVUK_PAY_ERROR_STATUS_CODES } from '@defra-fish/business-rules-lib'
+import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 const debug = db('webapp:agreed-handler')
 
 /**
@@ -150,7 +151,7 @@ const processPayment = async (request, transaction, status) => {
       status[COMPLETION_STATUS.paymentFailed] = true
       status.payment = { code: state.code }
       await request.cache().helpers.status.set(status)
-      next = PAYMENT_FAILED.uri
+      next = addLanguageCodeToUri(request, PAYMENT_FAILED.uri)
     }
 
     // The user cancelled the payment
@@ -159,7 +160,7 @@ const processPayment = async (request, transaction, status) => {
       status[COMPLETION_STATUS.paymentCancelled] = true
       status.pay = { code: state.code }
       await request.cache().helpers.status.set(status)
-      next = PAYMENT_CANCELLED.uri
+      next = addLanguageCodeToUri(request, PAYMENT_CANCELLED.uri)
     }
 
     // The payment was rejected
@@ -168,7 +169,7 @@ const processPayment = async (request, transaction, status) => {
       status[COMPLETION_STATUS.paymentFailed] = true
       status.payment = { code: state.code }
       await request.cache().helpers.status.set(status)
-      next = PAYMENT_FAILED.uri
+      next = addLanguageCodeToUri(request, PAYMENT_FAILED.uri)
     }
   }
 
@@ -252,5 +253,5 @@ export default async (request, h) => {
   }
 
   // If we are here we have completed
-  return h.redirect(ORDER_COMPLETE.uri)
+  return h.redirect(addLanguageCodeToUri(request, ORDER_COMPLETE.uri))
 }

--- a/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
@@ -1,5 +1,9 @@
 import { preparePayment } from '../payment.js'
 import { licenceTypeAndLengthDisplay } from '../licence-type-display.js'
+import { addLanguageCodeToUri } from '../uri-helper.js'
+import { AGREED } from '../../uri.js'
+
+jest.mock('../uri-helper.js')
 
 jest.mock('../licence-type-display.js')
 licenceTypeAndLengthDisplay.mockReturnValue('Trout and coarse, up to 2 rods, 8 day')
@@ -43,6 +47,7 @@ describe('preparePayment', () => {
 
   describe('provides the correct return url', () => {
     it.each(['http', 'https'])('uses SSL when "x-forwarded-proto" header is present, proto "%s"', proto => {
+      addLanguageCodeToUri.mockReturnValue(proto + '://localhost:1234/buy/agreed')
       const request = createRequest({ headers: { 'x-forwarded-proto': proto } })
       result = preparePayment(request, transaction)
       expect(result.return_url).toBe(`${proto}://localhost:1234/buy/agreed`)
@@ -53,9 +58,15 @@ describe('preparePayment', () => {
       ['https', 'otherhost:8888'],
       ['http', 'samplehost:4444']
     ])('uses request data when "x-forwarded-proto" header is not present, protocol "%s", host "%s"', (protocol, host) => {
+      addLanguageCodeToUri.mockReturnValue(protocol + '://' + host + '/buy/agreed')
       const request = createRequest({ headers: {}, protocol, host })
       result = preparePayment(request, transaction)
       expect(result.return_url).toBe(`${protocol}://${host}/buy/agreed`)
+    })
+
+    it('calls addLanguageCodeToUri with correct arguments', () => {
+      preparePayment(request, transaction)
+      expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, AGREED.uri)
     })
   })
 

--- a/packages/gafl-webapp-service/src/processors/payment.js
+++ b/packages/gafl-webapp-service/src/processors/payment.js
@@ -1,6 +1,7 @@
 import { AGREED } from '../uri.js'
 import db from 'debug'
 import { licenceTypeAndLengthDisplay } from './licence-type-display.js'
+import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 const debug = db('webapp:payment-processors')
 
 /**
@@ -17,7 +18,8 @@ const getAddressLine1 = licensee => (licensee.street ? `${licensee.premises} ${l
  * @returns {{reference: *, delayed_capture: boolean, amount: number, return_url: string, description: string}}
  */
 export const preparePayment = (request, transaction) => {
-  const url = new URL(AGREED.uri, `${request.headers['x-forwarded-proto'] || request.server.info.protocol}:${request.info.host}`)
+  const uri = addLanguageCodeToUri(request, AGREED.uri)
+  const url = new URL(uri, `${request.headers['x-forwarded-proto'] || request.server.info.protocol}:${request.info.host}`)
 
   const result = {
     return_url: url.href,

--- a/packages/gafl-webapp-service/src/services/payment/__test__/govuk-pay-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/payment/__test__/govuk-pay-service.spec.js
@@ -1,9 +1,14 @@
 import mockTransaction from './data/mock-transaction.js'
 import { preparePayment } from '../../../processors/payment.js'
 import { AGREED } from '../../../uri.js'
+import { addLanguageCodeToUri } from '../../../processors/uri-helper.js'
+
+jest.mock('../../../processors/uri-helper.js')
 
 describe('The govuk-pay-service', () => {
   it('prepares a correct payment response endpoint for http', async () => {
+    addLanguageCodeToUri.mockReturnValue('http://0.0.0.0:3000/buy/agreed')
+
     expect(
       preparePayment(
         {
@@ -22,6 +27,8 @@ describe('The govuk-pay-service', () => {
   })
 
   it('prepares a correct payment response endpoint for https', async () => {
+    addLanguageCodeToUri.mockReturnValue('https://0.0.0.0:3000/buy/agreed')
+
     expect(
       preparePayment(
         {
@@ -40,6 +47,8 @@ describe('The govuk-pay-service', () => {
   })
 
   it('prepares a correct payment creation object', async () => {
+    addLanguageCodeToUri.mockReturnValue('https://0.0.0.0:3000/buy/agreed')
+
     expect(
       preparePayment(
         {
@@ -76,6 +85,8 @@ describe('The govuk-pay-service', () => {
   })
 
   it('prepares a correct payment creation object - with locality', async () => {
+    addLanguageCodeToUri.mockReturnValue('https://0.0.0.0:3000/buy/agreed')
+
     const mockTransaction2 = Object.assign({}, mockTransaction)
     mockTransaction2.permissions[0].licensee.locality = 'Stoke Bishop'
     mockTransaction2.permissions[0].licenceLength = '8D'
@@ -115,6 +126,8 @@ describe('The govuk-pay-service', () => {
   })
 
   it('prepares a correct payment creation object where there are multiple licences', async () => {
+    addLanguageCodeToUri.mockReturnValue('https://0.0.0.0:3000/buy/agreed')
+
     const newMockTransaction = Object.assign({}, mockTransaction)
     newMockTransaction.permissions.push(mockTransaction.permissions[0])
     expect(preparePayment({ info: { host: '0.0.0.0:3000' }, headers: { 'x-forwarded-proto': 'https' } }, newMockTransaction)).toEqual({
@@ -128,6 +141,8 @@ describe('The govuk-pay-service', () => {
   })
 
   it('posts the prepared payment to the GOV.PAY api', async () => {
+    addLanguageCodeToUri.mockReturnValue('https://0.0.0.0:3000/buy/agreed')
+
     const preparedPayment = preparePayment({ info: { host: '0.0.0.0:3000' }, headers: { 'x-forwarded-proto': 'https' } }, mockTransaction)
     console.log(preparedPayment)
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2897

If a user has chosen to use the service in Welsh, we still want the service to be in Welsh when they return from using GovPay. This PR updates the return URL we send to GovPay to include the language change when needed.