### PR TITLE
Stop language parameters from being duplicated in URLs

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/uri-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/uri-helper.spec.js
@@ -45,4 +45,17 @@ describe('URI Helpers: addLanguageCodeToURI', () => {
       expect(result).toEqual(decoratedUrl)
     })
   })
+
+  describe.each(['https://my-url.com/path?data=true&lang=cy', 'https://my-url.com/path?lang=cy'])('', path => {
+    it('if the supplied url already has a language parameter on it, it does not add a duplicate parameter', () => {
+      const mockRequest = {
+        path: path,
+        url: {
+          search: '?lang=cy'
+        }
+      }
+      const result = addLanguageCodeToUri(mockRequest, path)
+      expect(result).toEqual(path)
+    })
+  })
 })

--- a/packages/gafl-webapp-service/src/processors/__tests__/uri-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/uri-helper.spec.js
@@ -46,16 +46,21 @@ describe('URI Helpers: addLanguageCodeToURI', () => {
     })
   })
 
-  describe.each(['https://my-url.com/path?data=true&lang=cy', 'https://my-url.com/path?lang=cy'])('', path => {
-    it('if the supplied url already has a language parameter on it, it does not add a duplicate parameter', () => {
+  describe.each([
+    ['https://my-url.com/path?data=true&lang=cy', 'https://my-url.com/path?data=true&lang=cy'],
+    ['https://my-url.com/path?lang=cy', 'https://my-url.com/path?lang=cy'],
+    ['https://my-url.com/path?data=true&lang=en', 'https://my-url.com/path?data=true&lang=cy'],
+    ['https://my-url.com/path?lang=en', 'https://my-url.com/path?lang=cy']
+  ])('', (suppliedPath, expectedPath) => {
+    it('if the supplied url already has a language parameter on it, it does not add a duplicate or conflicting parameter', () => {
       const mockRequest = {
-        path: path,
+        path: suppliedPath,
         url: {
           search: '?lang=cy'
         }
       }
-      const result = addLanguageCodeToUri(mockRequest, path)
-      expect(result).toEqual(path)
+      const result = addLanguageCodeToUri(mockRequest, suppliedPath)
+      expect(result).toEqual(expectedPath)
     })
   })
 })

--- a/packages/gafl-webapp-service/src/processors/uri-helper.js
+++ b/packages/gafl-webapp-service/src/processors/uri-helper.js
@@ -1,5 +1,10 @@
 export const addLanguageCodeToUri = (request, uri) => {
   const path = uri || request.path
+
+  if (/.*lang=cy.*/.test(path)) {
+    return path
+  }
+
   const languageSpecifier = /.*\?.*/.test(path) ? '&lang=cy' : '?lang=cy'
   return `${path}${/\?.*lang=cy.*$/.test(request.url.search) ? languageSpecifier : ''}`
 }

--- a/packages/gafl-webapp-service/src/processors/uri-helper.js
+++ b/packages/gafl-webapp-service/src/processors/uri-helper.js
@@ -1,10 +1,9 @@
 export const addLanguageCodeToUri = (request, uri) => {
   const path = uri || request.path
 
-  if (/.*lang=cy.*/.test(path)) {
-    return path
-  }
+  // Remove any existing lang parameters
+  const cleanPath = path.replace(/[?|&]lang=[a-z]{2}/, '')
 
-  const languageSpecifier = /.*\?.*/.test(path) ? '&lang=cy' : '?lang=cy'
-  return `${path}${/\?.*lang=cy.*$/.test(request.url.search) ? languageSpecifier : ''}`
+  const languageSpecifier = /.*\?.*/.test(cleanPath) ? '&lang=cy' : '?lang=cy'
+  return `${cleanPath}${/\?.*lang=cy.*$/.test(request.url.search) ? languageSpecifier : ''}`
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3111

Testing revealed that the links to accept and reject cookies were failing when the language was set to Welsh. This turned out to be because multiple `lang` parameters were being added - for example, `/buy?lang=cy&lang=cy`

We don't want this to happen, so this PR changes the addLanguageCodeToUri function to exit early if the URI provided already has a language code.