### PR TITLE
Fix Welsh heading for licence type page

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -390,7 +390,7 @@
   "licence_type_salmon_acr_warning": "Bydd angen i chi gyflwyno ffurflen dalfa flynyddol",
   "licence_type_salmon_junior": "You’ll only need this licence if you are specifically fishing for salmon or sea trout.",
   "licence_type_title_other": "Pa fath o drwydded yr hoffent ei chael?",
-  "licence_type_title_you": "Pa fath o drwydded hoffech chi ei chael?",
+  "licence_type_title_you": "Pa drwydded hoffech chi ei chael?",
   "licence_type_troute_three_rod": "Dim ond trwydded tair gwialen y bydd ei hangen arnoch os ydych yn bwriadu pysgota â thair gwialen ar yr un pryd. Gall hyn fod ar gyfer pysgota cerpynnod arbenigol, er enghraifft. Bydd hyn yn addas ar gyfer pob math o bysgota â gwialen ac yn gadael i chi bysgota brithyllod anfudol a physgod bras, yn amodol ar y ",
   "licence_type_troute_two_rod": "Y drwydded pysgod bras â dwy wialen yw’r drwydded wialen symlaf. Bydd hyn yn eich gwarchod ar gyfer pob math o bysgota gyda gwialen ac yn gadael i chi bysgota brithyllod anfudol a physgod bras. Bydd yn caniatáu i chi bysgota gydag un neu ddwy wialen ar yr un pryd, yn amodol ar y ",
   "name_abbr_hint": "Peidiwch â defnyddio byrfoddau na llysenwau",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3044

This fixes a heading change which was accidentally reverted.