### PR TITLE
Analytics Banner 500 error

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -220,9 +220,24 @@ describe('The page handler function', () => {
     const pageData = toolkit.view.mock.calls[0][1]
     expect(pageData.displayAnalytics).toBeFalsy()
   })
+
+  it.only('sets analytics values to default values if analytics key is not set', async () => {
+    const { get } = pageHandler('', 'view', '/next/page')
+    const toolkit = getMockToolkit()
+    const mockRequest = getMockRequest(null, '/current/page', false)
+    await get(mockRequest, toolkit)
+    const pageData = toolkit.view.mock.calls[0][1]
+    expect(pageData).toEqual(
+      expect.objectContaining({
+        analyticsMessageDisplayed: false,
+        analyticsSelected: false,
+        acceptedTracking: false
+      })
+    )
+  })
 })
 
-const getMockRequest = (setCurrentPermission = () => {}, path = '/buy/we/are/here') => ({
+const getMockRequest = (setCurrentPermission = () => {}, path = '/buy/we/are/here', includeAnalytics = true) => ({
   cache: () => ({
     helpers: {
       page: {
@@ -237,11 +252,14 @@ const getMockRequest = (setCurrentPermission = () => {}, path = '/buy/we/are/her
         getCurrentPermission: () => {}
       },
       analytics: {
-        get: () => ({
-          [ANALYTICS.selected]: 'selected',
-          [ANALYTICS.acceptTracking]: 'accepted-tracking',
-          [ANALYTICS.seenMessage]: 'seen-message'
-        })
+        get: () =>
+          includeAnalytics
+            ? ({
+                [ANALYTICS.selected]: 'selected',
+                [ANALYTICS.acceptTracking]: 'accepted-tracking',
+                [ANALYTICS.seenMessage]: 'seen-message'
+              })
+            : undefined
       }
     }
   }),

--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -221,7 +221,7 @@ describe('The page handler function', () => {
     expect(pageData.displayAnalytics).toBeFalsy()
   })
 
-  it.only('sets analytics values to default values if analytics key is not set', async () => {
+  it('sets analytics values to default values if analytics key is not set', async () => {
     const { get } = pageHandler('', 'view', '/next/page')
     const toolkit = getMockToolkit()
     const mockRequest = getMockRequest(null, '/current/page', false)
@@ -254,11 +254,11 @@ const getMockRequest = (setCurrentPermission = () => {}, path = '/buy/we/are/her
       analytics: {
         get: () =>
           includeAnalytics
-            ? ({
+            ? {
                 [ANALYTICS.selected]: 'selected',
                 [ANALYTICS.acceptTracking]: 'accepted-tracking',
                 [ANALYTICS.seenMessage]: 'seen-message'
-              })
+              }
             : undefined
       }
     }

--- a/packages/gafl-webapp-service/src/handlers/page-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/page-handler.js
@@ -127,10 +127,9 @@ export default (path, view, completion, getData) => ({
     pageData.uri = { ...(pageData.uri || {}), analyticsFormAction: addLanguageCodeToUri(request, PROCESS_ANALYTICS_PREFERENCES.uri) }
 
     const analytics = await request.cache().helpers.analytics.get()
-
-    pageData.analyticsMessageDisplayed = analytics[ANALYTICS.seenMessage]
-    pageData.analyticsSelected = analytics[ANALYTICS.selected]
-    pageData.acceptedTracking = analytics[ANALYTICS.acceptTracking]
+    pageData.analyticsMessageDisplayed = analytics ? analytics[ANALYTICS.seenMessage] : false
+    pageData.analyticsSelected = analytics ? analytics[ANALYTICS.selected] : false
+    pageData.acceptedTracking = analytics ? analytics[ANALYTICS.acceptTracking] : false
 
     pageData.displayAnalytics = displayAnalytics(request)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3094

We assume that the analytics values are set in the cache by the time the page is about to be displayed, but some errors are occurring to indicate that this is not the case. We need to code more defensively to account for this