### PR TITLE
Hide analytics banner on licence details page

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -4,7 +4,7 @@ import journeyDefinition from '../../routes/journey-definition.js'
 import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
 import GetDataRedirect from '../get-data-redirect.js'
 import { ANALYTICS } from '../../constants.js'
-import { AGREED, ORDER_COMPLETE, PAYMENT_CANCELLED, PAYMENT_FAILED } from '../../uri.js'
+import { AGREED, LICENCE_DETAILS, ORDER_COMPLETE, PAYMENT_CANCELLED, PAYMENT_FAILED } from '../../uri.js'
 
 jest.mock('debug', () => jest.fn(() => jest.fn()))
 jest.mock('../../routes/journey-definition.js', () => [])
@@ -21,6 +21,7 @@ jest.mock('../../constants', () => ({
 
 jest.mock('../../uri.js', () => ({
   AGREED: { uri: '/buy/agreed/page' },
+  LICENCE_DETAILS: { uri: '/buy/licence/details' },
   ORDER_COMPLETE: { uri: '/buy/order/complete/page' },
   PAYMENT_CANCELLED: { uri: '/buy/payment/cancelled/page' },
   PAYMENT_FAILED: { uri: '/buy/payment/failed/page' },
@@ -209,7 +210,8 @@ describe('The page handler function', () => {
     ['payment cancelled', PAYMENT_CANCELLED.uri],
     ['payment failed', PAYMENT_FAILED.uri],
     ['agreed', AGREED.uri],
-    ['order complete', ORDER_COMPLETE.uri]
+    ['order complete', ORDER_COMPLETE.uri],
+    ['licence details', LICENCE_DETAILS.uri]
   ])('hides the analytics banner for %s page', async (_pageLabel, pageUri) => {
     const { get } = pageHandler('', 'view', '/next/page')
     const toolkit = getMockToolkit()

--- a/packages/gafl-webapp-service/src/handlers/page-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/page-handler.js
@@ -1,13 +1,21 @@
 import db from 'debug'
 import { CacheError } from '../session-cache/cache-manager.js'
 import { PAGE_STATE, ANALYTICS } from '../constants.js'
-import { AGREED, CONTROLLER, ORDER_COMPLETE, PAYMENT_CANCELLED, PAYMENT_FAILED, PROCESS_ANALYTICS_PREFERENCES } from '../uri.js'
+import {
+  AGREED,
+  CONTROLLER,
+  LICENCE_DETAILS,
+  ORDER_COMPLETE,
+  PAYMENT_CANCELLED,
+  PAYMENT_FAILED,
+  PROCESS_ANALYTICS_PREFERENCES
+} from '../uri.js'
 import GetDataRedirect from './get-data-redirect.js'
 import journeyDefinition from '../routes/journey-definition.js'
 import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 
 const debug = db('webapp:page-handler')
-const pagesToOmitAnalyticsBanner = [AGREED.uri, ORDER_COMPLETE.uri, PAYMENT_CANCELLED.uri, PAYMENT_FAILED.uri]
+const pagesToOmitAnalyticsBanner = [AGREED.uri, LICENCE_DETAILS.uri, ORDER_COMPLETE.uri, PAYMENT_CANCELLED.uri, PAYMENT_FAILED.uri]
 
 const displayAnalytics = request => {
   if (pagesToOmitAnalyticsBanner.includes(request.path)) {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3083

The licence details page (accessed from the payment confirmation page) has the analytics banner, when it should be hidden