### PR TITLE
Remove text from address lookup page

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -76,7 +76,7 @@
   "address_entry_error_pattern_postcode": "Nid yw’r cod post yn edrych yn gywir. Gwiriwch a rhowch gynnig arall arni",
   "address_entry_other": "Rhowch eu cyfeiriad",
   "address_entry_you": "Rhowch eich cyfeiriad",
-  "address_lookup_content_info": "Byddwn yn anfon y drwydded at y cyfeiriad hwn. Gall swyddog gorfodi’r glannau ofyn am y wybodaeth hon os bydd y drwydded yn cael ei gwirio.",
+  "address_lookup_content_info": "Gall swyddog gorfodi’r glannau ofyn am y wybodaeth hon os bydd y drwydded yn cael ei gwirio.",
   "address_lookup_crown_copyright_new_tab": "OS (opens in a new tab)",
   "address_lookup_crown_copyright_ref": "100024198.",
   "address_lookup_crown_copyright_terms_link": "telerau a'r amodau",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -76,7 +76,7 @@
   "address_entry_error_pattern_postcode": "The postcode doesn’t look right. Check and enter again",
   "address_entry_other": "Enter their address",
   "address_entry_you": "Enter your address",
-  "address_lookup_content_info": "This is where we will send the licence card. A bankside enforcement officer may ask for this information if the licence is checked.",
+  "address_lookup_content_info": "A bankside enforcement officer may ask for this information if the licence is checked.",
   "address_lookup_crown_copyright_new_tab": "OS (opens in a new tab)",
   "address_lookup_crown_copyright_ref": "100024198.",
   "address_lookup_crown_copyright_terms_link": "terms and conditions",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3367

This PR removes a sentence from the address lookup page that was causing confusion for users without posted licences.