### PR TITLE
Update Ubuntu version used for GH Actions builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     name: tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       TZ: Europe/London
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   new-version:
     name: new-version
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: tests
     if: ${{ github.event_name == 'push' }}
     steps:


### PR DESCRIPTION
GitHub Actions is deprecating Ubuntu 18.04 for builds so we need to update this.