### PR TITLE
Start after 30 minutes text not showing with additional licences

### DIFF
--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/__snapshots__/route.spec.js.snap
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/__snapshots__/route.spec.js.snap
@@ -13,18 +13,5 @@ Object {
       "type": "Trout and coarse, up to 2 rods",
     },
   ],
-  "permission": Object {
-    "licenceLength": "8D",
-    "licenceType": "trout-and-coarse",
-    "licensee": Object {
-      "firstName": "Turanga",
-      "lastName": "Leela",
-    },
-    "numberOfRods": "2",
-    "permit": Object {
-      "cost": 12,
-    },
-  },
-  "startAfterPaymentMinutes": 4000,
 }
 `;

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
@@ -11,9 +11,6 @@ jest.mock('../../../../processors/licence-type-display.js')
 jest.mock('../../../../processors/date-and-time-display.js')
 jest.mock('../../../../routes/page-route.js')
 jest.mock('../../../../processors/multibuy-processor.js')
-jest.mock('@defra-fish/business-rules-lib', () => ({
-  START_AFTER_PAYMENT_MINUTES: 4000
-}))
 
 const permission = {
   licensee: {

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/__tests__/route.spec.js
@@ -2,7 +2,6 @@ import { getData, validator } from '../route'
 import { createMockRequest } from '../../../../__mocks__/request.js'
 import pageRoute from '../../../../routes/page-route.js'
 import { nextPage } from '../../../../routes/next-page.js'
-import constants from '@defra-fish/business-rules-lib'
 
 import { licenceTypeDisplay, licenceTypeAndLengthDisplay } from '../../../../processors/licence-type-display.js'
 import { displayStartTime } from '../../../../processors/date-and-time-display.js'
@@ -110,16 +109,6 @@ describe('view licences > getData', () => {
       const res = await getData(getSampleRequest())
       expect(res).toMatchSnapshot()
     })
-
-    it.each([[29], [31], [368]])(
-      'uses START_AFTER_PAYMENT_MINUTES environment variable for startAfterPaymentMinutes key',
-      async startAfter => {
-        constants.START_AFTER_PAYMENT_MINUTES = startAfter
-        const sampleRequest = getSampleRequest()
-        const { startAfterPaymentMinutes } = await getData(sampleRequest)
-        expect(startAfterPaymentMinutes).toEqual(startAfter)
-      }
-    )
 
     it('duplicates', async () => {
       hasDuplicates.mockReturnValueOnce(false)

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/route.js
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/route.js
@@ -5,11 +5,9 @@ import { licenceTypeDisplay, licenceTypeAndLengthDisplay } from '../../../proces
 import { displayStartTime } from '../../../processors/date-and-time-display.js'
 import { nextPage } from '../../../routes/next-page.js'
 import { hasDuplicates } from '../../../processors/multibuy-processor.js'
-import { START_AFTER_PAYMENT_MINUTES } from '@defra-fish/business-rules-lib'
 
 export const getData = async request => {
   const transaction = await request.cache().helpers.transaction.get()
-  const permission = await request.cache().helpers.transaction.getCurrentPermission()
   const mssgs = request.i18n.getCatalog()
 
   const licences = transaction.permissions.map((permission, index) => ({
@@ -24,10 +22,8 @@ export const getData = async request => {
   const duplicate = await hasDuplicates(licences)
 
   return {
-    permission,
     duplicate,
-    licences,
-    startAfterPaymentMinutes: START_AFTER_PAYMENT_MINUTES
+    licences
   }
 }
 

--- a/packages/gafl-webapp-service/src/pages/multibuy/view-licences/view-licences.njk
+++ b/packages/gafl-webapp-service/src/pages/multibuy/view-licences/view-licences.njk
@@ -21,15 +21,14 @@
           }) }}
         {% endif %}
 
+
           {% for licence in data.licences %}
 
               {% set licenceInfo = [
                 { key: { text: 'Licence holder' }, value: { text: licence.licenceHolder } }, 
                 { key: { text: 'Type' }, value: { text: licence.type } }, 
                 { key: { text: 'Length' }, value: { text: licence.length } }, 
-                { key: { text: 'Start' }, 
-                  value: { html: data.startAfterPaymentMinutes + mssgs.licence_summary_minutes_after_payment if data.permission.licenceToStart === 'after-payment' else licence.start } 
-                }, 
+                { key: { text: 'Start' }, value: { text: licence.start } }, 
                 { key: { text: 'Price' }, value: { text: '£' + licence.price } }
                 ]
               %}

--- a/packages/gafl-webapp-service/src/processors/__tests__/date-and-time-display.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/date-and-time-display.spec.js
@@ -54,15 +54,12 @@ describe('displayStartTime', () => {
     [[0], ['2029-06-030T01:00:00.000Z'], [' minutes until cobwebs are brushed off your rod']]
   ])(
     'generates a string of payment delay (%s) followed by licence_summary_minutes_after_payment label when licence is to start after payment',
-    async (startAfterMinutes, date, message) => {
+    async (startAfterMinutes, startDate, message) => {
       constant.START_AFTER_PAYMENT_MINUTES = startAfterMinutes
       const mockRequest = getSampleRequest({
         licence_summary_minutes_after_payment: message
       })
-      const mssgs = mockRequest.i18n.getCatalog()
-      console.log(mssgs)
-      const startDate = date
-      const expectedReturnText = `${constant.START_AFTER_PAYMENT_MINUTES}${mssgs.licence_summary_minutes_after_payment}`
+      const expectedReturnText = `${constant.START_AFTER_PAYMENT_MINUTES}${message}`
       const startAfterPaymentMinutes = displayStartTime(mockRequest, { startDate, licenceToStart: 'after-payment' })
       expect(startAfterPaymentMinutes).toEqual(expectedReturnText)
     }

--- a/packages/gafl-webapp-service/src/processors/__tests__/date-and-time-display.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/date-and-time-display.spec.js
@@ -27,13 +27,13 @@ jest.mock('moment-timezone', () => ({
   }))
 }))
 
-const getSampleRequest = (overrides = {}) => ({
+const getSampleRequest = (labelOverrides = {}) => ({
   i18n: {
     getCatalog: () => ({
       licence_start_time_am_text_0: '0.00am (first minute of the day)',
       licence_start_time_am_text_12: '12:00pm (midday)',
       renewal_start_date_expires_5: 'on',
-      ...overrides
+      ...labelOverrides
     })
   },
   locale: 'en'
@@ -59,7 +59,7 @@ describe('displayStartTime', () => {
       const mockRequest = getSampleRequest({
         licence_summary_minutes_after_payment: message
       })
-      const expectedReturnText = `${constant.START_AFTER_PAYMENT_MINUTES}${message}`
+      const expectedReturnText = `${startAfterMinutes}${message}`
       const startAfterPaymentMinutes = displayStartTime(mockRequest, { startDate, licenceToStart: 'after-payment' })
       expect(startAfterPaymentMinutes).toEqual(expectedReturnText)
     }

--- a/packages/gafl-webapp-service/src/processors/date-and-time-display.js
+++ b/packages/gafl-webapp-service/src/processors/date-and-time-display.js
@@ -17,7 +17,6 @@ export const advancePurchaseDateMoment = permission => {
  */
 export const displayStartTime = (request, permission) => {
   const mssgs = request.i18n.getCatalog()
-  const startAfter30Text = mssgs.licence_summary_minutes_after_payment
   const startMoment = permission.startDate
     ? moment.utc(permission.startDate, null, request.locale).tz(SERVICE_LOCAL_TIME)
     : advancePurchaseDateMoment(permission)
@@ -28,7 +27,7 @@ export const displayStartTime = (request, permission) => {
     .replace('12:00pm', mssgs.licence_start_time_am_text_12)
 
   if (permission.licenceToStart === licenceToStart.AFTER_PAYMENT) {
-    return START_AFTER_PAYMENT_MINUTES + startAfter30Text
+    return `${START_AFTER_PAYMENT_MINUTES}${mssgs.licence_summary_minutes_after_payment}`
   }
 
   return `${timeComponent} ${mssgs.renewal_start_date_expires_5} ${startMoment.format(dateDisplayFormat)}`

--- a/packages/gafl-webapp-service/src/processors/date-and-time-display.js
+++ b/packages/gafl-webapp-service/src/processors/date-and-time-display.js
@@ -17,6 +17,7 @@ export const advancePurchaseDateMoment = permission => {
  */
 export const displayStartTime = (request, permission) => {
   const mssgs = request.i18n.getCatalog()
+  const startAfter30Text = mssgs.licence_summary_minutes_after_payment
   const startMoment = permission.startDate
     ? moment.utc(permission.startDate, null, request.locale).tz(SERVICE_LOCAL_TIME)
     : advancePurchaseDateMoment(permission)
@@ -26,7 +27,6 @@ export const displayStartTime = (request, permission) => {
     .replace('12:00am', mssgs.licence_start_time_am_text_0)
     .replace('12:00pm', mssgs.licence_start_time_am_text_12)
 
-  const startAfter30Text = mssgs.licence_summary_minutes_after_payment
   if (permission.licenceToStart === licenceToStart.AFTER_PAYMENT) {
     return START_AFTER_PAYMENT_MINUTES + startAfter30Text
   }

--- a/packages/gafl-webapp-service/src/processors/date-and-time-display.js
+++ b/packages/gafl-webapp-service/src/processors/date-and-time-display.js
@@ -1,5 +1,7 @@
 import moment from 'moment-timezone'
 import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
+import { licenceToStart } from '../pages/licence-details/licence-to-start/update-transaction.js'
+import { START_AFTER_PAYMENT_MINUTES } from '../../../business-rules-lib/src/constants.js'
 export const dateDisplayFormat = 'D MMMM YYYY'
 export const cacheDateFormat = 'YYYY-MM-DD'
 
@@ -23,6 +25,12 @@ export const displayStartTime = (request, permission) => {
     .format('h:mma')
     .replace('12:00am', mssgs.licence_start_time_am_text_0)
     .replace('12:00pm', mssgs.licence_start_time_am_text_12)
+
+  const startAfter30Text = mssgs.licence_summary_minutes_after_payment
+  if (permission.licenceToStart === licenceToStart.AFTER_PAYMENT) {
+    return START_AFTER_PAYMENT_MINUTES + startAfter30Text
+  }
+
   return `${timeComponent} ${mssgs.renewal_start_date_expires_5} ${startMoment.format(dateDisplayFormat)}`
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3002

When the user adds additional licences with future start dates, the start time text for "30 minutes after" should remain for previous licences.