### PR TITLE
Refactor redirects to automatically use correct language

### DIFF
--- a/packages/gafl-webapp-service/src/__tests__/server.spec.js
+++ b/packages/gafl-webapp-service/src/__tests__/server.spec.js
@@ -34,6 +34,16 @@ describe('The server', () => {
     await server.stop()
   })
 
+  it('decorates the toolkit with redirectWithLanguageCode', async () => {
+    createServer(catboxOptions)
+
+    const serverDecorateSpy = jest.spyOn(server, 'decorate').mockImplementation(jest.fn())
+
+    await init()
+    expect(serverDecorateSpy).toHaveBeenCalledWith('toolkit', 'redirectWithLanguageCode', expect.any(Function))
+    await server.stop()
+  })
+
   it('configures session handling in redis by default', async () => {
     process.env.REDIS_HOST = '0.0.0.0'
     process.env.REDIS_PORT = '12345'

--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
@@ -294,7 +294,7 @@ describe('The agreed handler', () => {
 
       await agreedHandler(mockRequest, requestToolkit)
 
-      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, ORDER_COMPLETE.uri)
+      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(ORDER_COMPLETE.uri)
     })
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
@@ -13,12 +13,7 @@ import {
 import { COMPLETION_STATUS } from '../../constants.js'
 import { AGREED, TEST_TRANSACTION, TEST_STATUS, ORDER_COMPLETE } from '../../uri.js'
 import { PAYMENT_JOURNAL_STATUS_CODES } from '@defra-fish/business-rules-lib'
-import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
 import agreedHandler from '../agreed-handler.js'
-
-jest.mock('../../processors/uri-helper.js', () => ({
-  addLanguageCodeToUri: jest.fn(() => '/buy/order-complete')
-}))
 
 beforeAll(() => {
   process.env.ANALYTICS_PRIMARY_PROPERTY = 'UA-123456789-0'
@@ -290,25 +285,16 @@ describe('The agreed handler', () => {
     })
 
     const getRequestToolkit = () => ({
-      redirect: jest.fn()
-    })
-
-    it('calls addLanguageCodeToUri', async () => {
-      const mockRequest = getMockRequest()
-
-      await agreedHandler(mockRequest, getRequestToolkit())
-
-      expect(addLanguageCodeToUri).toHaveBeenCalledWith(mockRequest, ORDER_COMPLETE.uri)
+      redirectWithLanguageCode: jest.fn()
     })
 
     it('calls redirect correctly', async () => {
       const requestToolkit = getRequestToolkit()
-      const expectedPath = Symbol('expected path')
-      addLanguageCodeToUri.mockReturnValueOnce(expectedPath)
+      const mockRequest = getMockRequest()
 
-      await agreedHandler(getMockRequest(), requestToolkit)
+      await agreedHandler(mockRequest, requestToolkit)
 
-      expect(requestToolkit.redirect).toHaveBeenCalledWith(expectedPath)
+      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, ORDER_COMPLETE.uri)
     })
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-payment-failure.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-payment-failure.spec.js
@@ -7,11 +7,9 @@ import { COMPLETION_STATUS } from '../../constants.js'
 import { AGREED, TEST_TRANSACTION, TEST_STATUS, PAYMENT_FAILED, PAYMENT_CANCELLED } from '../../uri.js'
 
 import agreedHandler from '../agreed-handler.js'
-import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
 import { getPaymentStatus, sendPayment } from '../../services/payment/govuk-pay-service.js'
 import { preparePayment } from '../../processors/payment.js'
 jest.mock('../../services/payment/govuk-pay-service.js')
-jest.mock('../../processors/uri-helper.js')
 jest.mock('../../processors/payment.js')
 
 beforeAll(() => {
@@ -123,7 +121,7 @@ const getMockRequest = () => ({
 })
 
 const getRequestToolkit = () => ({
-  redirect: jest.fn()
+  redirectWithLanguageCode: jest.fn()
 })
 
 const getSendPaymentMockImplementation = () => ({
@@ -158,7 +156,6 @@ describe('The agreed handler', () => {
     ['expired', paymentStatusExpired],
     ['general-error', paymentGeneralError]
   ])('redirects to the payment-failed page if the GOV.UK Pay returns %s on payment status fetch', async (desc, pstat) => {
-    addLanguageCodeToUri.mockReturnValue('/buy/payment-failed')
     await ADULT_FULL_1_DAY_LICENCE.setup()
 
     salesApi.createTransaction.mockResolvedValue(ADULT_FULL_1_DAY_LICENCE.transactionResponse)
@@ -198,7 +195,6 @@ describe('The agreed handler', () => {
     expect(parsedStatus[COMPLETION_STATUS.paymentCompleted]).not.toBeTruthy()
     expect(parsedStatus[COMPLETION_STATUS.finalised]).not.toBeTruthy()
 
-    addLanguageCodeToUri.mockReturnValue('/buy/agreed')
     await injectWithCookies('GET', PAYMENT_FAILED.uri)
     const data4 = await injectWithCookies('POST', PAYMENT_FAILED.uri, {})
     expect(data4.statusCode).toBe(302)
@@ -225,26 +221,15 @@ describe('The agreed handler', () => {
       })
     })
 
-    it('calls addLanguageCodeToUri', async () => {
-      const mockRequest = getMockRequest()
-
-      addLanguageCodeToUri.mockReturnValue('/buy/payment-failed')
-
-      await agreedHandler(mockRequest, getRequestToolkit())
-
-      expect(addLanguageCodeToUri).toHaveBeenCalledWith(mockRequest, PAYMENT_FAILED.uri)
-    })
-
     it('calls redirect correctly', async () => {
       preparePayment.mockImplementation(() => {})
       sendPayment.mockImplementation(() => getSendPaymentMockImplementation())
       const requestToolkit = getRequestToolkit()
-      const expectedPath = Symbol('expected path')
-      addLanguageCodeToUri.mockReturnValueOnce(expectedPath)
+      const mockRequest = getMockRequest()
 
-      await agreedHandler(getMockRequest(), requestToolkit)
+      await agreedHandler(mockRequest, requestToolkit)
 
-      expect(requestToolkit.redirect).toHaveBeenCalledWith(expectedPath)
+      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, PAYMENT_FAILED.uri)
     })
   })
 
@@ -259,32 +244,19 @@ describe('The agreed handler', () => {
       })
     })
 
-    it('calls addLanguageCodeToUri', async () => {
-      const mockRequest = getMockRequest()
-
-      addLanguageCodeToUri.mockReturnValue('/buy/payment-failed')
-
-      await agreedHandler(mockRequest, getRequestToolkit())
-
-      expect(addLanguageCodeToUri).toHaveBeenCalledWith(mockRequest, PAYMENT_FAILED.uri)
-    })
-
     it('calls redirect correctly', async () => {
       preparePayment.mockImplementation(() => {})
       sendPayment.mockImplementation(() => getSendPaymentMockImplementation())
       const requestToolkit = getRequestToolkit()
-      const expectedPath = Symbol('expected path')
-      addLanguageCodeToUri.mockReturnValueOnce(expectedPath)
+      const mockRequest = getMockRequest()
 
-      await agreedHandler(getMockRequest(), requestToolkit)
+      await agreedHandler(mockRequest, requestToolkit)
 
-      expect(requestToolkit.redirect).toHaveBeenCalledWith(expectedPath)
+      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, PAYMENT_FAILED.uri)
     })
   })
 
   it('redirects to the payment-cancelled page if the GOV.UK Pay returns cancelled', async () => {
-    addLanguageCodeToUri.mockReturnValue('/buy/payment-cancelled')
-
     await ADULT_FULL_1_DAY_LICENCE.setup()
     salesApi.createTransaction = jest.fn(async () => new Promise(resolve => resolve(ADULT_FULL_1_DAY_LICENCE.transactionResponse)))
 
@@ -326,7 +298,6 @@ describe('The agreed handler', () => {
     expect(parsedStatus[COMPLETION_STATUS.finalised]).not.toBeTruthy()
 
     // Perform the redirect to the payment failed screen and attempt payment again
-    addLanguageCodeToUri.mockReturnValue('/buy/agreed')
     await injectWithCookies('GET', PAYMENT_CANCELLED.uri)
     const data3 = await injectWithCookies('POST', PAYMENT_CANCELLED.uri, {})
     expect(data3.statusCode).toBe(302)
@@ -363,26 +334,15 @@ describe('The agreed handler', () => {
       })
     })
 
-    it('calls addLanguageCodeToUri', async () => {
-      const mockRequest = getMockRequest()
-
-      addLanguageCodeToUri.mockReturnValue('/buy/payment-cancelled')
-
-      await agreedHandler(mockRequest, getRequestToolkit())
-
-      expect(addLanguageCodeToUri).toHaveBeenCalledWith(mockRequest, PAYMENT_CANCELLED.uri)
-    })
-
     it('calls redirect correctly', async () => {
       preparePayment.mockImplementation(() => {})
       sendPayment.mockImplementation(() => getSendPaymentMockImplementation())
       const requestToolkit = getRequestToolkit()
-      const expectedPath = Symbol('expected path')
-      addLanguageCodeToUri.mockReturnValueOnce(expectedPath)
+      const mockRequest = getMockRequest()
 
-      await agreedHandler(getMockRequest(), requestToolkit)
+      await agreedHandler(mockRequest, requestToolkit)
 
-      expect(requestToolkit.redirect).toHaveBeenCalledWith(expectedPath)
+      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, PAYMENT_CANCELLED.uri)
     })
   })
 

