### PR TITLE
Use chosen language when moving from renewals to new licence journey

### DIFF
--- a/packages/gafl-webapp-service/src/pages/renewals/identify/__tests__/identity.spec.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/__tests__/identity.spec.js
@@ -8,7 +8,8 @@ import {
   RENEWAL_PUBLIC,
   RENEWAL_INACTIVE,
   LICENCE_LENGTH,
-  CONTACT_SUMMARY
+  CONTACT_SUMMARY,
+  NEW_TRANSACTION
 } from '../../../../uri.js'
 import { start, stop, initialize, injectWithCookies, mockSalesApi } from '../../../../__mocks__/test-utils-system.js'
 
@@ -19,6 +20,9 @@ import { authenticationResult } from '../__mocks__/data/authentication-result.js
 import * as constants from '../../../../processors/mapping-constants.js'
 import { hasSenior } from '../../../../processors/concession-helper.js'
 import mockDefraCountries from '../../../../__mocks__/data/defra-country.js'
+import { addLanguageCodeToUri } from '../../../../processors/uri-helper.js'
+
+jest.mock('../../../../processors/uri-helper.js')
 
 beforeAll(() => {
   process.env.ANALYTICS_PRIMARY_PROPERTY = 'UA-123456789-0'
@@ -44,6 +48,8 @@ salesApi.countries.getAll = jest.fn(() => Promise.resolve(mockDefraCountries))
 
 describe('The easy renewal identification page', () => {
   it('redirects to identify page when called with an invalid permission reference', async () => {
+    addLanguageCodeToUri.mockReturnValue('/buy/renew/identify')
+
     const data = await injectWithCookies('GET', RENEWAL_PUBLIC.uri.replace('{referenceNumber}', 'not-a-valid-reference-number'))
     expect(data.statusCode).toBe(302)
     expect(data.headers.location).toBe(IDENTIFY.uri)
@@ -63,6 +69,8 @@ describe('The easy renewal identification page', () => {
   })
 
   it('redirects back to itself on posting an invalid postcode', async () => {
+    addLanguageCodeToUri.mockReturnValue('/buy/renew/identify')
+
     await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
     await injectWithCookies('GET', IDENTIFY.uri)
     const data = await injectWithCookies('POST', IDENTIFY.uri, Object.assign({ postcode: 'HHHHH' }, dobHelper(ADULT_TODAY)))
@@ -71,6 +79,8 @@ describe('The easy renewal identification page', () => {
   })
 
   it('redirects back to itself on posting an invalid data of birth', async () => {
+    addLanguageCodeToUri.mockReturnValue('/buy/renew/identify')
+
     await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
     await injectWithCookies('GET', IDENTIFY.uri)
     const data = await injectWithCookies('POST', IDENTIFY.uri, Object.assign({ postcode: 'BS9 1HJ' }, dobHelper(dobInvalid)))
@@ -79,6 +89,12 @@ describe('The easy renewal identification page', () => {
   })
 
   it('redirects back to itself on posting an valid but not authenticated details', async () => {
+    addLanguageCodeToUri
+      .mockReturnValueOnce('/buy/renew/authenticate')
+      .mockReturnValueOnce('/buy/renew/identify')
+      .mockReturnValueOnce('/buy/renew/authenticate')
+      .mockReturnValueOnce('/buy/renew/identify')
+
     salesApi.authenticate.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(null))))
     await injectWithCookies('GET', VALID_RENEWAL_PUBLIC_URI)
     await injectWithCookies('GET', IDENTIFY.uri)
@@ -96,37 +112,104 @@ describe('The easy renewal identification page', () => {
     expect(data3.statusCode).toBe(200)
   })
 
-  it.each([
+  describe.each([
     ['email', constants.HOW_CONTACTED.email],
     ['text', constants.HOW_CONTACTED.text],
     ['none', constants.HOW_CONTACTED.none],
     ['letter', constants.HOW_CONTACTED.letter]
-  ])('redirects to the controller on posting a valid response - (how contacted=%s), and shows both summary pages', async (name, fn) => {
-    const newAuthenticationResult = Object.assign({}, authenticationResult)
-    newAuthenticationResult.permission.licensee.preferredMethodOfConfirmation.label = fn
-    newAuthenticationResult.permission.endDate = moment().startOf('day').toISOString()
-    salesApi.authenticate.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult))))
+  ])('valid response - (how contacted=%s)', (name, fn) => {
+    beforeEach(async () => {
+      const newAuthenticationResult = Object.assign({}, authenticationResult)
+      newAuthenticationResult.permission.licensee.preferredMethodOfConfirmation.label = fn
+      newAuthenticationResult.permission.endDate = moment().startOf('day').toISOString()
+      salesApi.authenticate.mockImplementation(jest.fn(async () => new Promise(resolve => resolve(newAuthenticationResult))))
 
-    await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
-    await injectWithCookies('GET', IDENTIFY.uri)
-    const data = await injectWithCookies(
-      'POST',
-      IDENTIFY.uri,
-      Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
-    )
-    expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(AUTHENTICATE.uri)
+      await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
+      await injectWithCookies('GET', IDENTIFY.uri)
+    })
 
-    const data2 = await injectWithCookies('GET', AUTHENTICATE.uri)
-    expect(data2.statusCode).toBe(302)
-    expect(data2.headers.location).toBe(CONTROLLER.uri)
-    await injectWithCookies('GET', CONTROLLER.uri)
+    it('returns a 302 status code on a POST request to the identify uri', async () => {
+      const data = await injectWithCookies(
+        'POST',
+        IDENTIFY.uri,
+        Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
+      )
+      expect(data.statusCode).toBe(302)
+    })
 
-    const data4 = await injectWithCookies('GET', LICENCE_SUMMARY.uri)
-    expect(data4.statusCode).toBe(200)
+    it('redirects to the authentication uri on a POST request to the identify uri', async () => {
+      addLanguageCodeToUri.mockReturnValueOnce('/buy/renew/authenticate')
 
-    const data5 = await injectWithCookies('GET', CONTACT_SUMMARY.uri)
-    expect(data5.statusCode).toBe(200)
+      const data = await injectWithCookies(
+        'POST',
+        IDENTIFY.uri,
+        Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
+      )
+      expect(data.headers.location).toBe(AUTHENTICATE.uri)
+    })
+
+    it('returns a 302 status code on a GET request to the authenticate uri', async () => {
+      await injectWithCookies(
+        'POST',
+        IDENTIFY.uri,
+        Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
+      )
+      const data = await injectWithCookies('GET', AUTHENTICATE.uri)
+      expect(data.statusCode).toBe(302)
+    })
+
+    it('redirects to the controller uri on a GET request to the authenticate uri', async () => {
+      addLanguageCodeToUri.mockReturnValue('/buy')
+
+      await injectWithCookies(
+        'POST',
+        IDENTIFY.uri,
+        Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
+      )
+      const data = await injectWithCookies('GET', AUTHENTICATE.uri)
+      expect(data.headers.location).toBe(CONTROLLER.uri)
+    })
+
+    it('returns a 200 status code on a GET request to the licence summary', async () => {
+      await injectWithCookies(
+        'POST',
+        IDENTIFY.uri,
+        Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
+      )
+      await injectWithCookies('GET', AUTHENTICATE.uri)
+      await injectWithCookies('GET', CONTROLLER.uri)
+
+      const data = await injectWithCookies('GET', LICENCE_SUMMARY.uri)
+
+      expect(data.statusCode).toBe(200)
+    })
+
+    it('returns a 200 status code on a GET request to the contact summary', async () => {
+      await injectWithCookies(
+        'POST',
+        IDENTIFY.uri,
+        Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
+      )
+      await injectWithCookies('GET', AUTHENTICATE.uri)
+      await injectWithCookies('GET', CONTROLLER.uri)
+      await injectWithCookies('GET', LICENCE_SUMMARY.uri)
+
+      const data = await injectWithCookies('GET', CONTACT_SUMMARY.uri)
+
+      expect(data.statusCode).toBe(200)
+    })
+
+    it('calls addLanguageCodeToUri', async () => {
+      addLanguageCodeToUri.mockReturnValueOnce('/buy/new')
+
+      await injectWithCookies(
+        'POST',
+        IDENTIFY.uri,
+        Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
+      )
+
+      expect(addLanguageCodeToUri).toHaveBeenCalledWith(expect.anything(), NEW_TRANSACTION.uri)
+    })
   })
 
   const salmonAndSeaTroutPermitSubtype = {
@@ -187,6 +270,15 @@ describe('The easy renewal identification page', () => {
   })
 
   it('that an expiry too far in the future causes a redirect to the invalid renewal page', async () => {
+    addLanguageCodeToUri
+      .mockReturnValueOnce('/buy/renew/authenticate')
+      .mockReturnValueOnce('/buy/renew/authenticate')
+      .mockReturnValueOnce('/buy/renew/authenticate')
+      .mockReturnValueOnce('/buy/renew/inactive')
+      .mockReturnValueOnce('/buy/renew/inactive')
+      .mockReturnValueOnce('/buy/renew/inactive')
+      .mockReturnValueOnce('/buy/licence-length')
+
     const newAuthenticationResult = Object.assign({}, authenticationResult)
     newAuthenticationResult.permission.endDate = moment()
       .startOf('day')
@@ -210,6 +302,8 @@ describe('The easy renewal identification page', () => {
   })
 
   it('that an expiry that has expired causes a redirect to the invalid renewal page', async () => {
+    addLanguageCodeToUri.mockReturnValue('/buy/renew/inactive')
+
     const newAuthenticationResult = Object.assign({}, authenticationResult)
     newAuthenticationResult.permission.endDate = moment()
       .startOf('day')
@@ -225,6 +319,8 @@ describe('The easy renewal identification page', () => {
   })
 
   it('that an expiry for a 1 or 8 day licence causes a redirect to the invalid renewal page', async () => {
+    addLanguageCodeToUri.mockReturnValue('/buy/renew/inactive')
+
     const newAuthenticationResult = Object.assign({}, authenticationResult)
     newAuthenticationResult.permission.permit.durationMagnitude = 1
     newAuthenticationResult.permission.permit.durationDesignator.description = 'D'

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/route.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/route.js
@@ -23,7 +23,7 @@ const getData = async request => {
   return {
     referenceNumber: permission.referenceNumber,
     uri: {
-      new: NEW_TRANSACTION.uri
+      new: addLanguageCodeToUri(request, NEW_TRANSACTION.uri)
     }
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2899

The "get a new fishing licence" link from the renewals journey was not persisting the user's chosen language - for example, if the user had previously selected Welsh, the link swapped them back to English. This PR fixes that.

It also includes some test refactoring to break up some of the tests to be a bit more granular.