### PR TITLE
Display catch return info if any salmon licences are purchased

### DIFF
--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
@@ -2,62 +2,29 @@ import { LICENCE_DETAILS, NEW_TRANSACTION, ORDER_COMPLETE } from '../../../../ur
 import { addLanguageCodeToUri } from '../../../../processors/uri-helper.js'
 import { getData } from '../route.js'
 import { COMPLETION_STATUS, FEEDBACK_URI_DEFAULT } from '../../../../constants.js'
-import { displayStartTime } from '../../../../processors/date-and-time-display.js'
-import { LICENCE_TYPE } from '../../../../processors/mapping-constants.js'
-import { displayPermissionPrice } from '../../../../processors/price-display.js'
 
-jest.mock('../../../../processors/date-and-time-display.js')
 jest.mock('../../../../processors/uri-helper.js')
-jest.mock('../../../../constants.js', () => ({
-  ...jest.requireActual('../../../../constants.js'),
-  COMPLETION_STATUS: {
-    agreed: 'alright then',
-    posted: 'in the letterbox',
-    finalised: 'no going back now',
-    completed: 'all done'
-  },
-  FEEDBACK_URI_DEFAULT: Symbol('http://pulling-no-punches.com')
-}))
-jest.mock('../../../../processors/price-display.js')
-jest.mock('@defra-fish/business-rules-lib')
 
