### PR TITLE
bugfix/iwtf 2967 validation error for max char missing on find your a…

### DIFF
--- a/packages/business-rules-lib/src/validators/__tests__/contact.validators.spec.js
+++ b/packages/business-rules-lib/src/validators/__tests__/contact.validators.spec.js
@@ -304,8 +304,8 @@ describe('contact validators', () => {
     })
 
     it('throws where the premises exceeds the maximum allowed length', async () => {
-      await expect(contactValidation.createPremisesValidator(Joi).validateAsync('A'.repeat(101))).rejects.toThrow(
-        '"value" length must be less than or equal to 100 characters long'
+      await expect(contactValidation.createPremisesValidator(Joi).validateAsync('A'.repeat(51))).rejects.toThrow(
+        '"value" length must be less than or equal to 50 characters long'
       )
     })
   })

--- a/packages/business-rules-lib/src/validators/contact.validators.js
+++ b/packages/business-rules-lib/src/validators/contact.validators.js
@@ -109,8 +109,7 @@ export const createMobilePhoneValidator = joi => joi.string().trim().pattern(mob
  * @param {Joi.Root} joi the joi validator used by the consuming project
  * @returns {Joi.StringSchema}
  */
-export const createPremisesValidator = joi =>
-  joi.string().trim().min(1).max(100).external(toTitleCase()).required().example('Example House')
+export const createPremisesValidator = joi => joi.string().trim().min(1).max(50).external(toTitleCase()).required().example('Example House')
 
 /**
  * Create a validator to check a contact's address street


### PR DESCRIPTION
…ddress page

https://eaflood.atlassian.net/browse/IWTF-2967

The max character validation error is not showing when user exceeds 50 characters.