### PR TITLE
Stop checking SFTP

### DIFF
--- a/packages/pocl-job/src/__tests__/pocl-processor.spec.js
+++ b/packages/pocl-job/src/__tests__/pocl-processor.spec.js
@@ -68,10 +68,6 @@ describe('pocl-processor', () => {
       expect(config.initialise).toHaveBeenCalled()
     })
 
-    it('retrieves files from FTP', () => {
-      expect(ftpToS3).toHaveBeenCalled()
-    })
-
     it('refreshes S3 metadata', () => {
       expect(refreshS3Metadata).toHaveBeenCalled()
     })

--- a/packages/pocl-job/src/__tests__/pocl-processor.spec.js
+++ b/packages/pocl-job/src/__tests__/pocl-processor.spec.js
@@ -1,6 +1,5 @@
 import config from '../config.js'
 import { execute } from '../pocl-processor.js'
-import { ftpToS3 } from '../transport/ftp-to-s3.js'
 import { s3ToLocal } from '../transport/s3-to-local.js'
 import { getFileRecords } from '../io/db.js'
 import { refreshS3Metadata } from '../io/s3.js'

--- a/packages/pocl-job/src/pocl-processor.js
+++ b/packages/pocl-job/src/pocl-processor.js
@@ -33,7 +33,6 @@ export async function execute () {
       try {
         await config.initialise()
         debug('Retrieving files from FTP')
-        await ftpToS3()
         await refreshS3Metadata()
         const pendingFileRecords = await getFileRecords(FILE_STAGE.Pending, FILE_STAGE.Staging, FILE_STAGE.Finalising)
         debug('Found %s files remaining to be processed', pendingFileRecords.length)

--- a/packages/pocl-job/src/pocl-processor.js
+++ b/packages/pocl-job/src/pocl-processor.js
@@ -1,6 +1,5 @@
 import config from './config.js'
 import { DistributedLock, airbrake } from '@defra-fish/connectors-lib'
-import { ftpToS3 } from './transport/ftp-to-s3.js'
 import { s3ToLocal } from './transport/s3-to-local.js'
 import { getFileRecords } from './io/db.js'
 import { removeTemp } from './io/file.js'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3319

The Post Office SFTP server has been decommissioned and this is causing the POCL process to fall over every day. This change will stop the SFTP check taking place.