### PR TITLE
Update transaction journal to use new price

### DIFF
--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
@@ -64,6 +64,9 @@ const getSampleRequest = ({
 jest.mock('@defra-fish/connectors-lib')
 
 describe('The order completion handler', () => {
+  beforeAll(() => {
+    getPermissionCost.mockReturnValue(1)
+  })
   beforeEach(jest.clearAllMocks)
 
   it.each(['agreed', 'posted', 'finalised'])('throws Boom.forbidden error when %s is not set', async completion => {
@@ -123,13 +126,17 @@ describe('The order completion handler', () => {
     expect(feedback).toBe(FEEDBACK_URI_DEFAULT)
   })
 
-  it('uses business rules to calculate permission cost', async () => {
-    const calculatedCost = Symbol('oodles')
+  it.each([
+    [29, '29'],
+    [37, '37'],
+    [48.5, '48.50'],
+    [99.99, '99.99']
+  ])('uses business rules to calculate permission cost (returns %d, displays £%s)', async (calculatedCost, displayCost) => {
     getPermissionCost.mockReturnValueOnce(calculatedCost)
 
     const { permissionCost } = await getData(getSampleRequest())
 
-    expect(permissionCost).toBe(calculatedCost)
+    expect(permissionCost).toBe(displayCost)
   })
 
   it('passes start date and permit to getPermissionCost function', async () => {

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
@@ -132,10 +132,17 @@ describe('The order completion handler', () => {
     expect(permissionCost).toBe(calculatedCost)
   })
 
-  it('passes permission to getPermissionCost function', async () => {
+  it('passes start date and permit to getPermissionCost function', async () => {
     const permission = getSamplePermission()
+    permission.startDate = Symbol('start date')
+    permission.permit = Symbol('permit')
     await getData(getSampleRequest({ permission }))
-    expect(getPermissionCost).toHaveBeenCalledWith(permission)
+    expect(getPermissionCost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: permission.startDate,
+        permit: permission.permit
+      })
+    )
   })
 
   it('uses displayStartTime to generate startTimeStringTitle', async () => {

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
@@ -31,11 +31,12 @@ export const getData = async request => {
   await request.cache().helpers.status.set({ [COMPLETION_STATUS.completed]: true })
   await request.cache().helpers.status.setCurrentPermission({ currentPage: ORDER_COMPLETE.page })
   const startTimeStringTitle = displayStartTime(request, permission)
+  const permissionCost = getPermissionCost(permission)
 
   return {
     startTimeStringTitle,
     isSalmonLicence: permission.licenceType === mappings.LICENCE_TYPE['salmon-and-sea-trout'],
-    permissionCost: getPermissionCost(permission),
+    permissionCost: Number.isInteger(permissionCost) ? String(permissionCost) : permissionCost.toFixed(2),
     permissionReference: permission.referenceNumber,
     uri: {
       feedback: process.env.FEEDBACK_URI || FEEDBACK_URI_DEFAULT,

--- a/packages/sales-api-service/src/services/transactions/__tests__/create-transaction.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/create-transaction.spec.js
@@ -58,22 +58,19 @@ describe('transaction service', () => {
       expect(cost).toBe(permitPrice)
     })
 
-    it('passes permission to getPermissionCost', async () => {
+    it('passes startDate and permit to getPermissionCost', async () => {
+      getReferenceDataForEntityAndId.mockReturnValueOnce(MOCK_12MONTH_SENIOR_PERMIT)
       const mockPayload = mockTransactionPayload()
-      await createTransaction(mockPayload)
-      expect(getPermissionCost).toHaveBeenCalledWith(expect.objectContaining(mockPayload.permissions[0]))
-    })
-
-    it('attaches permit to permission', async () => {
-      const mockPermit = MOCK_12MONTH_SENIOR_PERMIT
-      getReferenceDataForEntityAndId.mockReturnValueOnce(mockPermit)
-      await createTransaction(mockTransactionPayload())
       const {
-        mock: {
-          calls: [[{ permit }]]
-        }
-      } = getPermissionCost
-      expect(permit).toBe(mockPermit)
+        permissions: [{ startDate }]
+      } = mockPayload
+      await createTransaction(mockPayload)
+      expect(getPermissionCost).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDate,
+          permit: MOCK_12MONTH_SENIOR_PERMIT
+        })
+      )
     })
 
     it('throws exceptions back up the stack', async () => {

--- a/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
@@ -278,7 +278,7 @@ describe('transaction service', () => {
     })
   })
 
-  it('passes expected data to getPermissionCost', async () => {
+  it('passes start date and permit to getPermissionCost', async () => {
     const mockRecord = mockFinalisedTransactionRecord()
     const {
       permissions: [permission]

--- a/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
@@ -252,7 +252,11 @@ describe('transaction service', () => {
         const mockRecord = mockFinalisedTransactionRecord()
         AwsMock.DynamoDB.DocumentClient.__setResponse('get', { Item: mockRecord })
         await processQueue({ id: mockRecord.id })
-        const { mock: { calls: [[[transaction, chargeJournal, paymentJournal]]] } } = persist
+        const {
+          mock: {
+            calls: [[[transaction, chargeJournal, paymentJournal]]]
+          }
+        } = persist
         return { transaction, chargeJournal, paymentJournal }
       }
 

--- a/packages/sales-api-service/src/services/transactions/create-transaction.js
+++ b/packages/sales-api-service/src/services/transactions/create-transaction.js
@@ -62,11 +62,11 @@ async function createTransactionRecord (payload) {
   }
 
   // Generate derived fields
-  for (const permission of record.permissions) {
-    const permit = await getReferenceDataForEntityAndId(Permit, permission.permitId)
+  for (const { permitId, startDate } of record.permissions) {
+    const permit = await getReferenceDataForEntityAndId(Permit, permitId)
     record.isRecurringPaymentSupported = record.isRecurringPaymentSupported && permit.isRecurringPaymentSupported
     record.cost += getPermissionCost({
-      ...permission,
+      startDate,
       permit
     })
   }

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -57,8 +57,6 @@ export async function processQueue ({ id }) {
     const contact = await resolveContactPayload(licensee)
     const permit = await getReferenceDataForEntityAndId(Permit, permitId)
 
-    totalTransactionValue += getPermissionCost()
-
     const permission = await mapToPermission(
       referenceNumber,
       transactionRecord,
@@ -69,6 +67,11 @@ export async function processQueue ({ id }) {
       isLicenceForYou,
       isRenewal
     )
+
+    totalTransactionValue += getPermissionCost({
+      startDate,
+      permit
+    })
 
     permission.bindToEntity(Permission.definition.relationships.licensee, contact)
     permission.bindToEntity(Permission.definition.relationships.permit, permit)

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -11,7 +11,7 @@ import {
   RecurringPayment,
   RecurringPaymentInstruction
 } from '@defra-fish/dynamics-lib'
-import { DDE_DATA_SOURCE, POCL_TRANSACTION_SOURCES } from '@defra-fish/business-rules-lib'
+import { DDE_DATA_SOURCE, getPermissionCost, POCL_TRANSACTION_SOURCES } from '@defra-fish/business-rules-lib'
 import { getReferenceDataForEntityAndId, getGlobalOptionSetValue, getReferenceDataForEntity } from '../reference-data.service.js'
 import { resolveContactPayload } from '../contacts.service.js'
 import { retrieveStagedTransaction } from './retrieve-transaction.js'
@@ -57,7 +57,7 @@ export async function processQueue ({ id }) {
     const contact = await resolveContactPayload(licensee)
     const permit = await getReferenceDataForEntityAndId(Permit, permitId)
 
-    totalTransactionValue += permit.cost
+    totalTransactionValue += getPermissionCost()
 
     const permission = await mapToPermission(
       referenceNumber,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3187

Update transaction journal creation to use new price calculation in business rules lib
Also, a bit of tidying up of code written for previous tickets and a bug fix for the order complete page where prices that had pence were displaying without a trailing zero when they only had one decimal digit (e.g. 49.50 displaying as 49.5)