### PR TITLE
Pin Docker to localstack v1.2.0

### DIFF
--- a/docker/infrastructure.yml
+++ b/docker/infrastructure.yml
@@ -9,7 +9,7 @@ services:
   # - CloudFormation (http port 4581)
   #######################################################
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:1.2.0
     ports:
       - '4563-4599:4563-4599'
       - '${PORT_WEB_UI-4080}:${PORT_WEB_UI-8080}'


### PR DESCRIPTION
Localstack v1.3.0 was released yesterday. This included some breaking changes for us - the `DEFAULT_REGION` env var has been deprecated and the location of the init scripts appears to have changed. I wasn't able to immediately fix this so pinning to an earlier working version for now, as I think we'll need a Jira ticket to properly upgrade it.