### PR TITLE
Update end date and time rules for 12-month licences

### DIFF
--- a/packages/sales-api-service/src/services/__tests__/permissions.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/permissions.service.spec.js
@@ -46,18 +46,12 @@ describe('permissions service', () => {
           licensee: {
             firstName: 'Fester',
             lastName: 'Tester',
-            birthDate: moment(now)
-              .subtract(JUNIOR_MAX_AGE, 'years')
-              .format('YYYY-MM-DD')
+            birthDate: moment(now).subtract(JUNIOR_MAX_AGE, 'years').format('YYYY-MM-DD')
           }
         },
         'Telesales'
       )
-      const block1 = moment(now)
-        .add(1, 'hour')
-        .startOf('hour')
-        .add(1, 'year')
-        .format('HHDDMMYY')
+      const block1 = moment(now).add(1, 'year').subtract(1, 'day').endOf('day').format('HHDDMMYY')
       const expected = new RegExp(`^${block1}-1TS3FFT-[A-Z0-9]{5}[0-9]$`)
       expect(number).toMatch(expected)
     })
@@ -79,11 +73,7 @@ describe('permissions service', () => {
         },
         'Web Sales'
       )
-      const block1 = moment(now)
-        .add(1, 'hour')
-        .startOf('hour')
-        .add(1, 'day')
-        .format('HHDDMMYY')
+      const block1 = moment(now).add(1, 'hour').startOf('hour').add(1, 'day').format('HHDDMMYY')
       const expected = new RegExp(`^${block1}-2WC1JFT-[A-Z0-9]{5}[0-9]$`)
       expect(number).toMatch(expected)
     })
@@ -98,41 +88,27 @@ describe('permissions service', () => {
           licensee: {
             firstName: 'Fester',
             lastName: 'Tester',
-            birthDate: moment(now)
-              .subtract(SENIOR_MIN_AGE, 'years')
-              .format('YYYY-MM-DD')
+            birthDate: moment(now).subtract(SENIOR_MIN_AGE, 'years').format('YYYY-MM-DD')
           }
         },
         'Web Sales'
       )
-      const block1 = moment(now)
-        .add(1, 'hour')
-        .startOf('hour')
-        .add(1, 'day')
-        .format('HHDDMMYY')
+      const block1 = moment(now).add(1, 'hour').startOf('hour').add(1, 'day').format('HHDDMMYY')
       const expected = new RegExp(`^${block1}-2WC1SFT-[A-Z0-9]{5}[0-9]$`)
       expect(number).toMatch(expected)
     })
   })
 
   describe('calculateEndDate', () => {
-    it('calculates 365 days for 1 year licences outside of a leap year', async () => {
+    it('calculates 364 days for 1 year licences outside of a leap year', async () => {
       const startDate = moment('2019-01-01')
       const endDate = await calculateEndDate({ permitId: 'e11b34a0-0c66-e611-80dc-c4346bad0190', startDate: startDate })
-      expect(endDate).toEqual(
-        moment(startDate)
-          .add(365, 'days')
-          .toISOString()
-      )
+      expect(endDate).toEqual(moment(startDate).add(364, 'days').endOf('day').toISOString())
     })
-    it('calculates 366 days for 1 year licences in a leap year', async () => {
+    it('calculates 365 days for 1 year licences in a leap year', async () => {
       const startDate = moment('2020-01-01')
       const endDate = await calculateEndDate({ permitId: 'e11b34a0-0c66-e611-80dc-c4346bad0190', startDate: startDate })
-      expect(endDate).toEqual(
-        moment(startDate)
-          .add(366, 'days')
-          .toISOString()
-      )
+      expect(endDate).toEqual(moment(startDate).add(365, 'days').endOf('day').toISOString())
     })
   })
 

--- a/packages/sales-api-service/src/services/__tests__/permissions.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/permissions.service.spec.js
@@ -102,13 +102,17 @@ describe('permissions service', () => {
   describe('calculateEndDate', () => {
     it('calculates 364 days for 1 year licences outside of a leap year', async () => {
       const startDate = moment('2019-01-01')
+      const expectedEndDate = moment('2019-12-31').endOf('day')
+
       const endDate = await calculateEndDate({ permitId: 'e11b34a0-0c66-e611-80dc-c4346bad0190', startDate: startDate })
-      expect(endDate).toEqual(moment(startDate).add(364, 'days').endOf('day').toISOString())
+      expect(endDate).toEqual(expectedEndDate.toISOString())
     })
     it('calculates 365 days for 1 year licences in a leap year', async () => {
       const startDate = moment('2020-01-01')
+      const expectedEndDate = moment('2020-12-31').endOf('day')
+
       const endDate = await calculateEndDate({ permitId: 'e11b34a0-0c66-e611-80dc-c4346bad0190', startDate: startDate })
-      expect(endDate).toEqual(moment(startDate).add(365, 'days').endOf('day').toISOString())
+      expect(endDate).toEqual(expectedEndDate.toISOString())
     })
   })
 

--- a/packages/sales-api-service/src/services/permissions.service.js
+++ b/packages/sales-api-service/src/services/permissions.service.js
@@ -31,9 +31,10 @@ export const generatePermissionNumber = async (
   const permit = await getReferenceDataForEntityAndId(Permit, permitId)
 
   const endDate = await calculateEndDateMoment({ permitId, startDate })
-  const endTime = moment(endDate)
-    .add(1, 'hour')
-    .startOf('hour')
+  const endTime =
+    permit.durationMagnitude === 12 && permit.durationDesignator.description === 'M'
+      ? moment(endDate)
+      : moment(endDate).add(1, 'hour').startOf('hour')
   const block1 = endTime.format('HH') + endDate.format('DDMMYY')
 
   const dataSourceOptionSetValue = await getGlobalOptionSetValue(Permission.definition.mappings.dataSource.ref, dataSource)
@@ -61,6 +62,9 @@ export const generatePermissionNumber = async (
 export const calculateEndDateMoment = async ({ permitId, startDate }) => {
   const permit = await getReferenceDataForEntityAndId(Permit, permitId)
   const duration = moment.duration(`P${permit.durationMagnitude}${permit.durationDesignator.description}`)
+  if (permit.durationMagnitude === 12 && permit.durationDesignator.description === 'M') {
+    return moment(startDate).add(duration).subtract(1, 'day').endOf('day')
+  }
   return moment(startDate).add(duration)
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2889

12-month licences should expire at 23:59 on the eve of the anniversary of purchase.

For example, if I bought a licence today on 1 August 2022, it would expire at 23:59 on 31 July 2023.