-const getSamplePermission = ({ referenceNumber = 'AAA111', licenceType = LICENCE_TYPE['trout-and-coarse'] } = {}) => ({
-  startDate: '2019-12-14T00:00:00Z',
-  licensee: {
-    postalFulfilment: 'test',
-    preferredMethodOfConfirmation: 'test'
-  },
-  licenceType,
-  referenceNumber
-})
-
-const getSampleRequest = ({
-  agreed = true,
-  posted = true,
-  finalised = true,
-  permission = getSamplePermission(),
-  statusSet = () => {},
-  transaction = () => ({
-    permissions: [],
-    cost: 0
-  }),
+const getMockRequest = ({
+  statusGetOverrides = {},
   statusSetCurrentPermission = () => {},
-  catalog = 'messages'
+  statusSet = () => {},
+  transaction = getMockTransaction()
 } = {}) => ({
   cache: () => ({
     helpers: {
       status: {
-        get: () => ({
-          [COMPLETION_STATUS.agreed]: agreed,
-          [COMPLETION_STATUS.posted]: posted,
-          [COMPLETION_STATUS.finalised]: finalised
+        get: async () => ({
+          [COMPLETION_STATUS.agreed]: true,
+          [COMPLETION_STATUS.posted]: true,
+          [COMPLETION_STATUS.finalised]: true,
+          ...statusGetOverrides
         }),
         setCurrentPermission: statusSetCurrentPermission,
         set: statusSet
       },
       transaction: {
-        getCurrentPermission: () => permission,
-        get: transaction
+        get: async () => transaction
       }
     }
   }),
@@ -65,26 +32,35 @@ const getSampleRequest = ({
     search: ''
   },
   i18n: {
-    getCatalog: () => catalog
+    getCatalog: () => 'messages'
   }
 })
+
+const getMockTransaction = (permissions = [], cost = 0) => ({
+  permissions,
+  cost
+})
+
 jest.mock('@defra-fish/connectors-lib')
 
 describe('The order completion handler', () => {
-  beforeAll(() => {
-    displayPermissionPrice.mockReturnValue('1')
-  })
   beforeEach(jest.clearAllMocks)
 
-  it.each(['agreed', 'posted', 'finalised'])('throws Boom.forbidden error when %s is not set', async completion => {
-    const request = getSampleRequest({ [completion]: false })
-    const callGetData = () => getData(request)
-    await expect(callGetData).rejects.toThrow(`Attempt to access the completion page handler with no ${completion} flag set`)
-  })
+  it.each([COMPLETION_STATUS.agreed, COMPLETION_STATUS.posted, COMPLETION_STATUS.finalised])(
+    'throws Boom.forbidden error when %s is not set',
+    async completion => {
+      const statusGetOverrides = { [completion]: false }
+      const request = getMockRequest({ statusGetOverrides })
+
+      await expect(() => getData(request)).rejects.toThrow(`Attempt to access the completion page handler with no ${completion} flag set`)
+    }
+  )
 
   it('sets completion flag', async () => {
     const statusSet = jest.fn()
-    await getData(getSampleRequest({ statusSet }))
+    const request = getMockRequest({ statusSet })
+
+    await getData(request)
     expect(statusSet).toHaveBeenCalledWith(
       expect.objectContaining({
         [COMPLETION_STATUS.completed]: true
@@ -94,7 +70,9 @@ describe('The order completion handler', () => {
 
   it('sets current page to order-complete in the cache', async () => {
     const statusSetCurrentPermission = jest.fn()
-    await getData(getSampleRequest({ statusSetCurrentPermission }))
+    const request = getMockRequest({ statusSetCurrentPermission })
+
+    await getData(request)
     expect(statusSetCurrentPermission).toHaveBeenCalledWith(
       expect.objectContaining({
         currentPage: ORDER_COMPLETE.page
@@ -103,7 +81,8 @@ describe('The order completion handler', () => {
   })
 
   it.each([[LICENCE_DETAILS.uri], [NEW_TRANSACTION.uri]])('addLanguageCodeToUri is called with request and %s', async uri => {
-    const request = getSampleRequest()
+    const request = getMockRequest()
+
     await getData(request)
     expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, uri)
   })
@@ -111,89 +90,60 @@ describe('The order completion handler', () => {
   it.each(['new', 'licenceDetails'])('data outputs addLanguageCodeToUri decorated value for %s uri', async uriName => {
     const decoratedUri = Symbol(uriName)
     addLanguageCodeToUri.mockReturnValue(decoratedUri)
+    const request = getMockRequest()
 
-    const { uri } = await getData(getSampleRequest())
-
-    expect(uri[uriName]).toEqual(decoratedUri)
+    const data = await getData(request)
+    expect(data.uri[uriName]).toEqual(decoratedUri)
   })
 
   it.each(['http://trustpilot.com', 'http://give-us-a-stinker'])('feedback link set to FEEDBACK_URI env var (%s)', async feedbackUri => {
     process.env.FEEDBACK_URI = feedbackUri
-    const {
-      uri: { feedback }
-    } = await getData(getSampleRequest())
-    expect(feedback).toBe(feedbackUri)
+    const request = getMockRequest()
+
+    const data = await getData(request)
+    expect(data.uri.feedback).toBe(feedbackUri)
   })
 
   it("uses FEEDBACK_URI_DEFAULT if FEEDBACK_URI env var isn't set", async () => {
     delete process.env.FEEDBACK_URI
-    const {
-      uri: { feedback }
-    } = await getData(getSampleRequest())
-    expect(feedback).toBe(FEEDBACK_URI_DEFAULT)
-  })
-
-  it.each([[LICENCE_DETAILS.uri], [NEW_TRANSACTION.uri]])('addLanguageCodeToUri is called with request and %s', async uri => {
-    const transaction = () => ({
-      permissions: [],
-      cost: 0
-    })
-
-    const request = getSampleRequest({ transaction })
-
-    displayStartTime.mockReturnValueOnce('1:00am on 6 June 2020')
-
-    await getData(request)
-    expect(addLanguageCodeToUri).toHaveBeenCalledWith(request, NEW_TRANSACTION.uri)
-  })
-
-  it.each`
-    permission                                                                    | expectedValue
-    ${getSamplePermission()}                                                      | ${false}
-    ${getSamplePermission({ licenceType: LICENCE_TYPE['salmon-and-sea-trout'] })} | ${true}
-  `('identifies salmon licence of type $permission.licenceType', async ({ permission, expectedValue }) => {
-    const request = getSampleRequest({ permission })
-    const { isSalmonLicence } = await getData(request)
-    expect(isSalmonLicence).toBe(expectedValue)
-  })
-
-  it('addLanguageCodeToUri outputs correct value', async () => {
-    const transaction = () => ({
-      permissions: [],
-      cost: 0
-    })
-
-    const decoratedUri = Symbol('order complete uri')
-    addLanguageCodeToUri.mockReturnValue(decoratedUri)
-
-    displayStartTime.mockReturnValueOnce('1:00am on 6 June 2020')
-    const request = getSampleRequest({ transaction })
+    const request = getMockRequest()
 
     const data = await getData(request)
-    expect(data.uri.new).toEqual(decoratedUri)
+    expect(data.uri.feedback).toBe(FEEDBACK_URI_DEFAULT)
   })
 
   it.each([
     [1, ['foo']],
     [2, ['foo', 'bar']]
   ])('checks the numberOfLicences correctly when the number of licences is %s', async (count, permissions) => {
-    const transaction = () => ({
-      permissions: permissions,
-      cost: 0
-    })
-    const request = getSampleRequest({ transaction })
+    const transaction = getMockTransaction(permissions)
+    const request = getMockRequest({ transaction })
+
     const data = await getData(request)
     expect(data.numberOfLicences).toEqual(count)
   })
 
   it('returns the correct totalCost', async () => {
-    const transaction = () => ({
-      permissions: [],
-      cost: 100
-    })
-    const request = getSampleRequest({ transaction })
-    const data = await getData(request)
+    const transaction = getMockTransaction([], 100)
+    const request = getMockRequest({ transaction })
 
+    const data = await getData(request)
     expect(data.totalCost).toEqual(100)
+  })
+
+  it.each([
+    ['no permits are for salmon fishing', false, ['Trout and coarse']],
+    ['the most recently-added permit is for salmon fishing', true, ['Trout and coarse', 'Salmon and sea trout']],
+    ['a previously-added permit is for salmon fishing', true, ['Salmon and sea trout', 'Trout and coarse']]
+  ])('returns the correct displayCatchReturnInfo when %s', async (_desc, expected, licenceTypes) => {
+    const permissions = []
+    for (const licenceType of licenceTypes) {
+      permissions.push({ licenceType })
+    }
+    const transaction = getMockTransaction(permissions)
+    const request = getMockRequest({ transaction })
+
+    const data = await getData(request)
+    expect(data.displayCatchReturnInfo).toEqual(expected)
   })
 })

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/order-complete.njk
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/order-complete.njk
@@ -40,15 +40,7 @@
             <p class="govuk-body">{{ mssgs.order_complete_conf_info_2 }}</p>
             <p class="govuk-body">{{ mssgs.order_complete_conf_info_3 }}</p>
 
-            <div class="govuk-!-margin-bottom-3">
-                {{ govukButton({
-                    href: data.uri.licenceDetails,
-                    text: mssgs.order_complete_view_details,
-                    classes: "govuk-button--secondary"
-                }) }}
-            </div>
-
-            {% if data.isSalmonLicence %}
+            {% if data.displayCatchReturnInfo %}
                 <div class="govuk-!-margin-bottom-3">
                     <h2 class="govuk-heading-l">{{ mssgs.order_complete_subheading_rcr }}</h2>
                     <div class="govuk-warning-text">

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
@@ -8,12 +8,7 @@ import { nextPage } from '../../../routes/next-page.js'
 import { addLanguageCodeToUri } from '../../../processors/uri-helper.js'
 
 const checkForSalmonPermits = transaction => {
-  for (const permission of transaction.permissions) {
-    if (permission.licenceType === mappings.LICENCE_TYPE['salmon-and-sea-trout']) {
-      return true
-    }
-  }
-  return false
+  return transaction.permissions.some(p => p.licenceType === mappings.LICENCE_TYPE['salmon-and-sea-trout'])
 }
 
 export const getData = async request => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3316

This fixes a bug in multibuy where we were only displaying the catch return info on the order complete page if the most recently added licence was for salmon fishing.

This info should be displayed if any of the licences added are for salmon fishing, not just the latest one.