### PR TITLE
Update welsh translation for 'mobile phone'

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -255,7 +255,7 @@
   "important_info_contact_input_email_hint": "Er enghraifft enw@enghraifft.com",
   "important_info_contact_input_email": "Cyfeiriad e-bost",
   "important_info_contact_input_mobile_hint": "Er enghraifft 07700 900 900",
-  "important_info_contact_input_mobile_note": "Mobile phone number",
+  "important_info_contact_input_mobile_note": "Rhif ffôn symudol",
   "important_info_contact_input_mobile": "Rhif ffôn symudol yn y DU",
   "important_info_contact_item_email": "E-bost",
   "important_info_contact_item_txt": "Neges destun",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3021

The welsh translation for mobile phone is missing on multiple pages. This is set by a label in the cy.json file, so this requires updating to update all pages.