### PR TITLE
Pass current language to GOV.UK Pay API

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
@@ -118,33 +118,14 @@ describe('preparePayment', () => {
     expect(ret).toEqual(returnValue)
   })
 
-  describe('provides the correct language', () => {
-    it('when the language is set to Welsh', () => {
-      addLanguageCodeToUri.mockReturnValue('https://localhost:1234/buy/agreed?lang=cy')
-
-      const result = preparePayment(request, transaction)
-      const ret = result.language
-
-      expect(ret).toEqual('cy')
-    })
-
-    it('when the language is set to English', () => {
-      addLanguageCodeToUri.mockReturnValue('https://localhost:1234/buy/agreed?lang=en')
-
-      const result = preparePayment(request, transaction)
-      const ret = result.language
-
-      expect(ret).toEqual('en')
-    })
-
-    it('when the language is not set', () => {
-      addLanguageCodeToUri.mockReturnValue('https://localhost:1234/buy/agreed')
-
-      const result = preparePayment(request, transaction)
-      const ret = result.language
-
-      expect(ret).toEqual('en')
-    })
+  it.each([
+    ['when the language is set to Welsh', 'https://localhost:1234/buy/agreed?lang=cy', 'cy'],
+    ['when the language is set to English', 'https://localhost:1234/buy/agreed?lang=en', 'en'],
+    ['when the language is not set', 'https://localhost:1234/buy/agreed', 'en']
+  ])('provides the correct language %s', (_desc, decoratedUrl, expectedLanguageCode) => {
+    addLanguageCodeToUri.mockReturnValue(decoratedUrl)
+    const result = preparePayment(request, transaction)
+    expect(result.language).toEqual(expectedLanguageCode)
   })
 
   describe('provides the correct description', () => {

--- a/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
@@ -118,6 +118,35 @@ describe('preparePayment', () => {
     expect(ret).toEqual(returnValue)
   })
 
+  describe('provides the correct language', () => {
+    it('when the language is set to Welsh', () => {
+      addLanguageCodeToUri.mockReturnValue('https://localhost:1234/buy/agreed?lang=cy')
+
+      const result = preparePayment(request, transaction)
+      const ret = result.language
+
+      expect(ret).toEqual('cy')
+    })
+
+    it('when the language is set to English', () => {
+      addLanguageCodeToUri.mockReturnValue('https://localhost:1234/buy/agreed?lang=en')
+
+      const result = preparePayment(request, transaction)
+      const ret = result.language
+
+      expect(ret).toEqual('en')
+    })
+
+    it('when the language is not set', () => {
+      addLanguageCodeToUri.mockReturnValue('https://localhost:1234/buy/agreed')
+
+      const result = preparePayment(request, transaction)
+      const ret = result.language
+
+      expect(ret).toEqual('en')
+    })
+  })
+
   describe('provides the correct description', () => {
     it('when there is only 1 permission', () => {
       expect(result.description).toBe('Trout and coarse, up to 2 rods, 8 day')

--- a/packages/gafl-webapp-service/src/processors/payment.js
+++ b/packages/gafl-webapp-service/src/processors/payment.js
@@ -30,7 +30,8 @@ export const preparePayment = (request, transaction) => {
         ? licenceTypeAndLengthDisplay(transaction.permissions[0], request.i18n.getCatalog())
         : 'Multiple permits',
     delayed_capture: false,
-    moto: process.env.CHANNEL === 'telesales'
+    moto: process.env.CHANNEL === 'telesales',
+    language: /\?.*lang=cy.*$/.test(url.search) ? 'cy' : 'en'
   }
 
   if (transaction.permissions.length === 1) {

--- a/packages/gafl-webapp-service/src/services/payment/__test__/govuk-pay-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/payment/__test__/govuk-pay-service.spec.js
@@ -72,6 +72,7 @@ describe('The govuk-pay-service', () => {
       reference: '44728b47-c809-4c31-8c92-bdf961be0c80',
       return_url: 'https://0.0.0.0:3000' + AGREED.uri,
       moto: false,
+      language: 'en',
       prefilled_cardholder_details: {
         cardholder_name: 'Graham Willis',
         billing_address: {
@@ -112,6 +113,7 @@ describe('The govuk-pay-service', () => {
       reference: '44728b47-c809-4c31-8c92-bdf961be0c80',
       return_url: 'https://0.0.0.0:3000' + AGREED.uri,
       moto: false,
+      language: 'en',
       prefilled_cardholder_details: {
         cardholder_name: 'Graham Willis',
         billing_address: {
@@ -136,7 +138,8 @@ describe('The govuk-pay-service', () => {
       description: 'Multiple permits',
       reference: '44728b47-c809-4c31-8c92-bdf961be0c80',
       return_url: 'https://0.0.0.0:3000' + AGREED.uri,
-      moto: false
+      moto: false,
+      language: 'en'
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2897

If the user has chosen to use the Welsh language for our service, it should also be used for GOV.UK Pay too.