### PR TITLE
Fix typo in label

### DIFF
--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -146,7 +146,7 @@
   "contact_summary_hidden_contact": "contact",
   "contact_summary_hidden_newsletter": "newsletter",
   "contact_summary_license_default": "Note of licence",
-  "contact_summary_license_non_physical": "Make a note on conrfirmation",
+  "contact_summary_license_non_physical": "Make a note on confirmation",
   "contact_summary_license_physical": "By post",
   "contact_summary_row_address": "Address",
   "contact_summary_row_licence": "Licence",


### PR DESCRIPTION
Fix a typo in a contact summary confirmation message