### PR TITLE
Keep selected language when clicking manual address link

### DIFF
--- a/packages/gafl-webapp-service/src/pages/contact/address/select/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/select/__tests__/route.spec.js
@@ -1,6 +1,6 @@
 import { getData } from '../route'
 import { addLanguageCodeToUri } from '../../../../../processors/uri-helper.js'
-import { ADDRESS_LOOKUP } from '../../../../../uri.js'
+import { ADDRESS_ENTRY, ADDRESS_LOOKUP } from '../../../../../uri.js'
 
 jest.mock('../../../../../processors/uri-helper.js')
 
@@ -67,6 +67,14 @@ describe('address-select > route', () => {
       await getData(mockRequest)
 
       expect(addLanguageCodeToUri).toHaveBeenCalledWith(mockRequest, ADDRESS_LOOKUP.uri)
+    })
+
+    it('addLanguageCodeToUri is called with the expected arguments for manual address entry', async () => {
+      mockTransactionCacheGet.mockImplementationOnce(() => ({ isLicenceForYou: true }))
+
+      await getData(mockRequest)
+
+      expect(addLanguageCodeToUri).toHaveBeenCalledWith(mockRequest, ADDRESS_ENTRY.uri)
     })
   })
 })

--- a/packages/gafl-webapp-service/src/pages/contact/address/select/route.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/select/route.js
@@ -13,7 +13,7 @@ export const getData = async request => {
     addresses,
     searchTerms,
     lookupPage: addLanguageCodeToUri(request, ADDRESS_LOOKUP.uri),
-    entryPage: ADDRESS_ENTRY.uri
+    entryPage: addLanguageCodeToUri(request, ADDRESS_ENTRY.uri)
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2977

The link from the address selection page to manually enter an address would previously default to English. This PR fixes that issue so the user can continue to use the service in their preferred language.