### PR TITLE
Display price as free rather than £0

### DIFF
--- a/packages/gafl-webapp-service/src/pages/macros/pricing-summary.njk
+++ b/packages/gafl-webapp-service/src/pages/macros/pricing-summary.njk
@@ -8,10 +8,10 @@
             {% if content[k].desc %}
                 <div class="govuk-body" id="pricing-summary-element-cost">
                     <span/>{{content[k].desc}}</span>
-                    {% if v.cost === 0  %}
+                    {% if v.cost === "0" %}
                         <strong/>{{ mssgs.free }}</strong>
                     {% else %}
-                        <strong/>{{ mssgs.pound }}{{v.cost}}</strong>
+                        <strong/>{{ mssgs.pound }}{{ v.cost }}</strong>
                     {% endif %}
                     {% if v.concessions %}
                         <div class="govuk-body-s" id="pricing-summary-element-concession">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3277

The pricing summary module should display licences with no cost as free, rather than as £0.