### PR TITLE
View licence page missing '30 minutes after payment' in start date

### DIFF
--- a/packages/gafl-webapp-service/src/__mocks__/request.js
+++ b/packages/gafl-webapp-service/src/__mocks__/request.js
@@ -5,7 +5,7 @@ const createCache = (cache = {}) => ({
       set: cache.status?.set || (() => {})
     },
     transaction: {
-      getCurrentPermission: () => cache.permissions || {},
+      getCurrentPermission: () => cache.transaction?.permissions[0] || {},
       get: () => cache.transaction || { permissions: [] }
     }
   }

--- a/packages/gafl-webapp-service/src/__mocks__/request.js
+++ b/packages/gafl-webapp-service/src/__mocks__/request.js
@@ -5,6 +5,7 @@ const createCache = (cache = {}) => ({
       set: cache.status?.set || (() => {})
     },
     transaction: {
+      getCurrentPermission: () => cache.permissions || {},
       get: () => cache.transaction || { permissions: [] }
     }
   }

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/__snapshots__/route.spec.js.snap
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/__snapshots__/route.spec.js.snap
@@ -12,7 +12,18 @@ Object {
       "type": "Trout and coarse, up to 2 rods",
     },
   ],
-  "permission": Object {},
+  "permission": Object {
+    "licenceLength": "8D",
+    "licenceType": "trout-and-coarse",
+    "licensee": Object {
+      "firstName": "Turanga",
+      "lastName": "Leela",
+    },
+    "numberOfRods": "2",
+    "permit": Object {
+      "cost": 12,
+    },
+  },
   "startAfterPaymentMinutes": 4000,
 }
 `;

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/__snapshots__/route.spec.js.snap
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/__snapshots__/route.spec.js.snap
@@ -13,6 +13,6 @@ Object {
     },
   ],
   "permission": Object {},
-  "startAfterPaymentMinutes": 30,
+  "startAfterPaymentMinutes": 4000,
 }
 `;

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/__snapshots__/route.spec.js.snap
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/__snapshots__/route.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`view licences > getData getData returns permissions, licences and text for start after minutes text 1`] = `
+Object {
+  "licences": Array [
+    Object {
+      "index": 0,
+      "length": "8 days",
+      "licenceHolder": "Turanga Leela",
+      "price": 12,
+      "start": "9:32am on 23 June 2021",
+      "type": "Trout and coarse, up to 2 rods",
+    },
+  ],
+  "permission": Object {},
+  "startAfterPaymentMinutes": 30,
+}
+`;

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
@@ -7,8 +7,6 @@ import constants from '@defra-fish/business-rules-lib'
 import { licenceTypeDisplay, licenceTypeAndLengthDisplay } from '../../../../processors/licence-type-display.js'
 import { displayStartTime } from '../../../../processors/date-and-time-display.js'
 
-// const mockStartAfterValue = null
-
 jest.mock('../../../../processors/licence-type-display.js')
 jest.mock('../../../../processors/date-and-time-display.js')
 jest.mock('../../../../routes/page-route.js')

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
@@ -98,6 +98,26 @@ describe('view licences > getData', () => {
       }
     }
 
+    it('returns permissions, licences and text for start after minutes text', async () => {
+      const res = await getData(sampleRequest)
+      expect(res).toEqual(
+        expect.objectContaining({
+          licences: [
+            {
+              index: 0,
+              length: '8 days',
+              licenceHolder: 'Turanga Leela',
+              price: 12,
+              start: '9:32am on 23 June 2021',
+              type: 'Trout and coarse, up to 2 rods'
+            }
+          ],
+          permission: {},
+          startAfterPaymentMinutes: 30
+        })
+      )
+    })
+
     it('licenceTypeDisplay is called with the expected arguments', async () => {
       await getData(sampleRequest)
 

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
@@ -100,22 +100,7 @@ describe('view licences > getData', () => {
 
     it('returns permissions, licences and text for start after minutes text', async () => {
       const res = await getData(sampleRequest)
-      expect(res).toEqual(
-        expect.objectContaining({
-          licences: [
-            {
-              index: 0,
-              length: '8 days',
-              licenceHolder: 'Turanga Leela',
-              price: 12,
-              start: '9:32am on 23 June 2021',
-              type: 'Trout and coarse, up to 2 rods'
-            }
-          ],
-          permission: {},
-          startAfterPaymentMinutes: 30
-        })
-      )
+      expect(res).toMatchSnapshot()
     })
 
     it('licenceTypeDisplay is called with the expected arguments', async () => {

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/route.js
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/route.js
@@ -4,9 +4,11 @@ import { VIEW_LICENCES } from '../../../uri.js'
 import { licenceTypeDisplay, licenceTypeAndLengthDisplay } from '../../../processors/licence-type-display.js'
 import { displayStartTime } from '../../../processors/date-and-time-display.js'
 import { nextPage } from '../../../routes/next-page.js'
+import { START_AFTER_PAYMENT_MINUTES } from '@defra-fish/business-rules-lib'
 
 export const getData = async request => {
   const transaction = await request.cache().helpers.transaction.get()
+  const permission = await request.cache().helpers.transaction.getCurrentPermission()
   const mssgs = request.i18n.getCatalog()
 
   const licences = transaction.permissions.map((permission, index) => ({
@@ -18,7 +20,11 @@ export const getData = async request => {
     index
   }))
 
-  return { licences }
+  return {
+    permission,
+    licences,
+    startAfterPaymentMinutes: START_AFTER_PAYMENT_MINUTES
+  }
 }
 
 export const validator = Joi.object({

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/view-licences.njk
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/view-licences.njk
@@ -12,14 +12,15 @@
     <div class="govuk-grid-column-two-thirds">
 
         <h1 class="govuk-heading-l"> {{ mssgs.multibuy_view_licences_title }} </h1>
-
           {% for licence in data.licences %}
 
               {% set licenceInfo = [
                 { key: { text: 'Licence holder' }, value: { text: licence.licenceHolder } }, 
                 { key: { text: 'Type' }, value: { text: licence.type } }, 
                 { key: { text: 'Length' }, value: { text: licence.length } }, 
-                { key: { text: 'Start' }, value: { text: licence.start } }, 
+                { key: { text: 'Start' }, 
+                  value: { html: data.startAfterPaymentMinutes + mssgs.licence_summary_minutes_after_payment if data.permission.licenceToStart === 'after-payment' else licence.start } 
+                }, 
                 { key: { text: 'Price' }, value: { text: '£' + licence.price } }
                 ]
               %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3002

The value for 'Start date' on the view licence page should display '30 minutes after payment' when this option has been selected.