--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-payment-failure.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-payment-failure.spec.js
@@ -229,7 +229,7 @@ describe('The agreed handler', () => {
 
       await agreedHandler(mockRequest, requestToolkit)
 
-      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, PAYMENT_FAILED.uri)
+      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(PAYMENT_FAILED.uri)
     })
   })
 
@@ -252,7 +252,7 @@ describe('The agreed handler', () => {
 
       await agreedHandler(mockRequest, requestToolkit)
 
-      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, PAYMENT_FAILED.uri)
+      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(PAYMENT_FAILED.uri)
     })
   })
 
@@ -342,7 +342,7 @@ describe('The agreed handler', () => {
 
       await agreedHandler(mockRequest, requestToolkit)
 
-      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, PAYMENT_CANCELLED.uri)
+      expect(requestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(PAYMENT_CANCELLED.uri)
     })
   })
 

--- a/packages/gafl-webapp-service/src/handlers/__tests__/analytics-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/analytics-handler.spec.js
@@ -31,7 +31,7 @@ describe('The analytics handler', () => {
 
     await analyticsHandler(request, responseToolkit)
 
-    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, redirect)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(redirect)
   })
 
   it.each([
@@ -51,7 +51,7 @@ describe('The analytics handler', () => {
 
     await analyticsHandler(request, responseToolkit)
 
-    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, '/buy')
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith('/buy')
   })
 
   it('selected not true and response is accept sets selected to true and acceptTracking to true', async () => {

--- a/packages/gafl-webapp-service/src/handlers/__tests__/analytics-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/analytics-handler.spec.js
@@ -1,10 +1,5 @@
 import { ANALYTICS } from '../../constants.js'
 import analyticsHandler from '../analytics-handler.js'
-import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
-
-jest.mock('../../processors/uri-helper.js', () => ({
-  addLanguageCodeToUri: jest.fn((_request, uri) => uri)
-}))
 
 jest.mock('../../constants', () => ({
   ANALYTICS: {
@@ -36,7 +31,7 @@ describe('The analytics handler', () => {
 
     await analyticsHandler(request, responseToolkit)
 
-    expect(responseToolkit.redirect).toHaveBeenCalledWith(redirect)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, redirect)
   })
 
   it.each([
@@ -56,30 +51,7 @@ describe('The analytics handler', () => {
 
     await analyticsHandler(request, responseToolkit)
 
-    expect(responseToolkit.redirect).toHaveBeenCalledWith('/buy')
-  })
-
-  it('calls addLanguageCodeToUri with request and /buy', async () => {
-    const headers = { origin: 'https://localhost:1234', referer: 'https://localhost:3000/buy' }
-    const redirect = '/buy'
-    const payload = { analyticsResponse: 'accept' }
-    const responseToolkit = generateResponseToolkitMock()
-    const request = generateRequestMock(payload, 'analytics', headers, 'localhost:1234')
-
-    await analyticsHandler(request, responseToolkit)
-
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, redirect)
-  })
-
-  it('addLanguageCodeToUri is not called when HTTP_REFERER host matches the host of the current page', async () => {
-    const headers = { origin: 'https://localhost:3000', referer: 'https://localhost:3000/example/test' }
-    const payload = { analyticsResponse: 'accept' }
-    const responseToolkit = generateResponseToolkitMock()
-    const request = generateRequestMock(payload, 'analytics', headers, 'localhost:3000')
-
-    await analyticsHandler(request, responseToolkit)
-
-    expect(addLanguageCodeToUri).not.toBeCalled()
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, '/buy')
   })
 
   it('selected not true and response is accept sets selected to true and acceptTracking to true', async () => {
@@ -136,6 +108,6 @@ describe('The analytics handler', () => {
   })
 
   const generateResponseToolkitMock = () => ({
-    redirect: jest.fn()
+    redirectWithLanguageCode: jest.fn()
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/attribution-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/attribution-handler.spec.js
@@ -65,7 +65,7 @@ describe('The attribution handler', () => {
       }
       const responseToolkit = generateResponseToolkitMock()
       await attributionHandler(generateRequestMock(query), responseToolkit)
-      expect(responseToolkit.redirect).toHaveBeenCalledWith(ATTRIBUTION_REDIRECT_DEFAULT)
+      expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(ATTRIBUTION_REDIRECT_DEFAULT)
     }
   )
 
@@ -81,7 +81,7 @@ describe('The attribution handler', () => {
     }
     const responseToolkit = generateResponseToolkitMock()
     await attributionHandler(generateRequestMock(query), responseToolkit)
-    expect(responseToolkit.redirect).toHaveBeenCalledWith(attributionRedirect)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(attributionRedirect)
     delete process.env.ATTRIBUTION_REDIRECT
   })
 
@@ -96,7 +96,7 @@ describe('The attribution handler', () => {
     const responseToolkit = generateResponseToolkitMock()
 
     await attributionHandler(generateRequestMock(query), responseToolkit)
-    expect(responseToolkit.redirect).toHaveBeenCalledWith(IDENTIFY.uri)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(IDENTIFY.uri)
   })
 
   it('redirects begins with { IDENTIFY } when journey is renewal', async () => {
@@ -111,7 +111,7 @@ describe('The attribution handler', () => {
     const regExMatch = new RegExp(`^${IDENTIFY.uri}`)
 
     await attributionHandler(generateRequestMock(query), responseToolkit)
-    expect(responseToolkit.redirect).toHaveBeenCalledWith(expect.stringMatching(regExMatch))
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(expect.stringMatching(regExMatch))
   })
 
   it.each([['B2F11U'], ['AH56F6'], ['GH330P']])(
@@ -128,7 +128,7 @@ describe('The attribution handler', () => {
       const responseToolkit = generateResponseToolkitMock()
       await attributionHandler(generateRequestMock(query), responseToolkit)
       const regExMatch = new RegExp(`^${RENEWAL_BASE.uri}/${licenceKey}$`)
-      expect(responseToolkit.redirect).toHaveBeenCalledWith(expect.stringMatching(regExMatch))
+      expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(expect.stringMatching(regExMatch))
     }
   )
 
@@ -145,6 +145,6 @@ describe('The attribution handler', () => {
   })
 
   const generateResponseToolkitMock = () => ({
-    redirect: jest.fn()
+    redirectWithLanguageCode: jest.fn()
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/authentication-handler.redirect.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/authentication-handler.redirect.spec.js
@@ -56,7 +56,7 @@ describe.each([
     const mockRequest = getSampleRequest()
     const responseToolkit = getSampleResponseToolkit()
     await handler(mockRequest, responseToolkit)
-    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, redirectUri)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(redirectUri)
   })
 
   const getSampleRequest = () => ({

--- a/packages/gafl-webapp-service/src/handlers/__tests__/authentication-handler.redirect.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/authentication-handler.redirect.spec.js
@@ -1,5 +1,4 @@
 import handler from '../authentication-handler.js'
-import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
 import { IDENTIFY, CONTROLLER, RENEWAL_INACTIVE } from '../../uri.js'
 import { salesApi } from '@defra-fish/connectors-lib'
 
@@ -54,22 +53,10 @@ describe.each([
   })
 
   it(`redirects to decorated uri if auth ${authResult ? 'passes' : 'fails'}`, async () => {
-    const expectedUri = Symbol('decorated uri')
-    addLanguageCodeToUri.mockReturnValueOnce(expectedUri)
+    const mockRequest = getSampleRequest()
     const responseToolkit = getSampleResponseToolkit()
-    await handler(getSampleRequest(), responseToolkit)
-    expect(responseToolkit.redirect).toHaveBeenCalledWith(expectedUri)
-  })
-
-  it(`passes request to addLanguageCodeToUri if auth ${authResult ? 'passes' : 'fails'}`, async () => {
-    const request = getSampleRequest()
-    await handler(request, getSampleResponseToolkit())
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, expect.anything())
-  })
-
-  it(`passes ${uriDescription} uri to addLangaugeCodeToUri if result error ${authResult ? 'passes' : 'fails'}`, async () => {
-    await handler(getSampleRequest(), getSampleResponseToolkit())
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(expect.any(Object), redirectUri)
+    await handler(mockRequest, responseToolkit)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, redirectUri)
   })
 
   const getSampleRequest = () => ({
@@ -101,6 +88,6 @@ describe.each([
     })
   })
   const getSampleResponseToolkit = () => ({
-    redirect: jest.fn()
+    redirectWithLanguageCode: jest.fn()
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/new-session-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/new-session-handler.spec.js
@@ -1,0 +1,39 @@
+import newSessionHandler from '../new-session-handler.js'
+import { CONTROLLER } from '../../uri.js'
+import { initialiseAnalyticsSessionData } from '../../processors/analytics.js'
+
+jest.mock('../../processors/analytics.js')
+
+describe('New session handler', () => {
+  const getMockRequest = mockStatus => ({
+    cache: () => ({
+      initialize: () => ({}),
+      helpers: {
+        status: {
+          get: async () => mockStatus
+        }
+      }
+    })
+  })
+
+  const getRequestToolkit = () => ({
+    redirectWithLanguageCode: jest.fn()
+  })
+
+  it('calls initialiseAnalyticsSessionData with the correct arguments', async () => {
+    const mockCacheStatus = Symbol('mockCacheStatus')
+    const mockRequest = getMockRequest(mockCacheStatus)
+    const mockRequestToolkit = getRequestToolkit()
+
+    await newSessionHandler(mockRequest, mockRequestToolkit)
+    expect(initialiseAnalyticsSessionData).toHaveBeenCalledWith(mockRequest, mockCacheStatus)
+  })
+
+  it('redirects to the controller uri', async () => {
+    const mockRequest = getMockRequest()
+    const mockRequestToolkit = getRequestToolkit()
+
+    await newSessionHandler(mockRequest, mockRequestToolkit)
+    expect(mockRequestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, CONTROLLER.uri)
+  })
+})

--- a/packages/gafl-webapp-service/src/handlers/__tests__/new-session-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/new-session-handler.spec.js
@@ -34,6 +34,6 @@ describe('New session handler', () => {
     const mockRequestToolkit = getRequestToolkit()
 
     await newSessionHandler(mockRequest, mockRequestToolkit)
-    expect(mockRequestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(mockRequest, CONTROLLER.uri)
+    expect(mockRequestToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(CONTROLLER.uri)
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/oidc-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/oidc-handler.spec.js
@@ -76,7 +76,7 @@ describe('oidc handler', () => {
           ttl: jest.fn()
         }
       }
-      const fakeHandler = { redirect: jest.fn() }
+      const fakeHandler = { redirectWithLanguageCode: jest.fn() }
 
       salesApi.getSystemUser.mockResolvedValue({
         id: '26449770-5e67-e911-a988-000d3ab9df39',
@@ -99,7 +99,7 @@ describe('oidc handler', () => {
         email: mockSettings.TEST_EMAIL
       })
       expect(fakeRequest.cookieAuth.ttl).toHaveBeenCalledWith(expect.any(Number))
-      expect(fakeHandler.redirect).toHaveBeenCalledWith(mockSettings.TEST_POST_AUTH_REDIRECT)
+      expect(fakeHandler.redirectWithLanguageCode).toHaveBeenCalledWith(mockSettings.TEST_POST_AUTH_REDIRECT)
     })
 
     it('redirects to /oidc/role-required if the user does not have the required role set in Dynamics', async () => {
@@ -107,7 +107,7 @@ describe('oidc handler', () => {
         payload: { id_token: 'sample_token', state: mockSettings.TEST_STATE },
         cookieAuth: { set: jest.fn(), ttl: jest.fn() }
       }
-      const fakeHandler = { redirect: jest.fn() }
+      const fakeHandler = { redirectWithLanguageCode: jest.fn() }
 
       salesApi.getSystemUser.mockResolvedValue({
         id: '26449770-5e67-e911-a988-000d3ab9df39',
@@ -126,7 +126,7 @@ describe('oidc handler', () => {
       await expect(signIn(fakeRequest, fakeHandler)).resolves.toBeUndefined()
       expect(fakeRequest.cookieAuth.set).not.toHaveBeenCalled()
       expect(fakeRequest.cookieAuth.ttl).not.toHaveBeenCalled()
-      expect(fakeHandler.redirect).toHaveBeenCalledWith('/oidc/role-required')
+      expect(fakeHandler.redirectWithLanguageCode).toHaveBeenCalledWith('/oidc/role-required')
     })
 
     it('redirects to /oidc/account-disabled if the user account is not recognised in Dynamics', async () => {
@@ -134,12 +134,12 @@ describe('oidc handler', () => {
         payload: { id_token: 'sample_token', state: 'test_stored_state' },
         cookieAuth: { set: jest.fn(), ttl: jest.fn() }
       }
-      const fakeHandler = { redirect: jest.fn() }
+      const fakeHandler = { redirectWithLanguageCode: jest.fn() }
       salesApi.getSystemUser.mockResolvedValue(null)
       await expect(signIn(fakeRequest, fakeHandler)).resolves.toBeUndefined()
       expect(fakeRequest.cookieAuth.set).not.toHaveBeenCalled()
       expect(fakeRequest.cookieAuth.ttl).not.toHaveBeenCalled()
-      expect(fakeHandler.redirect).toHaveBeenCalledWith('/oidc/account-disabled')
+      expect(fakeHandler.redirectWithLanguageCode).toHaveBeenCalledWith('/oidc/account-disabled')
     })
 
     it('redirects to /oidc/account-disabled if the user account has been set to disabled in Dynamics', async () => {
@@ -147,7 +147,7 @@ describe('oidc handler', () => {
         payload: { id_token: 'sample_token', state: 'test_stored_state' },
         cookieAuth: { set: jest.fn(), ttl: jest.fn() }
       }
-      const fakeHandler = { redirect: jest.fn() }
+      const fakeHandler = { redirectWithLanguageCode: jest.fn() }
 
       salesApi.getSystemUser.mockResolvedValue({
         id: '26449770-5e67-e911-a988-000d3ab9df39',
@@ -166,20 +166,20 @@ describe('oidc handler', () => {
       await expect(signIn(fakeRequest, fakeHandler)).resolves.toBeUndefined()
       expect(fakeRequest.cookieAuth.set).not.toHaveBeenCalled()
       expect(fakeRequest.cookieAuth.ttl).not.toHaveBeenCalled()
-      expect(fakeHandler.redirect).toHaveBeenCalledWith('/oidc/account-disabled')
+      expect(fakeHandler.redirectWithLanguageCode).toHaveBeenCalledWith('/oidc/account-disabled')
     })
 
     it('throws errors authenticating the token back up the stack', async () => {
       mockOidcClient.callback.mockRejectedValue(new Error('error validating jwt token'))
       mockCache.get.mockResolvedValue(null)
       const fakeRequest = { payload: { id_token: 'sample_token', state: mockSettings.TEST_STATE } }
-      const fakeHandler = { redirect: jest.fn() }
+      const fakeHandler = { redirectWithLanguageCode: jest.fn() }
       await expect(signIn(fakeRequest, fakeHandler)).rejects.toThrow('error validating jwt token')
     })
 
     it('throws a 500 error if the payload does not contain an id_token', async () => {
       const fakeRequest = { payload: { error: 'ERROR_CODE', error_description: 'Something went wrong' } }
-      const fakeHandler = { redirect: jest.fn() }
+      const fakeHandler = { redirectWithLanguageCode: jest.fn() }
       await expect(signIn(fakeRequest, fakeHandler)).rejects.toThrow('Authentication error: ERROR_CODE: Something went wrong')
     })
   })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -157,7 +157,7 @@ describe('The page handler function', () => {
 
     await get(request, toolkit)
 
-    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, url)
+    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(url)
   })
 
   it.each([['/route/one'], ['/route/sixty-six']])('error redirects to request uri', async url => {
@@ -165,7 +165,7 @@ describe('The page handler function', () => {
     const request = getMockRequest(undefined, url)
     const toolkit = getMockToolkit()
     await error(request, toolkit, { details: [] })
-    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request)
+    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalled()
   })
 
   it('sets the value of pageData with displayAnalytics true', async () => {

--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -160,12 +160,12 @@ describe('The page handler function', () => {
     expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(url)
   })
 
-  it.each([['/route/one'], ['/route/sixty-six']])('error redirects to request uri', async url => {
+  it.each([['/route/one'], ['/route/sixty-six']])('error redirects with language code', async url => {
     const { error } = pageHandler('', 'view')
     const request = getMockRequest(undefined, url)
     const toolkit = getMockToolkit()
     await error(request, toolkit, { details: [] })
-    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalled()
+    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith()
   })
 
   it('sets the value of pageData with displayAnalytics true', async () => {

--- a/packages/gafl-webapp-service/src/handlers/__tests__/renewal-start-date-validation-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/renewal-start-date-validation-handler.spec.js
@@ -2,16 +2,16 @@ import renewalStartDateValidationHandler from '../renewal-start-date-validation-
 import { LICENCE_SUMMARY, RENEWAL_START_DATE } from '../../uri.js'
 
 describe('Renewal start date validation handler', () => {
-  const getMockRequest = (startYear, startMonth, startDay, renewedEndDate) => ({
+  const getMockRequest = (startYear = 1970, startMonth = 1, startDay = 1, renewedEndDate = '2023-01-01T00:00:00.000Z') => ({
     cache: () => ({
       initialize: () => ({}),
       helpers: {
         page: {
           getCurrentPermission: async () => ({
             payload: {
-              'licence-start-date-year': startYear || 1970,
-              'licence-start-date-month': startMonth || 1,
-              'licence-start-date-day': startDay || 1
+              'licence-start-date-year': startYear,
+              'licence-start-date-month': startMonth,
+              'licence-start-date-day': startDay
             }
           }),
           setCurrentPermission: async () => {}
@@ -21,7 +21,7 @@ describe('Renewal start date validation handler', () => {
             licensee: {
               noLicenceRequired: {}
             },
-            renewedEndDate: renewedEndDate || '2023-01-01T00:00:00.000Z'
+            renewedEndDate: renewedEndDate
           }),
           setCurrentPermission: async () => {}
         },

--- a/packages/gafl-webapp-service/src/handlers/__tests__/renewal-start-date-validation-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/renewal-start-date-validation-handler.spec.js
@@ -1,0 +1,57 @@
+import renewalStartDateValidationHandler from '../renewal-start-date-validation-handler'
+import { LICENCE_SUMMARY, RENEWAL_START_DATE } from '../../uri.js'
+
+describe('Renewal start date validation handler', () => {
+  const getMockRequest = (startYear, startMonth, startDay, renewedEndDate) => ({
+    cache: () => ({
+      initialize: () => ({}),
+      helpers: {
+        page: {
+          getCurrentPermission: async () => ({
+            payload: {
+              'licence-start-date-year': startYear || 1970,
+              'licence-start-date-month': startMonth || 1,
+              'licence-start-date-day': startDay || 1
+            }
+          }),
+          setCurrentPermission: async () => {}
+        },
+        transaction: {
+          getCurrentPermission: async () => ({
+            licensee: {
+              noLicenceRequired: {}
+            },
+            renewedEndDate: renewedEndDate || '2023-01-01T00:00:00.000Z'
+          }),
+          setCurrentPermission: async () => {}
+        },
+        status: {
+          getCurrentPermission: async () => {},
+          setCurrentPermission: async () => {}
+        }
+      }
+    })
+  })
+
+  const getRequestToolkit = () => ({
+    redirectWithLanguageCode: jest.fn()
+  })
+
+  it('redirects to the licence summary page when validation passes', async () => {
+    const request = getMockRequest(2023, 1, 3, '2023-01-01T00:00:00.000Z')
+    const toolkit = getRequestToolkit()
+
+    await renewalStartDateValidationHandler(request, toolkit)
+
+    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, LICENCE_SUMMARY.uri)
+  })
+
+  it('redirects to the start page when validation fails', async () => {
+    const request = getMockRequest()
+    const toolkit = getRequestToolkit()
+
+    await renewalStartDateValidationHandler(request, toolkit)
+
+    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, RENEWAL_START_DATE.uri)
+  })
+})

--- a/packages/gafl-webapp-service/src/handlers/__tests__/renewal-start-date-validation-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/renewal-start-date-validation-handler.spec.js
@@ -43,7 +43,7 @@ describe('Renewal start date validation handler', () => {
 
     await renewalStartDateValidationHandler(request, toolkit)
 
-    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, LICENCE_SUMMARY.uri)
+    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(LICENCE_SUMMARY.uri)
   })
 
   it('redirects to the start page when validation fails', async () => {
@@ -52,6 +52,6 @@ describe('Renewal start date validation handler', () => {
 
     await renewalStartDateValidationHandler(request, toolkit)
 
-    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, RENEWAL_START_DATE.uri)
+    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(RENEWAL_START_DATE.uri)
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/renewals-friendly-url-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/renewals-friendly-url-handler.spec.js
@@ -30,19 +30,21 @@ describe('The url handler', () => {
       [UTM.CAMPAIGN]: 'renewals',
       [QUERYSTRING_LICENCE_KEY]: null
     }
+    const request = generateRequestMock(params)
     const responseToolkit = generateResponseToolkitMock()
-    await urlHandler(generateRequestMock(params), responseToolkit)
-    expect(responseToolkit.redirect).toHaveBeenCalledWith(IDENTIFY.uri)
+    await urlHandler(request, responseToolkit)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, IDENTIFY.uri)
   })
 
   it.each([['B2F11U'], ['AH56F6'], ['GH330P']])('6 digit reference number exists and returns ATTRIBUTION', async licenceKey => {
     const params = {
       [QUERYSTRING_LICENCE_KEY]: licenceKey
     }
+    const request = generateRequestMock(params)
     const responseToolkit = generateResponseToolkitMock()
-    await urlHandler(generateRequestMock(params), responseToolkit)
+    await urlHandler(request, responseToolkit)
     const regExMatch = new RegExp(`^/attribution-url\\?utmcampaign\\=renewals&utmsource\\=aen_invitation&reference\\=${licenceKey}$`)
-    expect(responseToolkit.redirect).toHaveBeenCalledWith(expect.stringMatching(regExMatch))
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, expect.stringMatching(regExMatch))
   })
 
   it.each([['B2F11UH5D'], ['AH56'], ['GH330PPTD']])('reference number is not 6 digits and returns back to IDENTIFY', async licenceKey => {
@@ -51,9 +53,10 @@ describe('The url handler', () => {
       [UTM.SOURCE]: 'aen_invitation',
       [QUERYSTRING_LICENCE_KEY]: licenceKey
     }
+    const request = generateRequestMock(params)
     const responseToolkit = generateResponseToolkitMock()
-    await urlHandler(generateRequestMock(params), responseToolkit)
-    expect(responseToolkit.redirect).toHaveBeenCalledWith(IDENTIFY.uri)
+    await urlHandler(request, responseToolkit)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, IDENTIFY.uri)
   })
 
   const generateRequestMock = (params, query, status = {}) => ({
@@ -70,6 +73,6 @@ describe('The url handler', () => {
   })
 
   const generateResponseToolkitMock = () => ({
-    redirect: jest.fn()
+    redirectWithLanguageCode: jest.fn()
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/renewals-friendly-url-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/renewals-friendly-url-handler.spec.js
@@ -33,7 +33,7 @@ describe('The url handler', () => {
     const request = generateRequestMock(params)
     const responseToolkit = generateResponseToolkitMock()
     await urlHandler(request, responseToolkit)
-    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, IDENTIFY.uri)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(IDENTIFY.uri)
   })
 
   it.each([['B2F11U'], ['AH56F6'], ['GH330P']])('6 digit reference number exists and returns ATTRIBUTION', async licenceKey => {
@@ -44,7 +44,7 @@ describe('The url handler', () => {
     const responseToolkit = generateResponseToolkitMock()
     await urlHandler(request, responseToolkit)
     const regExMatch = new RegExp(`^/attribution-url\\?utmcampaign\\=renewals&utmsource\\=aen_invitation&reference\\=${licenceKey}$`)
-    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, expect.stringMatching(regExMatch))
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(expect.stringMatching(regExMatch))
   })
 
   it.each([['B2F11UH5D'], ['AH56'], ['GH330PPTD']])('reference number is not 6 digits and returns back to IDENTIFY', async licenceKey => {
@@ -56,7 +56,7 @@ describe('The url handler', () => {
     const request = generateRequestMock(params)
     const responseToolkit = generateResponseToolkitMock()
     await urlHandler(request, responseToolkit)
-    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, IDENTIFY.uri)
+    expect(responseToolkit.redirectWithLanguageCode).toHaveBeenCalledWith(IDENTIFY.uri)
   })
 
   const generateRequestMock = (params, query, status = {}) => ({

--- a/packages/gafl-webapp-service/src/handlers/agreed-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/agreed-handler.js
@@ -240,7 +240,7 @@ export default async (request, h) => {
     // Note: At this point payment completed status is never set
     const next = await processPayment(request, transaction, status)
     if (next) {
-      return h.redirectWithLanguageCode(request, next)
+      return h.redirectWithLanguageCode(next)
     }
   }
 
@@ -252,5 +252,5 @@ export default async (request, h) => {
   }
 
   // If we are here we have completed
-  return h.redirectWithLanguageCode(request, ORDER_COMPLETE.uri)
+  return h.redirectWithLanguageCode(ORDER_COMPLETE.uri)
 }

--- a/packages/gafl-webapp-service/src/handlers/agreed-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/agreed-handler.js
@@ -18,7 +18,6 @@ import { preparePayment } from '../processors/payment.js'
 import { COMPLETION_STATUS } from '../constants.js'
 import { ORDER_COMPLETE, PAYMENT_CANCELLED, PAYMENT_FAILED } from '../uri.js'
 import { PAYMENT_JOURNAL_STATUS_CODES, GOVUK_PAY_ERROR_STATUS_CODES } from '@defra-fish/business-rules-lib'
-import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 const debug = db('webapp:agreed-handler')
 
 /**
@@ -151,7 +150,7 @@ const processPayment = async (request, transaction, status) => {
       status[COMPLETION_STATUS.paymentFailed] = true
       status.payment = { code: state.code }
       await request.cache().helpers.status.set(status)
-      next = addLanguageCodeToUri(request, PAYMENT_FAILED.uri)
+      next = PAYMENT_FAILED.uri
     }
 
     // The user cancelled the payment
@@ -160,7 +159,7 @@ const processPayment = async (request, transaction, status) => {
       status[COMPLETION_STATUS.paymentCancelled] = true
       status.pay = { code: state.code }
       await request.cache().helpers.status.set(status)
-      next = addLanguageCodeToUri(request, PAYMENT_CANCELLED.uri)
+      next = PAYMENT_CANCELLED.uri
     }
 
     // The payment was rejected
@@ -169,7 +168,7 @@ const processPayment = async (request, transaction, status) => {
       status[COMPLETION_STATUS.paymentFailed] = true
       status.payment = { code: state.code }
       await request.cache().helpers.status.set(status)
-      next = addLanguageCodeToUri(request, PAYMENT_FAILED.uri)
+      next = PAYMENT_FAILED.uri
     }
   }
 
@@ -241,7 +240,7 @@ export default async (request, h) => {
     // Note: At this point payment completed status is never set
     const next = await processPayment(request, transaction, status)
     if (next) {
-      return h.redirect(next)
+      return h.redirectWithLanguageCode(request, next)
     }
   }
 
@@ -253,5 +252,5 @@ export default async (request, h) => {
   }
 
   // If we are here we have completed
-  return h.redirect(addLanguageCodeToUri(request, ORDER_COMPLETE.uri))
+  return h.redirectWithLanguageCode(request, ORDER_COMPLETE.uri)
 }

--- a/packages/gafl-webapp-service/src/handlers/analytics-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/analytics-handler.js
@@ -1,5 +1,4 @@
 import { ANALYTICS } from '../constants.js'
-import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 /**
  * Analytics route handler
  * @param request
@@ -56,8 +55,8 @@ export default async (request, h) => {
 
   if (host === referrerHost) {
     const redirect = referer.replace(origin, '')
-    return h.redirect(redirect)
+    return h.redirectWithLanguageCode(request, redirect)
   }
 
-  return h.redirect(addLanguageCodeToUri(request, '/buy'))
+  return h.redirectWithLanguageCode(request, '/buy')
 }

--- a/packages/gafl-webapp-service/src/handlers/analytics-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/analytics-handler.js
@@ -55,8 +55,8 @@ export default async (request, h) => {
 
   if (host === referrerHost) {
     const redirect = referer.replace(origin, '')
-    return h.redirectWithLanguageCode(request, redirect)
+    return h.redirectWithLanguageCode(redirect)
   }
 
-  return h.redirectWithLanguageCode(request, '/buy')
+  return h.redirectWithLanguageCode('/buy')
 }

--- a/packages/gafl-webapp-service/src/handlers/attribution-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/attribution-handler.js
@@ -13,10 +13,10 @@ export default async (request, h) => {
 
   if (request.query[UTM.CAMPAIGN] === RENEWALS_CAMPAIGN_ID) {
     if (request.query[QUERYSTRING_LICENCE_KEY]) {
-      return h.redirect(`${RENEWAL_BASE.uri}/${request.query[QUERYSTRING_LICENCE_KEY]}`)
+      return h.redirectWithLanguageCode(`${RENEWAL_BASE.uri}/${request.query[QUERYSTRING_LICENCE_KEY]}`)
     }
-    return h.redirect(IDENTIFY.uri)
+    return h.redirectWithLanguageCode(IDENTIFY.uri)
   }
 
-  return h.redirect(process.env.ATTRIBUTION_REDIRECT || ATTRIBUTION_REDIRECT_DEFAULT)
+  return h.redirectWithLanguageCode(process.env.ATTRIBUTION_REDIRECT || ATTRIBUTION_REDIRECT_DEFAULT)
 }

--- a/packages/gafl-webapp-service/src/handlers/authentication-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/authentication-handler.js
@@ -5,7 +5,6 @@ import { validation, RENEW_BEFORE_DAYS, RENEW_AFTER_DAYS, SERVICE_LOCAL_TIME } f
 import Joi from 'joi'
 import { salesApi } from '@defra-fish/connectors-lib'
 import moment from 'moment-timezone'
-import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 
 /**
  * Handler to authenticate the user on the easy renewals journey. It will
@@ -39,14 +38,14 @@ export default async (request, h) => {
         endDate: authenticationResult.permission.endDate
       }
     })
-    return h.redirect(addLanguageCodeToUri(request, RENEWAL_INACTIVE.uri))
+    return h.redirectWithLanguageCode(request, RENEWAL_INACTIVE.uri)
   }
 
   if (!authenticationResult) {
     payload.referenceNumber = referenceNumber
     await request.cache().helpers.page.setCurrentPermission(IDENTIFY.page, { payload, error: { referenceNumber: 'string.invalid' } })
     await request.cache().helpers.status.setCurrentPermission({ referenceNumber, authentication: { authorized: false } })
-    return h.redirect(addLanguageCodeToUri(request, IDENTIFY.uri))
+    return h.redirectWithLanguageCode(request, IDENTIFY.uri)
   } else {
     // Test for 12 month licence
     const daysDiff = moment(authenticationResult.permission.endDate).diff(moment().tz(SERVICE_LOCAL_TIME).startOf('day'), 'days')
@@ -63,7 +62,7 @@ export default async (request, h) => {
         await setUpCacheFromAuthenticationResult(request, authenticationResult)
         await setUpPayloads(request)
         await request.cache().helpers.status.setCurrentPermission({ authentication: { authorized: true } })
-        return h.redirect(addLanguageCodeToUri(request, CONTROLLER.uri))
+        return h.redirectWithLanguageCode(request, CONTROLLER.uri)
       }
     } else {
       return linkInactive(RENEWAL_ERROR_REASON.NOT_ANNUAL)

--- a/packages/gafl-webapp-service/src/handlers/authentication-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/authentication-handler.js
@@ -38,14 +38,14 @@ export default async (request, h) => {
         endDate: authenticationResult.permission.endDate
       }
     })
-    return h.redirectWithLanguageCode(request, RENEWAL_INACTIVE.uri)
+    return h.redirectWithLanguageCode(RENEWAL_INACTIVE.uri)
   }
 
   if (!authenticationResult) {
     payload.referenceNumber = referenceNumber
     await request.cache().helpers.page.setCurrentPermission(IDENTIFY.page, { payload, error: { referenceNumber: 'string.invalid' } })
     await request.cache().helpers.status.setCurrentPermission({ referenceNumber, authentication: { authorized: false } })
-    return h.redirectWithLanguageCode(request, IDENTIFY.uri)
+    return h.redirectWithLanguageCode(IDENTIFY.uri)
   } else {
     // Test for 12 month licence
     const daysDiff = moment(authenticationResult.permission.endDate).diff(moment().tz(SERVICE_LOCAL_TIME).startOf('day'), 'days')
@@ -62,7 +62,7 @@ export default async (request, h) => {
         await setUpCacheFromAuthenticationResult(request, authenticationResult)
         await setUpPayloads(request)
         await request.cache().helpers.status.setCurrentPermission({ authentication: { authorized: true } })
-        return h.redirectWithLanguageCode(request, CONTROLLER.uri)
+        return h.redirectWithLanguageCode(CONTROLLER.uri)
       }
     } else {
       return linkInactive(RENEWAL_ERROR_REASON.NOT_ANNUAL)

--- a/packages/gafl-webapp-service/src/handlers/controller-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/controller-handler.js
@@ -3,4 +3,4 @@
  * It is a state machine
  */
 import { nextPage } from '../routes/next-page.js'
-export default async (request, h) => h.redirect(await nextPage(request))
+export default async (request, h) => h.redirectWithLanguageCode(request, await nextPage(request))

--- a/packages/gafl-webapp-service/src/handlers/controller-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/controller-handler.js
@@ -3,4 +3,4 @@
  * It is a state machine
  */
 import { nextPage } from '../routes/next-page.js'
-export default async (request, h) => h.redirectWithLanguageCode(request, await nextPage(request))
+export default async (request, h) => h.redirectWithLanguageCode(await nextPage(request))

--- a/packages/gafl-webapp-service/src/handlers/new-session-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/new-session-handler.js
@@ -6,5 +6,5 @@ export default async (request, h) => {
   const existingCacheStatus = await request.cache().helpers.status.get()
   await request.cache().initialize()
   await initialiseAnalyticsSessionData(request, existingCacheStatus)
-  return h.redirectWithLanguageCode(request, CONTROLLER.uri)
+  return h.redirectWithLanguageCode(CONTROLLER.uri)
 }

--- a/packages/gafl-webapp-service/src/handlers/new-session-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/new-session-handler.js
@@ -1,11 +1,10 @@
 import { CONTROLLER } from '../uri.js'
 import { initialiseAnalyticsSessionData } from '../processors/analytics.js'
-import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 
 export default async (request, h) => {
   // The user may have an existing session, in which case we need to examine this for attribution and/or clientId
   const existingCacheStatus = await request.cache().helpers.status.get()
   await request.cache().initialize()
   await initialiseAnalyticsSessionData(request, existingCacheStatus)
-  return h.redirect(addLanguageCodeToUri(request, CONTROLLER.uri))
+  return h.redirectWithLanguageCode(request, CONTROLLER.uri)
 }

--- a/packages/gafl-webapp-service/src/handlers/oidc-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/oidc-handler.js
@@ -90,15 +90,15 @@ export const signIn = async (request, h) => {
     const hasTelesalesRole = !!userDetails?.roles.find(role => role.name === process.env.OIDC_REQUIRE_DYNAMICS_ROLE)
 
     if (!userDetails || userDetails.isDisabled) {
-      return h.redirect('/oidc/account-disabled')
+      return h.redirectWithLanguageCode('/oidc/account-disabled')
     } else if (!hasTelesalesRole) {
-      return h.redirect('/oidc/role-required')
+      return h.redirectWithLanguageCode('/oidc/role-required')
     } else {
       request.cookieAuth.set({ oid, name, email })
 
       db('Token expires at: %s', moment.unix(exp).format())
       request.cookieAuth.ttl((exp - moment().unix()) * 1000)
-      return h.redirect(postAuthRedirect)
+      return h.redirectWithLanguageCode(postAuthRedirect)
     }
   } else {
     const { error, error_description: errorDescription } = request.payload

--- a/packages/gafl-webapp-service/src/handlers/page-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/page-handler.js
@@ -112,7 +112,7 @@ export default (path, view, completion, getData) => ({
       } catch (err) {
         // If GetDataRedirect is thrown the getData function is requesting a redirect
         if (err instanceof GetDataRedirect) {
-          return h.redirectWithLanguageCode(request, err.redirectUrl)
+          return h.redirectWithLanguageCode(err.redirectUrl)
         }
 
         throw err
@@ -156,9 +156,9 @@ export default (path, view, completion, getData) => ({
     await request.cache().helpers.status.setCurrentPermission(status)
 
     if (typeof completion === 'function') {
-      return h.redirectWithLanguageCode(request, await completion(request))
+      return h.redirectWithLanguageCode(await completion(request))
     } else {
-      return h.redirectWithLanguageCode(request, completion)
+      return h.redirectWithLanguageCode(completion)
     }
   },
   /**
@@ -173,11 +173,11 @@ export default (path, view, completion, getData) => ({
       await request.cache().helpers.page.setCurrentPermission(view, { payload: request.payload, error: errorShimm(err) })
       await request.cache().helpers.status.setCurrentPermission({ [view]: PAGE_STATE.error, currentPage: view })
 
-      return h.redirectWithLanguageCode(request).takeover()
+      return h.redirectWithLanguageCode().takeover()
     } catch (err2) {
       // Need a catch here if the user has posted an invalid response with no cookie
       if (err2 instanceof CacheError) {
-        return h.redirectWithLanguageCode(request, CONTROLLER.uri).takeover()
+        return h.redirectWithLanguageCode(CONTROLLER.uri).takeover()
       }
 
       throw err2

--- a/packages/gafl-webapp-service/src/handlers/page-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/page-handler.js
@@ -112,7 +112,7 @@ export default (path, view, completion, getData) => ({
       } catch (err) {
         // If GetDataRedirect is thrown the getData function is requesting a redirect
         if (err instanceof GetDataRedirect) {
-          return h.redirect(addLanguageCodeToUri(request, err.redirectUrl))
+          return h.redirectWithLanguageCode(request, err.redirectUrl)
         }
 
         throw err
@@ -156,9 +156,9 @@ export default (path, view, completion, getData) => ({
     await request.cache().helpers.status.setCurrentPermission(status)
 
     if (typeof completion === 'function') {
-      return h.redirect(await completion(request))
+      return h.redirectWithLanguageCode(request, await completion(request))
     } else {
-      return h.redirect(completion)
+      return h.redirectWithLanguageCode(request, completion)
     }
   },
   /**
@@ -173,11 +173,11 @@ export default (path, view, completion, getData) => ({
       await request.cache().helpers.page.setCurrentPermission(view, { payload: request.payload, error: errorShimm(err) })
       await request.cache().helpers.status.setCurrentPermission({ [view]: PAGE_STATE.error, currentPage: view })
 
-      return h.redirect(addLanguageCodeToUri(request)).takeover()
+      return h.redirectWithLanguageCode(request).takeover()
     } catch (err2) {
       // Need a catch here if the user has posted an invalid response with no cookie
       if (err2 instanceof CacheError) {
-        return h.redirect(CONTROLLER.uri).takeover()
+        return h.redirectWithLanguageCode(request, CONTROLLER.uri).takeover()
       }
 
       throw err2

--- a/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
@@ -42,7 +42,7 @@ export default async (request, h) => {
     await request
       .cache()
       .helpers.status.setCurrentPermission({ [RENEWAL_START_DATE.page]: PAGE_STATE.error, currentPage: RENEWAL_START_DATE.page })
-    return h.redirectWithLanguageCode(request, RENEWAL_START_DATE.uri)
+    return h.redirectWithLanguageCode(RENEWAL_START_DATE.uri)
   } else {
     permission.licenceStartDate = moment({
       year: payload['licence-start-date-year'],
@@ -69,6 +69,6 @@ export default async (request, h) => {
 
     ageConcessionHelper(permission)
     await request.cache().helpers.transaction.setCurrentPermission(permission)
-    return h.redirectWithLanguageCode(request, LICENCE_SUMMARY.uri)
+    return h.redirectWithLanguageCode(LICENCE_SUMMARY.uri)
   }
 }

--- a/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/renewal-start-date-validation-handler.js
@@ -8,7 +8,6 @@ import JoiDate from '@hapi/joi-date'
 import { ageConcessionHelper } from '../processors/concession-helper.js'
 import { licenceToStart } from '../pages/licence-details/licence-to-start/update-transaction.js'
 import { cacheDateFormat } from '../processors/date-and-time-display.js'
-import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 
 const JoiX = Joi.extend(JoiDate)
 /**
@@ -43,7 +42,7 @@ export default async (request, h) => {
     await request
       .cache()
       .helpers.status.setCurrentPermission({ [RENEWAL_START_DATE.page]: PAGE_STATE.error, currentPage: RENEWAL_START_DATE.page })
-    return h.redirect(addLanguageCodeToUri(request, RENEWAL_START_DATE.uri))
+    return h.redirectWithLanguageCode(request, RENEWAL_START_DATE.uri)
   } else {
     permission.licenceStartDate = moment({
       year: payload['licence-start-date-year'],
@@ -70,6 +69,6 @@ export default async (request, h) => {
 
     ageConcessionHelper(permission)
     await request.cache().helpers.transaction.setCurrentPermission(permission)
-    return h.redirect(addLanguageCodeToUri(request, LICENCE_SUMMARY.uri))
+    return h.redirectWithLanguageCode(request, LICENCE_SUMMARY.uri)
   }
 }

--- a/packages/gafl-webapp-service/src/handlers/renewals-friendly-url-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/renewals-friendly-url-handler.js
@@ -15,10 +15,9 @@ export default async (request, h) => {
     const sixDigit = /^[A-Za-z0-9]{6}$/.test(refNumber)
     if (sixDigit) {
       return h.redirectWithLanguageCode(
-        request,
         `${ATTRIBUTION.uri}?${UTM.CAMPAIGN}=${RENEWALS_CAMPAIGN_ID}&${UTM.SOURCE}=${AEN_INVITATION_ID}&${QUERYSTRING_LICENCE_KEY}=${refNumber}`
       )
     }
   }
-  return h.redirectWithLanguageCode(request, IDENTIFY.uri)
+  return h.redirectWithLanguageCode(IDENTIFY.uri)
 }

--- a/packages/gafl-webapp-service/src/handlers/renewals-friendly-url-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/renewals-friendly-url-handler.js
@@ -14,10 +14,11 @@ export default async (request, h) => {
     const refNumber = request.params[QUERYSTRING_LICENCE_KEY]
     const sixDigit = /^[A-Za-z0-9]{6}$/.test(refNumber)
     if (sixDigit) {
-      return h.redirect(
+      return h.redirectWithLanguageCode(
+        request,
         `${ATTRIBUTION.uri}?${UTM.CAMPAIGN}=${RENEWALS_CAMPAIGN_ID}&${UTM.SOURCE}=${AEN_INVITATION_ID}&${QUERYSTRING_LICENCE_KEY}=${refNumber}`
       )
     }
   }
-  return h.redirect(IDENTIFY.uri)
+  return h.redirectWithLanguageCode(request, IDENTIFY.uri)
 }

--- a/packages/gafl-webapp-service/src/routes/__tests__/misc-routes.spec.js
+++ b/packages/gafl-webapp-service/src/routes/__tests__/misc-routes.spec.js
@@ -1,33 +1,5 @@
 import { start, stop, injectWithCookies, initialize } from '../../__mocks__/test-utils-system.js'
 import { REFUND_POLICY, ACCESSIBILITY_STATEMENT, COOKIES, PRIVACY_POLICY, RENEWAL_PUBLIC, IDENTIFY, CONTROLLER } from '../../uri.js'
-import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
-
-jest.mock('../../processors/uri-helper.js')
-
-const mockTransactionCacheGet = jest.fn(() => ({
-  licenceStartDate: '2021-07-01',
-  numberOfRods: '3',
-  licenceType: 'Salmon and sea trout',
-  licenceLength: '12M',
-  licensee: {
-    firstName: 'Graham',
-    lastName: 'Willis',
-    birthDate: '1946-01-01'
-  },
-  permit: {
-    cost: 6
-  }
-}))
-
-const mockRequest = {
-  cache: () => ({
-    helpers: {
-      transaction: {
-        getCurrentPermission: mockTransactionCacheGet
-      }
-    }
-  })
-}
 
 // Start application before running the test case
 beforeAll(() => new Promise(resolve => start(resolve)))
@@ -40,7 +12,7 @@ describe('The miscellaneous route handlers', () => {
   it('redirect to the main controller when / is requested', async () => {
     const data = await injectWithCookies('GET', '/')
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(addLanguageCodeToUri(mockRequest, CONTROLLER.uri))
+    expect(data.headers.location).toBe(CONTROLLER.uri)
   })
 
   it('return the refund policy page when requested', async () => {

--- a/packages/gafl-webapp-service/src/routes/__tests__/next-page.spec.js
+++ b/packages/gafl-webapp-service/src/routes/__tests__/next-page.spec.js
@@ -1,13 +1,10 @@
 import { nextPage } from '../next-page.js'
-import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
 
-/* jest.mock('../../handlers/update-transaction-functions.js') */
 jest.mock('../journey-definition.js', () => [
   { current: { page: 'start', uri: '/start' }, next: { okay: { page: { uri: '/after/start' } } } },
   { current: { page: 'not-start', uri: '/not/start', next: { okay: { page: { uri: '/next/page' } } } } }
 ])
 jest.mock('../../handlers/result-functions.js', () => ({ start: () => 'okay' }))
-jest.mock('../../processors/uri-helper.js')
 
 describe('nextPage', () => {
   beforeEach(jest.resetAllMocks)
@@ -15,23 +12,12 @@ describe('nextPage', () => {
   it.each([
     ['start', '/after/start'],
     ['not-start', '/not/start']
-  ])('passes request and route node to addLanguageCodeToUri', async (currentPage, uri) => {
+  ])('returns the expected uri', async (currentPage, uri) => {
     const request = getSampleRequest(currentPage)
-    await nextPage(request)
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, uri)
-  })
-
-  it.each([
-    ['start', '/after/start'],
-    ['not-start', '/not/start']
-  ])('returns result of addLanguageCodeToUri', async (currentPage, uri) => {
-    const request = getSampleRequest(currentPage)
-    const returnValue = Symbol(uri)
-    addLanguageCodeToUri.mockReturnValueOnce(returnValue)
 
     const result = await nextPage(request)
 
-    expect(result).toEqual(returnValue)
+    expect(result).toEqual(uri)
   })
 })
 

--- a/packages/gafl-webapp-service/src/routes/misc-routes.js
+++ b/packages/gafl-webapp-service/src/routes/misc-routes.js
@@ -50,7 +50,7 @@ export default [
   {
     method: 'GET',
     path: '/',
-    handler: async (request, h) => h.redirectWithLanguageCode(CONTROLLER.uri)
+    handler: async (_request, h) => h.redirectWithLanguageCode(CONTROLLER.uri)
   },
   {
     method: 'GET',

--- a/packages/gafl-webapp-service/src/routes/misc-routes.js
+++ b/packages/gafl-webapp-service/src/routes/misc-routes.js
@@ -50,7 +50,7 @@ export default [
   {
     method: 'GET',
     path: '/',
-    handler: async (request, h) => h.redirectWithLanguageCode(request, CONTROLLER.uri)
+    handler: async (request, h) => h.redirectWithLanguageCode(CONTROLLER.uri)
   },
   {
     method: 'GET',
@@ -71,7 +71,7 @@ export default [
       if (request.params.referenceNumber) {
         await request.cache().helpers.status.setCurrentPermission({ referenceNumber: request.params.referenceNumber })
       }
-      return h.redirectWithLanguageCode(request, IDENTIFY.uri)
+      return h.redirectWithLanguageCode(IDENTIFY.uri)
     }
   },
   {
@@ -94,7 +94,7 @@ export default [
     path: ADD_PERMISSION.uri,
     handler: async (request, h) => {
       await addPermission(request)
-      return h.redirectWithLanguageCode(request, CONTROLLER.uri)
+      return h.redirectWithLanguageCode(CONTROLLER.uri)
     }
   },
   {

--- a/packages/gafl-webapp-service/src/routes/misc-routes.js
+++ b/packages/gafl-webapp-service/src/routes/misc-routes.js
@@ -50,7 +50,7 @@ export default [
   {
     method: 'GET',
     path: '/',
-    handler: async (request, h) => h.redirect(addLanguageCodeToUri(request, CONTROLLER.uri))
+    handler: async (request, h) => h.redirectWithLanguageCode(request, CONTROLLER.uri)
   },
   {
     method: 'GET',
@@ -71,7 +71,7 @@ export default [
       if (request.params.referenceNumber) {
         await request.cache().helpers.status.setCurrentPermission({ referenceNumber: request.params.referenceNumber })
       }
-      return h.redirect(IDENTIFY.uri)
+      return h.redirectWithLanguageCode(request, IDENTIFY.uri)
     }
   },
   {
@@ -94,7 +94,7 @@ export default [
     path: ADD_PERMISSION.uri,
     handler: async (request, h) => {
       await addPermission(request)
-      return h.redirect(addLanguageCodeToUri(request, CONTROLLER.uri))
+      return h.redirectWithLanguageCode(request, CONTROLLER.uri)
     }
   },
   {

--- a/packages/gafl-webapp-service/src/routes/next-page.js
+++ b/packages/gafl-webapp-service/src/routes/next-page.js
@@ -6,7 +6,6 @@ import resultFunctions from '../handlers/result-functions.js'
 import updateTransactionFunctions from '../handlers/update-transaction-functions.js'
 import journeyDefinition from './journey-definition.js'
 import { CommonResults } from '../constants.js'
-import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 
 const defaultResultFunction = () => CommonResults.OK
 
@@ -18,7 +17,7 @@ export const nextPage = async request => {
   const routeNode = journeyDefinition.find(p => p.current.page === currentPage)
   // If the current page has an error then reload it.
   if (!status[status.currentPage] && currentPage !== 'start') {
-    return addLanguageCodeToUri(request, routeNode.current.uri)
+    return routeNode.current.uri
   }
   // Update the transaction with the validated page details
   if (typeof updateTransactionFunctions[currentPage] === 'function') {
@@ -29,5 +28,5 @@ export const nextPage = async request => {
   const result = await (resultFunctions[currentPage] || defaultResultFunction)(request)
 
   // Locate the next page
-  return addLanguageCodeToUri(request, routeNode.next[result].page.uri)
+  return routeNode.next[result].page.uri
 }

--- a/packages/gafl-webapp-service/src/server.js
+++ b/packages/gafl-webapp-service/src/server.js
@@ -180,8 +180,8 @@ const init = async () => {
    */
   server.decorate('request', 'cache', cacheDecorator(sessionCookieName))
 
-  server.decorate('toolkit', 'redirectWithLanguageCode', function (request, redirect) {
-    const uriWithLanguage = addLanguageCodeToUri(request, redirect)
+  server.decorate('toolkit', 'redirectWithLanguageCode', function (redirect) {
+    const uriWithLanguage = addLanguageCodeToUri(this.request, redirect)
 
     return this.redirect(uriWithLanguage)
   })

--- a/packages/gafl-webapp-service/src/server.js
+++ b/packages/gafl-webapp-service/src/server.js
@@ -25,6 +25,7 @@ import { errorHandler } from './handlers/error-handler.js'
 import { initialise as initialiseOIDC } from './handlers/oidc-handler.js'
 import { getPlugins } from './plugins.js'
 import { airbrake } from '@defra-fish/connectors-lib'
+import { addLanguageCodeToUri } from './processors/uri-helper.js'
 airbrake.initialise()
 let server
 
@@ -178,6 +179,12 @@ const init = async () => {
    * simple setters and getters hiding the session key.
    */
   server.decorate('request', 'cache', cacheDecorator(sessionCookieName))
+
+  server.decorate('toolkit', 'redirectWithLanguageCode', function (request, redirect) {
+    const uriWithLanguage = addLanguageCodeToUri(request, redirect)
+
+    return this.redirect(uriWithLanguage)
+  })
 
   if (process.env.CHANNEL === 'telesales') {
     await initialiseOIDC(server)

--- a/packages/gafl-webapp-service/src/session-cache/__tests__/session-manager.spec.js
+++ b/packages/gafl-webapp-service/src/session-cache/__tests__/session-manager.spec.js
@@ -151,7 +151,7 @@ describe('takeover by agreed handler once agreed flag is set', () => {
     const request = getMockRequest()
     const toolkit = getMockToolkit()
     await initialisedSessionManager(request, toolkit)
-    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, AGREED.uri)
+    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(AGREED.uri)
   })
 
   it('returns a takeover response after redirect', async () => {

--- a/packages/gafl-webapp-service/src/session-cache/__tests__/session-manager.spec.js
+++ b/packages/gafl-webapp-service/src/session-cache/__tests__/session-manager.spec.js
@@ -12,11 +12,6 @@ import {
   IDENTIFY,
   AGREED
 } from '../../uri.js'
-import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
-
-jest.mock('../../processors/uri-helper.js', () => ({
-  addLanguageCodeToUri: jest.fn((request, uri) => uri)
-}))
 
 mockSalesApi()
 
@@ -144,7 +139,7 @@ describe('takeover by agreed handler once agreed flag is set', () => {
   })
   const getMockToolkit = (takeover = () => {}) => ({
     state: () => {},
-    redirect: jest.fn(() => ({
+    redirectWithLanguageCode: jest.fn(() => ({
       takeover
     }))
   })
@@ -153,9 +148,10 @@ describe('takeover by agreed handler once agreed flag is set', () => {
   beforeEach(jest.clearAllMocks)
 
   it("redirects to agreed handler when status is already agreed and request path isn't in exempt set", async () => {
+    const request = getMockRequest()
     const toolkit = getMockToolkit()
-    await initialisedSessionManager(getMockRequest(), toolkit)
-    expect(toolkit.redirect).toHaveBeenCalledWith(AGREED.uri)
+    await initialisedSessionManager(request, toolkit)
+    expect(toolkit.redirectWithLanguageCode).toHaveBeenCalledWith(request, AGREED.uri)
   })
 
   it('returns a takeover response after redirect', async () => {
@@ -165,24 +161,5 @@ describe('takeover by agreed handler once agreed flag is set', () => {
       getMockToolkit(() => takeoverResponse)
     )
     expect(response).toBe(takeoverResponse)
-  })
-
-  it('passes request to addLanguageCodeToUri before redirecting', async () => {
-    const request = getMockRequest()
-    await initialisedSessionManager(request, getMockToolkit())
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, expect.any(String))
-  })
-
-  it('passes AGREED.uri to addLanguageCodeToUri before redirecting', async () => {
-    await initialisedSessionManager(getMockRequest(), getMockToolkit())
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(expect.any(Object), AGREED.uri)
-  })
-
-  it('passes result of addLanguageCodeToUri to redirect', async () => {
-    const decoratedUri = Symbol('redirect uri')
-    addLanguageCodeToUri.mockReturnValueOnce(decoratedUri)
-    const toolkit = getMockToolkit()
-    await initialisedSessionManager(getMockRequest(), toolkit)
-    expect(toolkit.redirect).toHaveBeenCalledWith(decoratedUri)
   })
 })

--- a/packages/gafl-webapp-service/src/session-cache/session-manager.js
+++ b/packages/gafl-webapp-service/src/session-cache/session-manager.js
@@ -18,7 +18,6 @@ import {
   COOKIES
 } from '../uri.js'
 import { initialiseAnalyticsSessionData } from '../processors/analytics.js'
-import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 
 const debug = db('webapp:session-manager')
 
@@ -91,7 +90,7 @@ const sessionManager = sessionCookieName => async (request, h) => {
      */
     const status = await request.cache().helpers.status.get()
     if (status.agreed && !agreedHandlerProtectionExemptSet.includes(request.path)) {
-      return h.redirect(addLanguageCodeToUri(request, AGREED.uri)).takeover()
+      return h.redirectWithLanguageCode(request, AGREED.uri).takeover()
     }
 
     /*
@@ -110,7 +109,7 @@ const sessionManager = sessionCookieName => async (request, h) => {
     if (initialized) {
       await initialiseAnalyticsSessionData(request)
       if (!includesRegex(request.path, startProtectionExemptSet)) {
-        return h.redirect(CONTROLLER.uri).takeover()
+        return h.redirectWithLanguageCode(request, CONTROLLER.uri).takeover()
       }
     }
   }

--- a/packages/gafl-webapp-service/src/session-cache/session-manager.js
+++ b/packages/gafl-webapp-service/src/session-cache/session-manager.js
@@ -90,7 +90,7 @@ const sessionManager = sessionCookieName => async (request, h) => {
      */
     const status = await request.cache().helpers.status.get()
     if (status.agreed && !agreedHandlerProtectionExemptSet.includes(request.path)) {
-      return h.redirectWithLanguageCode(request, AGREED.uri).takeover()
+      return h.redirectWithLanguageCode(AGREED.uri).takeover()
     }
 
     /*
@@ -109,7 +109,7 @@ const sessionManager = sessionCookieName => async (request, h) => {
     if (initialized) {
       await initialiseAnalyticsSessionData(request)
       if (!includesRegex(request.path, startProtectionExemptSet)) {
-        return h.redirectWithLanguageCode(request, CONTROLLER.uri).takeover()
+        return h.redirectWithLanguageCode(CONTROLLER.uri).takeover()
       }
     }
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3111

This PR refactors internal redirects to use a new redirectWithLanguageCode function on the response toolkit. This function allows us to call a redirect for the correct language without having to also call addLanguageCodeToUri each time.  This approach was initially demoed in https://github.com/DEFRA/rod-licensing/pull/1514 but this PR handles the implementation of the function and rolling it out to the rest of the app.