### PR TITLE
Remove redudant text from user journey

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -306,8 +306,6 @@
   "licence_confirm_method_how_body_text": "Dyma sut y byddwn yn anfon cadarnhad o’r drwydded bysgota",
   "licence_confirm_method_how_title_other": "Sut fydden nhw’n dymuno derbyn eu cadarnhad trwydded bysgota?",
   "licence_confirm_method_how_title_you": "Sut hoffech chi dderbyn cadarnhad o'ch trwydded bysgota?",
-  "licence_confirm_method_where_body_hint_other": "Licence information will be sent by email or text message only. We will not send a licence card.",
-  "licence_confirm_method_where_body_hint_you": "Byddwch yn derbyn gwybodaeth am eich trwydded drwy e-bost neu neges destun yn unig. Ni fyddwch yn derbyn cerdyn trwydded.",
   "licence_confirm_method_where_body_text": "Dyma ble byddwn yn anfon y drwydded ar ôl derbyn y taliad.",
   "licence_confirm_method_where_title_other": "I ble y dylen ni anfon y drwydded bysgota?",
   "licence_confirm_method_where_title_you": "I ble y dylen ni anfon eich trwydded bysgota?",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -305,8 +305,6 @@
   "licence_confirm_method_how_body_text": "This is where we will send confirmation of the fishing licence",
   "licence_confirm_method_how_title_other": "How do they want their fishing licence confirmation?",
   "licence_confirm_method_how_title_you": "How do you want your fishing licence confirmation?",
-  "licence_confirm_method_where_body_hint_other": "Licence information will be sent by email or text message only. We will not send a licence card.",
-  "licence_confirm_method_where_body_hint_you": "You will receive your licence information by email or text message only. You will not receive a licence card.",
   "licence_confirm_method_where_body_text": "This is where we will send the licence after payment.",
   "licence_confirm_method_where_title_other": "Where should we send the fishing licence?",
   "licence_confirm_method_where_title_you": "Where should we send your fishing licence?",

--- a/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/licence-confirmation-method.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/licence-confirmation-method.njk
@@ -109,14 +109,11 @@
             value: "none",
             text: mssgs.licence_confirm_method_how_body_item,
             checked: payload['licence-confirmation-method'] === 'none'
-        }), itemsArray) 
+        }), itemsArray)
     %}
 {% else %}
     {% set title = mssgs.licence_confirm_method_where_title_you if data.isLicenceForYou else mssgs.licence_confirm_method_where_title_other %}
     {% set bodyText = mssgs.licence_confirm_method_where_body_text %}
-    {% if data.isLicenceForYou %}
-        {% set hintText = mssgs.licence_confirm_method_where_body_hint_you %}
-    {% endif %}   
 {% endif %}
 
 {% block pageContent %}
@@ -124,10 +121,6 @@
     {{ govukRadios({
         idPrefix: "licence-confirmation-method",
         name: "licence-confirmation-method",
-        hint: {
-          text: hintText,
-          classes: 'govuk-inset-text' if hintText
-        },
         errorMessage: { text: errorMsg } if error['licence-confirmation-method'],
         items: itemsArray
     }) }}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3366

The message in this text is now explained on the previous page in the journey, so this hint text is no longer necessary.

The variant text for the BOBO journey does not seem to have been in use at all, so removing it as well for cleanup.