### PR TITLE
Language doesn't persist on Renewals licence start

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
@@ -37,6 +37,7 @@ export default async (request, h) => {
 
   const licenceStartDate = `${payload['licence-start-date-year']}-${payload['licence-start-date-month']}-${payload['licence-start-date-day']}`
   const result = schema.validate({ 'licence-start-date': licenceStartDate })
+
   if (result.error) {
     await request.cache().helpers.page.setCurrentPermission(RENEWAL_START_DATE.page, { payload, error: errorShimm(result.error) })
     await request

--- a/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
@@ -8,6 +8,7 @@ import JoiDate from '@hapi/joi-date'
 import { ageConcessionHelper } from '../processors/concession-helper.js'
 import { licenceToStart } from '../pages/licence-details/licence-to-start/update-transaction.js'
 import { cacheDateFormat } from '../processors/date-and-time-display.js'
+import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 
 const JoiX = Joi.extend(JoiDate)
 /**
@@ -36,13 +37,12 @@ export default async (request, h) => {
 
   const licenceStartDate = `${payload['licence-start-date-year']}-${payload['licence-start-date-month']}-${payload['licence-start-date-day']}`
   const result = schema.validate({ 'licence-start-date': licenceStartDate })
-
   if (result.error) {
     await request.cache().helpers.page.setCurrentPermission(RENEWAL_START_DATE.page, { payload, error: errorShimm(result.error) })
     await request
       .cache()
       .helpers.status.setCurrentPermission({ [RENEWAL_START_DATE.page]: PAGE_STATE.error, currentPage: RENEWAL_START_DATE.page })
-    return h.redirect(RENEWAL_START_DATE.uri)
+    return h.redirect(addLanguageCodeToUri(request, RENEWAL_START_DATE.uri))
   } else {
     permission.licenceStartDate = moment({
       year: payload['licence-start-date-year'],
@@ -69,6 +69,6 @@ export default async (request, h) => {
 
     ageConcessionHelper(permission)
     await request.cache().helpers.transaction.setCurrentPermission(permission)
-    return h.redirect(LICENCE_SUMMARY.uri)
+    return h.redirect(addLanguageCodeToUri(request, LICENCE_SUMMARY.uri))
   }
 }

--- a/packages/gafl-webapp-service/src/pages/renewals/renewal-start-date/__tests__/renewal-start-date.next-page.spec.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/renewal-start-date/__tests__/renewal-start-date.next-page.spec.js
@@ -1,0 +1,49 @@
+import pageRoute from '../../../../routes/page-route.js'
+import { RENEWAL_START_VALIDATE } from '../../../../uri.js'
+import { addLanguageCodeToUri } from '../../../../processors/uri-helper.js'
+require('../route.js') // require rather than import to avoid lint error with unused variable
+
+jest.mock('../../../../routes/page-route.js', () => jest.fn())
+jest.mock('../../../../uri.js', () => ({
+  RENEWAL_START_DATE: { page: 'renewal start date page', uri: 'renewal start date uri' },
+  RENEWAL_START_VALIDATE: { uri: Symbol('renewal start validate uri') }
+}))
+jest.mock('../../../../processors/uri-helper.js')
+
+describe('page route next', () => {
+  const nextPage = pageRoute.mock.calls[0][3]
+  beforeEach(jest.clearAllMocks)
+
+  it('passes a function as the nextPage argument', () => {
+    expect(typeof (nextPage)).toBe('function')
+  })
+
+  it('calls addLanguageCodeToUri', () => {
+    nextPage()
+    expect(addLanguageCodeToUri).toHaveBeenCalled()
+  })
+
+  it('passes request to addLanguageCodeToUri', () => {
+    const request = Symbol('request')
+    nextPage(request)
+    expect(addLanguageCodeToUri).toHaveBeenCalledWith(
+      request,
+      expect.anything()
+    )
+  })
+
+  it('passes RENEWAL_START_VALIDATE to addLangaugeCodeToUri', () => {
+    const request = Symbol('request')
+    nextPage(request)
+    expect(addLanguageCodeToUri).toHaveBeenCalledWith(
+      expect.anything(),
+      RENEWAL_START_VALIDATE.uri
+    )
+  })
+
+  it('next page returns result of addLanguageCodeToUri', () => {
+    const expectedResult = Symbol('add language code to uri')
+    addLanguageCodeToUri.mockReturnValueOnce(expectedResult)
+    expect(nextPage()).toBe(expectedResult)
+  })
+})

--- a/packages/gafl-webapp-service/src/pages/renewals/renewal-start-date/__tests__/renewal-start-date.next-page.spec.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/renewal-start-date/__tests__/renewal-start-date.next-page.spec.js
@@ -15,7 +15,7 @@ describe('page route next', () => {
   beforeEach(jest.clearAllMocks)
 
   it('passes a function as the nextPage argument', () => {
-    expect(typeof (nextPage)).toBe('function')
+    expect(typeof nextPage).toBe('function')
   })
 
   it('calls addLanguageCodeToUri', () => {
@@ -26,19 +26,13 @@ describe('page route next', () => {
   it('passes request to addLanguageCodeToUri', () => {
     const request = Symbol('request')
     nextPage(request)
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(
-      request,
-      expect.anything()
-    )
+    expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, expect.anything())
   })
 
   it('passes RENEWAL_START_VALIDATE to addLangaugeCodeToUri', () => {
     const request = Symbol('request')
     nextPage(request)
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(
-      expect.anything(),
-      RENEWAL_START_VALIDATE.uri
-    )
+    expect(addLanguageCodeToUri).toHaveBeenCalledWith(expect.anything(), RENEWAL_START_VALIDATE.uri)
   })
 
   it('next page returns result of addLanguageCodeToUri', () => {

--- a/packages/gafl-webapp-service/src/pages/renewals/renewal-start-date/route.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/renewal-start-date/route.js
@@ -6,6 +6,7 @@ import Joi from 'joi'
 import JoiDate from '@hapi/joi-date'
 import moment from 'moment-timezone'
 import { displayExpiryDate } from '../../../processors/date-and-time-display.js'
+import { addLanguageCodeToUri } from '../../../processors/uri-helper.js'
 const JoiX = Joi.extend(JoiDate)
 
 const validator = payload => {
@@ -33,4 +34,10 @@ const getData = async request => {
   }
 }
 
-export default pageRoute(RENEWAL_START_DATE.page, RENEWAL_START_DATE.uri, validator, RENEWAL_START_VALIDATE.uri, getData)
+export default pageRoute(
+  RENEWAL_START_DATE.page,
+  RENEWAL_START_DATE.uri,
+  validator,
+  request => addLanguageCodeToUri(request, RENEWAL_START_VALIDATE.uri),
+  getData
+)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2995

When the Welsh langugage is selected and validation fails on the Renewals licence start page, the selected language isn't persisted and the page switches back to English