### PR TITLE
Persist lang from Contact to Licence Summary

### DIFF
--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/route.spec.js
@@ -5,15 +5,17 @@ import {
   CONTACT,
   LICENCE_FULFILMENT,
   LICENCE_CONFIRMATION_METHOD,
-  NEWSLETTER
+  NEWSLETTER,
+  LICENCE_SUMMARY
 } from '../../../../uri.js'
 import { addLanguageCodeToUri } from '../../../../processors/uri-helper.js'
 import { HOW_CONTACTED } from '../../../../processors/mapping-constants'
 import pageRoute from '../../../../routes/page-route.js'
 import { CONTACT_SUMMARY_SEEN } from '../../../../constants.js'
 
+const mockDecoratedUri = Symbol('addLanguageCodeToUri')
 jest.mock('../../../../processors/uri-helper.js', () => ({
-  addLanguageCodeToUri: jest.fn(() => Symbol('addLanguageCodeToUri'))
+  addLanguageCodeToUri: jest.fn(() => mockDecoratedUri)
 }))
 
 jest.mock('../../../../processors/mapping-constants', () => ({
@@ -266,7 +268,7 @@ describe('contact-summary > route', () => {
   describe('addLanguageCodeToUri', () => {
     beforeEach(jest.clearAllMocks)
 
-    it.each([[ADDRESS_LOOKUP.uri], [LICENCE_FULFILMENT.uri], [LICENCE_CONFIRMATION_METHOD.uri], [CONTACT.uri], [NEWSLETTER.uri]])(
+    it.each([[ADDRESS_LOOKUP.uri], [LICENCE_FULFILMENT.uri], [LICENCE_CONFIRMATION_METHOD.uri], [CONTACT.uri], [NEWSLETTER.uri], [LICENCE_SUMMARY.uri]])(
       'test addLanguageCodeToUri is called correctly',
       async urlToCheck => {
         const sampleRequest = getRequestMock(getMockPermission({}))
@@ -274,6 +276,17 @@ describe('contact-summary > route', () => {
         expect(addLanguageCodeToUri).toHaveBeenCalledWith(sampleRequest, urlToCheck)
       }
     )
+
+    it('uses url modified by addLanguageCode for licenceSummary', async () => {
+      const decoratedUri = Symbol('decoratedUri')
+      addLanguageCodeToUri.mockReturnValue(decoratedUri)
+
+      const { uri: { licenceSummary } } = await getData(getRequestMock())
+
+      expect(licenceSummary).toBe(decoratedUri)
+
+      addLanguageCodeToUri.mockReturnValue(mockDecoratedUri)
+    })
   })
 
   describe('checkNavigation', () => {

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/route.spec.js
@@ -268,20 +268,26 @@ describe('contact-summary > route', () => {
   describe('addLanguageCodeToUri', () => {
     beforeEach(jest.clearAllMocks)
 
-    it.each([[ADDRESS_LOOKUP.uri], [LICENCE_FULFILMENT.uri], [LICENCE_CONFIRMATION_METHOD.uri], [CONTACT.uri], [NEWSLETTER.uri], [LICENCE_SUMMARY.uri]])(
-      'test addLanguageCodeToUri is called correctly',
-      async urlToCheck => {
-        const sampleRequest = getRequestMock(getMockPermission({}))
-        await getData(sampleRequest)
-        expect(addLanguageCodeToUri).toHaveBeenCalledWith(sampleRequest, urlToCheck)
-      }
-    )
+    it.each([
+      [ADDRESS_LOOKUP.uri],
+      [LICENCE_FULFILMENT.uri],
+      [LICENCE_CONFIRMATION_METHOD.uri],
+      [CONTACT.uri],
+      [NEWSLETTER.uri],
+      [LICENCE_SUMMARY.uri]
+    ])('test addLanguageCodeToUri is called correctly', async urlToCheck => {
+      const sampleRequest = getRequestMock(getMockPermission({}))
+      await getData(sampleRequest)
+      expect(addLanguageCodeToUri).toHaveBeenCalledWith(sampleRequest, urlToCheck)
+    })
 
     it('uses url modified by addLanguageCode for licenceSummary', async () => {
       const decoratedUri = Symbol('decoratedUri')
       addLanguageCodeToUri.mockReturnValue(decoratedUri)
 
-      const { uri: { licenceSummary } } = await getData(getRequestMock())
+      const {
+        uri: { licenceSummary }
+      } = await getData(getRequestMock())
 
       expect(licenceSummary).toBe(decoratedUri)
 

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
@@ -226,7 +226,7 @@ const getData = async request => {
   return {
     summaryTable: getLicenseeDetailsSummaryRows(permission, countryName, request),
     uri: {
-      licenceSummary: LICENCE_SUMMARY.uri
+      licenceSummary: addLanguageCodeToUri(request, LICENCE_SUMMARY.uri)
     },
     changeLicenceDetails
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3192

When selecting to modify the licence from the contact summary, the language selection isn't persisted