### PR TITLE
Reduce renew prior window

### DIFF
--- a/packages/business-rules-lib/src/constants.js
+++ b/packages/business-rules-lib/src/constants.js
@@ -50,7 +50,7 @@ export const POCL_TRANSACTION_SOURCES = [POCL_DATA_SOURCE, DDE_DATA_SOURCE]
 /**
  * Describes the lifetime of the renewal link.
  */
-export const RENEW_BEFORE_DAYS = 60 // The number of days before licence expiry the link is active
+export const RENEW_BEFORE_DAYS = 30 // The number of days before licence expiry the link is active
 export const RENEW_AFTER_DAYS = 60 // The number of days after licence expiry the link is active
 
 /**


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3253

Reduce the length of time it's possible to renew in advance of a permission expiring from 60 to 30 days