### PR TITLE
Re-add missing new licence button

### DIFF
--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
@@ -10,7 +10,8 @@ import {
   COOKIES,
   ACCESSIBILITY_STATEMENT,
   PRIVACY_POLICY,
-  REFUND_POLICY
+  REFUND_POLICY,
+  NEW_TRANSACTION
 } from '../../../../uri.js'
 import { addLanguageCodeToUri } from '../../../../processors/uri-helper.js'
 import { getData } from '../route.js'
@@ -137,7 +138,7 @@ describe('The order completion handler', () => {
     expect(data.statusCode).toBe(200)
   })
 
-  it('addLanguageCodeToUri is called with request and LICENCE_DETAILS.uri', async () => {
+  it.each([[LICENCE_DETAILS.uri], [NEW_TRANSACTION.uri]])('addLanguageCodeToUri is called with request and %s', async uri => {
     const status = () => ({
       [COMPLETION_STATUS.agreed]: true,
       [COMPLETION_STATUS.posted]: true,
@@ -160,7 +161,7 @@ describe('The order completion handler', () => {
     displayStartTime.mockReturnValueOnce('1:00am on 6 June 2020')
 
     await getData(request)
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, LICENCE_DETAILS.uri)
+    expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, uri)
   })
 
   it('addLanguageCodeToUri outputs correct value for licence details', async () => {

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/order-complete.njk
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/order-complete.njk
@@ -66,6 +66,13 @@
                 <a class="govuk-link" href="https://www.gov.uk/government/publications/fisheries-annual-report-2020-to-2021/fisheries-annual-report-2020-to-2021">{{ mssgs.order_complete_fisheries_report_link }}</a>{{ mssgs.order_complete_fisheries_report_suffix }}
             </p>
             <p class="govuk-body no-print"><a class="govuk-link" href="{{ data.uri.feedback }}">{{ mssgs.order_complete_tell_us }}</a>{{ mssgs.order_complete_tell_us_link }}</p>
+
+            {{ govukButton({
+                href: data.uri.new,
+                attributes: { id: 'continue' },
+                text: mssgs.buy_another_licence,
+                classes: "govuk-!-margin-top-4 no-print govuk-button--secondary"
+            }) }}
         </div>
 
     </div>

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
@@ -2,7 +2,7 @@ import pageRoute from '../../../routes/page-route.js'
 
 import Boom from '@hapi/boom'
 import { COMPLETION_STATUS, FEEDBACK_URI_DEFAULT } from '../../../constants.js'
-import { ORDER_COMPLETE, LICENCE_DETAILS } from '../../../uri.js'
+import { ORDER_COMPLETE, NEW_TRANSACTION, LICENCE_DETAILS } from '../../../uri.js'
 import { displayStartTime } from '../../../processors/date-and-time-display.js'
 import * as mappings from '../../../processors/mapping-constants.js'
 import { nextPage } from '../../../routes/next-page.js'
@@ -42,6 +42,7 @@ export const getData = async request => {
     totalCost: transaction.cost,
     numberOfLicences: transaction.permissions.length,
     uri: {
+      new: addLanguageCodeToUri(request, NEW_TRANSACTION.uri),
       feedback: process.env.FEEDBACK_URI || FEEDBACK_URI_DEFAULT,
       licenceDetails: addLanguageCodeToUri(request, LICENCE_DETAILS.uri)
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3209

This PR re-adds the new licence button to the order completion page, as it should not have been removed but there was a prototype error.