### PR TITLE
Trigger specific error response codes from route

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/__tests__/error-testing-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/error-testing-handler.spec.js
@@ -1,0 +1,16 @@
+import errorTestingHandler from '../error-testing-handler.js'
+
+describe('Error testing handler', () => {
+  it.each([
+    ['401', 'Unauthorized'],
+    ['403', 'Forbidden'],
+    ['500', 'Internal Server Error']
+  ])('throws the correct error when given %s as the param', async (code, message) => {
+    const mockRequest = {
+      query: { error: code }
+    }
+    const mockH = {}
+
+    await expect(errorTestingHandler(mockRequest, mockH)).rejects.toThrow(message)
+  })
+})

--- a/packages/gafl-webapp-service/src/handlers/error-testing-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/error-testing-handler.js
@@ -1,0 +1,6 @@
+import Boom from '@hapi/boom'
+
+export default async (request, _h) => {
+  const errorCode = parseInt(request.query.error)
+  throw Boom.boomify(new Error(), { statusCode: errorCode })
+}

--- a/packages/gafl-webapp-service/src/routes/__tests__/__snapshots__/error-test-routes.spec.js.snap
+++ b/packages/gafl-webapp-service/src/routes/__tests__/__snapshots__/error-test-routes.spec.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Error test route handler error route has a return value with a method of GET and path of /buy/throw-error 1`] = `
+Array [
+  Object {
+    "handler": [Function],
+    "method": "GET",
+    "path": "/buy/throw-error",
+  },
+]
+`;

--- a/packages/gafl-webapp-service/src/routes/__tests__/error-test-routes.spec.js
+++ b/packages/gafl-webapp-service/src/routes/__tests__/error-test-routes.spec.js
@@ -1,0 +1,26 @@
+import errorTestRoutes from '../error-test-routes'
+
+describe('Error test route handler', () => {
+  describe('error route', () => {
+    it('has a return value with a method of GET and path of /buy/throw-error', async () => {
+      expect(errorTestRoutes).toMatchSnapshot()
+    })
+  })
+
+  describe('ERROR_TESTING handler', () => {
+    const errorTesting = errorTestRoutes[0].handler
+
+    it.each([
+      ['401', 'Unauthorized'],
+      ['403', 'Forbidden'],
+      ['500', 'Internal Server Error']
+    ])('throws the correct error when given %s as the param', async (code, message) => {
+      const mockRequest = {
+        query: { error: code }
+      }
+      const mockH = {}
+
+      await expect(errorTesting(mockRequest, mockH)).rejects.toThrow(message)
+    })
+  })
+})

--- a/packages/gafl-webapp-service/src/routes/__tests__/routes.spec.js
+++ b/packages/gafl-webapp-service/src/routes/__tests__/routes.spec.js
@@ -1,6 +1,9 @@
 const mockErrorRoutes = [Symbol('error')]
 jest.mock('../error-routes.js', () => mockErrorRoutes)
 
+const mockErrorTestingRoutes = [Symbol('error-testing')]
+jest.mock('../error-test-routes.js', () => mockErrorTestingRoutes)
+
 const mockTelesalesRoutes = [Symbol('telesales')]
 jest.mock('../telesales-routes.js', () => mockTelesalesRoutes)
 
@@ -22,6 +25,12 @@ describe('route', () => {
     expect(routes.default).toEqual(expect.arrayContaining(mockErrorRoutes))
   })
 
+  it('if ERROR_PAGE environment variable is true error testing route is added to the routes array', async () => {
+    process.env.ERROR_PAGE_ROUTE = 'true'
+    const routes = require('../routes.js')
+    expect(routes.default).toEqual(expect.arrayContaining(mockErrorTestingRoutes))
+  })
+
   it('if channel environment variables are not for telesales then telesales route is not added to the routes array', async () => {
     process.env.CHANNEL = 'not_telesales'
     const routes = require('../routes.js')
@@ -32,5 +41,11 @@ describe('route', () => {
     process.env.ERROR_PAGE_ROUTE = 'false'
     const routes = require('../routes.js')
     expect(routes.default).toEqual(expect.not.arrayContaining(mockErrorRoutes))
+  })
+
+  it('if ERROR_PAGE environment variable is false error testing route is not added to the routes array', async () => {
+    process.env.ERROR_PAGE_ROUTE = 'false'
+    const routes = require('../routes.js')
+    expect(routes.default).toEqual(expect.not.arrayContaining(mockErrorTestingRoutes))
   })
 })

--- a/packages/gafl-webapp-service/src/routes/error-test-routes.js
+++ b/packages/gafl-webapp-service/src/routes/error-test-routes.js
@@ -1,0 +1,10 @@
+import { ERROR_TESTING } from '../uri.js'
+import errorTestingHandler from '../handlers/error-testing-handler.js'
+
+export default [
+  {
+    method: 'GET',
+    path: ERROR_TESTING.uri,
+    handler: errorTestingHandler
+  }
+]

--- a/packages/gafl-webapp-service/src/routes/routes.js
+++ b/packages/gafl-webapp-service/src/routes/routes.js
@@ -35,6 +35,7 @@ import staticAssets from './static-routes.js'
 import miscRoutes from './misc-routes.js'
 import telesalesRoutes from './telesales-routes.js'
 import errorRoutes from './error-routes.js'
+import errorTestRoutes from './error-test-routes.js'
 
 const routes = [
   ...staticAssets,
@@ -74,6 +75,10 @@ if (process.env.CHANNEL === 'telesales') {
 
 if (process.env.ERROR_PAGE_ROUTE === 'true') {
   routes.push(...errorRoutes)
+}
+
+if (process.env.ERROR_PAGE_ROUTE === 'true') {
+  routes.push(...errorTestRoutes)
 }
 
 export default routes

--- a/packages/gafl-webapp-service/src/uri.js
+++ b/packages/gafl-webapp-service/src/uri.js
@@ -59,6 +59,7 @@ export const AGREED = { uri: '/buy/agreed' }
 
 export const CLIENT_ERROR = { uri: '/buy/client-error', page: 'client-error' }
 export const SERVER_ERROR = { uri: '/buy/server-error', page: 'server-error' }
+export const ERROR_TESTING = { uri: '/buy/throw-error' }
 
 /**
  * These are informational static pages


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3123

This PR adds a new route for testing specific error response codes. So going to /buy/throw-error?error=401 will return a 401 response code, etc.

The env var ERROR_PAGE_ROUTE must be set to true for it to work.