### PR TITLE
bugfix/iwtf 2992 update example text and welsh dob error incorrect

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -207,7 +207,7 @@
   "email_alt": "E-bost",
   "email": "E-bost: ",
   "ends": "Ends",
-  "enter_dob_example": "Er enghraifft, 23 11 1979",
+  "enter_dob_example": "Er enghraifft, 23 11 1970",
   "enter_dob": "Nodwch eich dyddiad geni",
   "enter_postcode": "Nodwch god post",
   "exit_service_button": "Exit the service",

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -34,17 +34,20 @@
 
 {% set dateInputItems = [
     {
-      name: mssgs.dob_day,
+      label: mssgs.dob_day,
+      name: "day",
       classes: "govuk-input--width-2",
       value: payload['date-of-birth-day']
     },
     {
-      name: mssgs.dob_month,
+      label: mssgs.dob_month,
+      name: "month",
       classes: "govuk-input--width-2",
       value: payload['date-of-birth-month']
     },
     {
-      name: mssgs.dob_year,
+      label: mssgs.dob_year,
+      name: "year",
       classes: "govuk-input--width-4",
       value: payload['date-of-birth-year']
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2992

DOB example text is incorrect year date and when in welsh lang: if dob is in past or in future the relevant error text does not show, instead has the enter dob text and removes input.