### PR TITLE
bugfix/iwtf 3011 renewal page dob fields require char limit

### DIFF
--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -37,19 +37,22 @@
       label: mssgs.dob_day,
       name: "day",
       classes: "govuk-input--width-2",
-      value: payload['date-of-birth-day']
+      value: payload['date-of-birth-day'],
+      attributes: { maxlength : 2 }
     },
     {
       label: mssgs.dob_month,
       name: "month",
       classes: "govuk-input--width-2",
-      value: payload['date-of-birth-month']
+      value: payload['date-of-birth-month'],
+      attributes: { maxlength : 2 }
     },
     {
       label: mssgs.dob_year,
       name: "year",
       classes: "govuk-input--width-4",
-      value: payload['date-of-birth-year']
+      value: payload['date-of-birth-year'],
+      attributes: { maxlength : 4 }
     }
   ]
 %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3011

The dob fields on the renewals identify page need char limits, as users can type too many.