### PR TITLE
Error after Ts&Cs page purchasing licence

### DIFF
--- a/packages/sales-api-service/src/services/transactions/__tests__/create-transaction.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/create-transaction.spec.js
@@ -68,7 +68,11 @@ describe('transaction service', () => {
       const mockPermit = MOCK_12MONTH_SENIOR_PERMIT
       getReferenceDataForEntityAndId.mockReturnValueOnce(mockPermit)
       await createTransaction(mockTransactionPayload())
-      const { mock: { calls: [[{ permit }]] } } = getPermissionCost
+      const {
+        mock: {
+          calls: [[{ permit }]]
+        }
+      } = getPermissionCost
       expect(permit).toBe(mockPermit)
     })
 

--- a/packages/sales-api-service/src/services/transactions/create-transaction.js
+++ b/packages/sales-api-service/src/services/transactions/create-transaction.js
@@ -65,7 +65,10 @@ async function createTransactionRecord (payload) {
   for (const permission of record.permissions) {
     const permit = await getReferenceDataForEntityAndId(Permit, permission.permitId)
     record.isRecurringPaymentSupported = record.isRecurringPaymentSupported && permit.isRecurringPaymentSupported
-    record.cost += getPermissionCost(permission) // permit.cost
+    record.cost += getPermissionCost({
+      ...permission,
+      permit
+    })
   }
   return record
 }


### PR DESCRIPTION
There's an error after the Ts&Cs page when purchasing a licence, after the latest change in IWTF-3184. This is due to there being no permit being attached to the permission passed to the cost calculator