### PR TITLE
Amend permission end date to use locale time

### DIFF
--- a/packages/business-rules-lib/src/util/ages.js
+++ b/packages/business-rules-lib/src/util/ages.js
@@ -7,7 +7,7 @@ export const JUNIOR_MAX_AGE = 16
 /** The minimum age at which an angler becomes entitled to a senior concession */
 export const SENIOR_MIN_AGE = 65
 export const NEW_SENIOR_MIN_AGE = 66
-export const SENIOR_AGE_CHANGE_DATE = '2023-04-01'
+export const SENIOR_AGE_CHANGE_DATE = '2023-04-01T00:00:00.000+01:00'
 const changeoverMoment = moment(SENIOR_AGE_CHANGE_DATE)
 
 /**

--- a/packages/sales-api-service/src/services/permissions.service.js
+++ b/packages/sales-api-service/src/services/permissions.service.js
@@ -1,5 +1,5 @@
 import { Permission, Permit } from '@defra-fish/dynamics-lib'
-import { isJunior, isSenior } from '@defra-fish/business-rules-lib'
+import { isJunior, isSenior, SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
 import { getGlobalOptionSetValue, getReferenceDataForEntityAndId } from './reference-data.service.js'
 import { redis } from './ioredis.service.js'
 import moment from 'moment-timezone'
@@ -63,7 +63,7 @@ export const calculateEndDateMoment = async ({ permitId, startDate }) => {
   const permit = await getReferenceDataForEntityAndId(Permit, permitId)
   const duration = moment.duration(`P${permit.durationMagnitude}${permit.durationDesignator.description}`)
   if (permit.durationMagnitude === 12 && permit.durationDesignator.description === 'M') {
-    return moment(startDate).add(duration).subtract(1, 'day').tz('Europe/London').endOf('day')
+    return moment(startDate).tz(SERVICE_LOCAL_TIME).add(duration).subtract(1, 'day').tz(SERVICE_LOCAL_TIME).endOf('day')
   }
   return moment(startDate).add(duration)
 }

--- a/packages/sales-api-service/src/services/permissions.service.js
+++ b/packages/sales-api-service/src/services/permissions.service.js
@@ -63,7 +63,7 @@ export const calculateEndDateMoment = async ({ permitId, startDate }) => {
   const permit = await getReferenceDataForEntityAndId(Permit, permitId)
   const duration = moment.duration(`P${permit.durationMagnitude}${permit.durationDesignator.description}`)
   if (permit.durationMagnitude === 12 && permit.durationDesignator.description === 'M') {
-    return moment(startDate).tz(SERVICE_LOCAL_TIME).add(duration).subtract(1, 'day').tz(SERVICE_LOCAL_TIME).endOf('day')
+    return moment(startDate).tz(SERVICE_LOCAL_TIME).add(duration).subtract(1, 'day').endOf('day')
   }
   return moment(startDate).add(duration)
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3324

The end date calculation for a permission is going wrong after the change to BST, where it is going back an extra day. This is because the permission start date is set as midnight in the locale time, which is 11pm the day before in GMT, and the end date calculation takes the last minute of the previous date. Therefore '2023-03-31T23:00:00.000Z', which is '2023-04-01T00:00:00.000+01:00' is resulting in an end date of '2023-03-30T23:59:00.000Z'. It should actually be
'2023-03-31T22:59:00.000Z', or '2023-03-31T23:59:00.000+01:00'.