### PR TITLE
GetDataRedirect test refactor

### DIFF
--- a/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/__tests__/route.spec.js
@@ -1,6 +1,5 @@
 import { CONTACT } from '../../../../../uri.js'
 import { getData } from '../route.js'
-import GetDataRedirect from '../../../../../handlers/get-data-redirect.js'
 
 describe('licence-confirmation-method > route', () => {
   describe('getData', () => {
@@ -25,9 +24,8 @@ describe('licence-confirmation-method > route', () => {
     beforeEach(jest.clearAllMocks)
 
     it('should reject and redirect to the contact page, if licence is not physical', async () => {
-      const getDataRedirectError = new GetDataRedirect(CONTACT.uri)
       const func = async () => await getData(createRequestMock({ licenceLength: '1D' }))
-      await expect(func).rejects.toThrow(getDataRedirectError)
+      await expect(func).rejects.toThrowRedirectTo(CONTACT.uri)
     })
 
     it('returns the expected data', async () => {

--- a/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-fulfilment/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-fulfilment/__tests__/route.spec.js
@@ -1,6 +1,5 @@
 import { getData } from '../route'
 import { CONTACT } from '../../../../../uri'
-import GetDataRedirect from '../../../../../handlers/get-data-redirect'
 
 describe('licence-fulfilment > route', () => {
   const mockTransactionCacheGet = jest.fn()
@@ -21,7 +20,7 @@ describe('licence-fulfilment > route', () => {
     it('should throw an error if the licence is not 12M', async () => {
       mockTransactionCacheGet.mockImplementationOnce(() => ({ licenceLength: '1D' }))
       const func = async () => await getData(mockRequest)
-      await expect(func).rejects.toThrow(new GetDataRedirect(CONTACT.uri))
+      await expect(func).rejects.toThrowRedirectTo(CONTACT.uri)
     })
     it('should return isLicenceForYou as true, if isLicenceForYou is true on the transaction cache', async () => {
       mockTransactionCacheGet.mockImplementationOnce(() => ({ licenceLength: '12M', isLicenceForYou: true }))

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/route.spec.js
@@ -1,4 +1,3 @@
-import GetDataRedirect from '../../../../handlers/get-data-redirect.js'
 import {
   ADDRESS_ENTRY,
   ADDRESS_LOOKUP,
@@ -350,7 +349,7 @@ describe('contact-summary > route', () => {
       const permission = { licenceLength: '12M', isRenewal: true, licensee: {} }
       const mockRequest = generateRequestMock(permission, '', status)
 
-      await expect(() => getData(mockRequest)).rejects.toThrow(GetDataRedirect)
+      await expect(() => getData(mockRequest)).rejects.toThrowRedirectTo(LICENCE_FULFILMENT.uri)
     })
 
     it('should throw a GetDataRedirect if licence-confirmation page is false on the status', async () => {
@@ -360,7 +359,7 @@ describe('contact-summary > route', () => {
       const permission = { licenceLength: '12M', isRenewal: true, licensee: {} }
       const mockRequest = generateRequestMock(permission, '', status)
 
-      await expect(() => getData(mockRequest)).rejects.toThrow(GetDataRedirect)
+      await expect(() => getData(mockRequest)).rejects.toThrowRedirectTo(LICENCE_CONFIRMATION_METHOD.uri)
     })
   })
 })


### PR DESCRIPTION
A new, custom matcher has been added for the GetDataRedirect error, so we need to refactor tests that up until now have only been checking for the type of error thrown and not for the url that's set on these errors