### PR TITLE
Fix double count of page views from analytics banner

### DIFF
--- a/packages/gafl-webapp-service/src/__tests__/plugin.spec.js
+++ b/packages/gafl-webapp-service/src/__tests__/plugin.spec.js
@@ -51,7 +51,7 @@ describe('plugins', () => {
     )
   })
 
-  describe('initialiseHapiGapiPlugin', () => {
+  describe('trackAnalytics', () => {
     const generateRequestMock = (analytics = {}) => ({
       cache: jest.fn(() => ({
         hasSession: () => true,
@@ -71,7 +71,7 @@ describe('plugins', () => {
     it.each([
       [true, true],
       [false, false]
-    ])('trackAnalytics to be set to value of checkAnalytics', async (tracking, expectedResult) => {
+    ])('when acceptedTracking property equals %s, trackAnalytics should return %s', async (tracking, expectedResult) => {
       const analytics = {
         [ANALYTICS.acceptTracking]: tracking
       }

--- a/packages/gafl-webapp-service/src/__tests__/plugin.spec.js
+++ b/packages/gafl-webapp-service/src/__tests__/plugin.spec.js
@@ -1,13 +1,13 @@
 import { getPlugins } from '../plugins'
 import { ANALYTICS } from '../constants.js'
-import { checkAnalytics, getAnalyticsSessionId, skipPage } from '../handlers/analytics-handler.js'
+import { checkAnalytics, getAnalyticsSessionId, checkPage } from '../handlers/analytics-handler.js'
 import db from 'debug'
 
 jest.mock('../constants', () => ({
   ANALYTICS: {
     acceptTracking: 'accept',
     seenMessage: 'seen',
-    skipPage: 'skip'
+    skipPage: 'skip-page'
   },
   CommonResults: {
     OK: 'ok'
@@ -18,7 +18,7 @@ jest.mock('../constants', () => ({
 }))
 
 jest.mock('../handlers/analytics-handler.js', () => ({
-  skipPage: jest.fn(() => false),
+  checkPage: jest.fn(() => false),
   checkAnalytics: jest.fn(() => true),
   getAnalyticsSessionId: jest.fn(() => '123')
 }))
@@ -83,21 +83,20 @@ describe('plugins', () => {
     })
 
     it.each([
-      [true, 'session_id_example', 'Session is being tracked for: session_id_example', undefined],
-      [false, 'testing_session_id', 'Session is not being tracked for: testing_session_id', undefined],
-      [true, 'example_session_id', 'Session is being tracked for: example_session_id', undefined],
-      [true, 'test_session_id', 'Session is skipping page. Not tracking current page for: test_session_id', true]
+      [true, 'session_id_example', 'Session is being tracked for: session_id_example', false],
+      [false, 'testing_session_id', 'Session is not being tracked for: testing_session_id', false],
+      [true, 'example_session_id', 'Session is being tracked for: example_session_id', false],
+      [false, 'test_session_id', 'Session is not tracking current page for: test_session_id', true]
     ])('debug is called with session id and set ENABLE_ANALYTICS_OPT_IN_DEBUGGING to true', async (tracking, id, expectedResult, skip) => {
       const analytics = {
         [ANALYTICS.acceptTracking]: tracking,
-        [ANALYTICS.seenMessage]: true,
         [ANALYTICS.skipPage]: skip
       }
       process.env.ENABLE_ANALYTICS_OPT_IN_DEBUGGING = true
 
       checkAnalytics.mockReturnValueOnce(tracking)
       getAnalyticsSessionId.mockReturnValueOnce(id)
-      skipPage.mockReturnValue(skip)
+      checkPage.mockReturnValueOnce(skip)
 
       await hapiGapiPlugin.options.trackAnalytics(generateRequestMock(analytics))
 

--- a/packages/gafl-webapp-service/src/constants.js
+++ b/packages/gafl-webapp-service/src/constants.js
@@ -19,7 +19,8 @@ export const ANALYTICS = {
   selected: 'selected',
   acceptTracking: 'accepted-tracking',
   seenMessage: 'seen-message',
-  skipPage: 'skip-page'
+  skipPage: 'skip-page',
+  pageSkipped: 'page-skipped'
 }
 
 export const COMPLETION_STATUS = {

--- a/packages/gafl-webapp-service/src/constants.js
+++ b/packages/gafl-webapp-service/src/constants.js
@@ -19,7 +19,7 @@ export const ANALYTICS = {
   selected: 'selected',
   acceptTracking: 'accepted-tracking',
   seenMessage: 'seen-message',
-  skipPage: 'skip-page',
+  omitPageFromAnalytics: 'skip-page',
   pageSkipped: 'page-skipped'
 }
 

--- a/packages/gafl-webapp-service/src/constants.js
+++ b/packages/gafl-webapp-service/src/constants.js
@@ -18,7 +18,8 @@ export const AEN_INVITATION_ID = 'aen_invitation'
 export const ANALYTICS = {
   selected: 'selected',
   acceptTracking: 'accepted-tracking',
-  seenMessage: 'seen-message'
+  seenMessage: 'seen-message',
+  skipPage: 'skip-page'
 }
 
 export const COMPLETION_STATUS = {

--- a/packages/gafl-webapp-service/src/handlers/__tests__/__snapshots__/page-handler.spec.js.snap
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/__snapshots__/page-handler.spec.js.snap
@@ -6,10 +6,10 @@ exports[`The page handler function sets the value of pageData with displayAnalyt
     Array [
       "view",
       Object {
-        "acceptedTracking": "accepted-tracking",
+        "acceptedTracking": false,
         "altLang": Array [],
-        "analyticsMessageDisplayed": "seen-message",
-        "analyticsSelected": "selected",
+        "analyticsMessageDisplayed": false,
+        "analyticsSelected": false,
         "backRef": null,
         "displayAnalytics": false,
         "mssgs": undefined,
@@ -34,10 +34,10 @@ exports[`The page handler function sets the value of pageData with displayAnalyt
     Array [
       "view",
       Object {
-        "acceptedTracking": "accepted-tracking",
+        "acceptedTracking": false,
         "altLang": Array [],
-        "analyticsMessageDisplayed": "seen-message",
-        "analyticsSelected": "selected",
+        "analyticsMessageDisplayed": false,
+        "analyticsSelected": false,
         "backRef": null,
         "displayAnalytics": true,
         "mssgs": undefined,

--- a/packages/gafl-webapp-service/src/handlers/__tests__/check-analytics-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/check-analytics-handler.spec.js
@@ -17,11 +17,11 @@ describe('checkAnalytics', () => {
   })
 
   it.each`
-    desc                                                                                                                  | analytics                                                           | page     | trackingResult
-    ${'analytics has value of accept tracking as true, page should not be skipped then return of checkAnalytics is true'} | ${{ [ANALYTICS.acceptTracking]: true }}                             | ${false} | ${true}
-    ${'analytics has value of accept tracking as true, page should be skipped then return of checkAnalytics is false'}    | ${{ [ANALYTICS.acceptTracking]: true, [ANALYTICS.skipPage]: true }} | ${true}  | ${false}
-    ${'analytics has value but accept tracking is false so return of checkAnalytics is false'}                            | ${{ [ANALYTICS.acceptTracking]: false }}                            | ${false} | ${false}
-  `('when $desc', async ({ analytics, page, trackingResult }) => {
+    desc                                                                                           | analytics                                                           | page     | trackingResult
+    ${'of accept tracking as true, page should not be skipped then return checkAnalytics as true'} | ${{ [ANALYTICS.acceptTracking]: true }}                             | ${false} | ${true}
+    ${'of accept tracking as true, page should be skipped then return checkAnalytics as false'}    | ${{ [ANALYTICS.acceptTracking]: true, [ANALYTICS.skipPage]: true }} | ${true}  | ${false}
+    ${'but accept tracking is false so return checkAnalytics as false'}                            | ${{ [ANALYTICS.acceptTracking]: false }}                            | ${false} | ${false}
+  `('when analytics has a value $desc', async ({ analytics, page, trackingResult }) => {
     const result = await checkAnalytics(generateRequestMock(analytics), page)
 
     expect(result).toBe(trackingResult)
@@ -45,7 +45,7 @@ describe('checkPage', () => {
   it.each([
     [true, true],
     [false, false]
-  ])('when analytics skip page is %s, returns %s', async (skipPage, expected) => {
+  ])('when analytics skipPage property is %s, skipPage returns %s', async (skipPage, expected) => {
     const analytics = { [ANALYTICS.skipPage]: skipPage }
     const result = await checkPage(generateRequestMock(analytics))
 

--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -10,11 +10,11 @@ jest.mock('../../processors/uri-helper.js')
 
 jest.mock('../../constants', () => ({
   ANALYTICS: {
-    selected: 'selected',
-    acceptTracking: 'accepted-tracking',
-    seenMessage: 'seen-message',
-    skipPage: 'skip-page',
-    pageSkipped: 'page-skipped'
+    selected: 'chosen-one',
+    acceptTracking: 'you-may-watch-me',
+    seenMessage: 'seen-it',
+    omitPageFromAnalytics: 'no-tracky',
+    pageSkipped: 'ignored-page'
   },
   PAGE_STATE: { completed: true, error: false }
 }))
@@ -223,14 +223,14 @@ describe('The page handler function', () => {
     }
   )
 
-  describe('skipPage', () => {
+  describe('omitPageFromAnalytics', () => {
     it.each`
-      desc                                                                                                                                                                              | values                                                                        | result
-      ${'undefined: skipPage property is set to false'}                                                                                                                                 | ${{}}                                                                         | ${{ [ANALYTICS.skipPage]: false }}
-      ${'defined with pageSkip property not equal to true, seenMessage property equals true and skipPage property not equal to true: skipPage and pageSkipped property is set to true'} | ${{ [ANALYTICS.seenMessage]: 'seen-message' }}                                | ${{ [ANALYTICS.skipPage]: true, [ANALYTICS.pageSkipped]: true }}
-      ${'defined, pageSkip property equals true, seenMessage property equals true and skipPage property not equal to true: skipPage property is set to false'}                          | ${{ [ANALYTICS.skipPage]: true, [ANALYTICS.seenMessage]: 'seen-message' }}    | ${{ [ANALYTICS.skipPage]: false }}
-      ${'defined, pageSkip property not equal to true, seenMessage property not equal to true and skipPage property not equal to true: skipPage property is set to false'}              | ${{ [ANALYTICS.seenMessage]: false }}                                         | ${{ [ANALYTICS.skipPage]: false }}
-      ${'defined, pageSkip property not equal to true, seenMessage property equals true and skipPage property equals true: skipPage property is set to false'}                          | ${{ [ANALYTICS.seenMessage]: 'seen-message', [ANALYTICS.pageSkipped]: true }} | ${{ [ANALYTICS.skipPage]: false }}
+      desc                                                                                                                                                                                                        | values                                                                                  | result
+      ${'undefined: omitPageFromAnalytics property is set to false'}                                                                                                                                              | ${{}}                                                                                   | ${{ [ANALYTICS.omitPageFromAnalytics]: false }}
+      ${'defined with pageSkip property not equal to true, seenMessage property equals true and omitPageFromAnalytics property not equal to true: omitPageFromAnalytics and pageSkipped property is set to true'} | ${{ [ANALYTICS.seenMessage]: 'seen-message' }}                                          | ${{ [ANALYTICS.omitPageFromAnalytics]: true, [ANALYTICS.pageSkipped]: true }}
+      ${'defined, pageSkip property equals true, seenMessage property equals true and omitPageFromAnalytics property not equal to true: omitPageFromAnalytics property is set to false'}                          | ${{ [ANALYTICS.omitPageFromAnalytics]: true, [ANALYTICS.seenMessage]: 'seen-message' }} | ${{ [ANALYTICS.omitPageFromAnalytics]: false }}
+      ${'defined, pageSkip property not equal to true, seenMessage property not equal to true and omitPageFromAnalytics property not equal to true: omitPageFromAnalytics property is set to false'}              | ${{ [ANALYTICS.seenMessage]: false }}                                                   | ${{ [ANALYTICS.omitPageFromAnalytics]: false }}
+      ${'defined, pageSkip property not equal to true, seenMessage property equals true and omitPageFromAnalytics property equals true: omitPageFromAnalytics property is set to false'}                          | ${{ [ANALYTICS.seenMessage]: 'seen-message', [ANALYTICS.pageSkipped]: true }}           | ${{ [ANALYTICS.omitPageFromAnalytics]: false }}
     `('when analytics cache is $desc', async ({ values, result }) => {
       const set = jest.fn()
       const analytics = getAnalytics(values)

--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -224,23 +224,14 @@ describe('The page handler function', () => {
   )
 
   describe('skipPage', () => {
-    it('called with undefined when analytics is undefined on initial get request', async () => {
-      const set = jest.fn()
-      const { get } = pageHandler('', 'view', 'next-page')
-      const toolkit = getMockToolkit()
-      const mockRequest = getMockRequest({ analytics: undefined, set })
-      await get(mockRequest, toolkit)
-      expect(set).toBeCalledWith({ [ANALYTICS.skipPage]: false })
-    })
-
     it.each`
-      desc                                                                                                                          | values                                                                        | result
-      ${'analytics undefined, set called with skippage false'}                                                                      | ${{}}                                                                         | ${{ [ANALYTICS.skipPage]: false }}
-      ${'analytics defined, pageskip != true, seenmessage = true, skippage != true, set called with skippage and pageskipped true'} | ${{ [ANALYTICS.seenMessage]: 'seen-message' }}                                | ${{ [ANALYTICS.skipPage]: true, [ANALYTICS.pageSkipped]: true }}
-      ${'analytics defined, pageskip = true, seenmessage = true, skippage != true, set called with skippage false'}                 | ${{ [ANALYTICS.skipPage]: true, [ANALYTICS.seenMessage]: 'seen-message' }}    | ${{ [ANALYTICS.skipPage]: false }}
-      ${'analytics defined, pageskip != true, seenmessage != true, skippage != true, set called with skippage false'}               | ${{ [ANALYTICS.seenMessage]: false }}                                         | ${{ [ANALYTICS.skipPage]: false }}
-      ${'analytics defined, pageskip != true, seenmessage = true, skippage = true, set called with skippage false'}                 | ${{ [ANALYTICS.seenMessage]: 'seen-message', [ANALYTICS.pageSkipped]: true }} | ${{ [ANALYTICS.skipPage]: false }}
-    `('when $desc', async ({ values, result }) => {
+      desc                                                                                                                                                                              | values                                                                        | result
+      ${'undefined: skipPage property is set to false'}                                                                                                                                 | ${{}}                                                                         | ${{ [ANALYTICS.skipPage]: false }}
+      ${'defined with pageSkip property not equal to true, seenMessage property equals true and skipPage property not equal to true: skipPage and pageSkipped property is set to true'} | ${{ [ANALYTICS.seenMessage]: 'seen-message' }}                                | ${{ [ANALYTICS.skipPage]: true, [ANALYTICS.pageSkipped]: true }}
+      ${'defined, pageSkip property equals true, seenMessage property equals true and skipPage property not equal to true: skipPage property is set to false'}                          | ${{ [ANALYTICS.skipPage]: true, [ANALYTICS.seenMessage]: 'seen-message' }}    | ${{ [ANALYTICS.skipPage]: false }}
+      ${'defined, pageSkip property not equal to true, seenMessage property not equal to true and skipPage property not equal to true: skipPage property is set to false'}              | ${{ [ANALYTICS.seenMessage]: false }}                                         | ${{ [ANALYTICS.skipPage]: false }}
+      ${'defined, pageSkip property not equal to true, seenMessage property equals true and skipPage property equals true: skipPage property is set to false'}                          | ${{ [ANALYTICS.seenMessage]: 'seen-message', [ANALYTICS.pageSkipped]: true }} | ${{ [ANALYTICS.skipPage]: false }}
+    `('when analytics cache is $desc', async ({ values, result }) => {
       const set = jest.fn()
       const analytics = getAnalytics(values)
       const { get } = pageHandler('', 'view', 'next-page')

--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -235,9 +235,10 @@ describe('The page handler function', () => {
 
     it.each`
       desc                                                                                                                          | values                                                                        | result
+      ${'analytics undefined, set called with skippage false'}                                                                      | ${{}}                                                                         | ${{ [ANALYTICS.skipPage]: false }}
       ${'analytics defined, pageskip != true, seenmessage = true, skippage != true, set called with skippage and pageskipped true'} | ${{ [ANALYTICS.seenMessage]: 'seen-message' }}                                | ${{ [ANALYTICS.skipPage]: true, [ANALYTICS.pageSkipped]: true }}
       ${'analytics defined, pageskip = true, seenmessage = true, skippage != true, set called with skippage false'}                 | ${{ [ANALYTICS.skipPage]: true, [ANALYTICS.seenMessage]: 'seen-message' }}    | ${{ [ANALYTICS.skipPage]: false }}
-      ${'analytics defined, pageskip != true, seenmessage != true, skippage != true, set called with skippage false'}               | ${{}}                                                                         | ${{ [ANALYTICS.skipPage]: false }}
+      ${'analytics defined, pageskip != true, seenmessage != true, skippage != true, set called with skippage false'}               | ${{ [ANALYTICS.seenMessage]: false }}                                         | ${{ [ANALYTICS.skipPage]: false }}
       ${'analytics defined, pageskip != true, seenmessage = true, skippage = true, set called with skippage false'}                 | ${{ [ANALYTICS.seenMessage]: 'seen-message', [ANALYTICS.pageSkipped]: true }} | ${{ [ANALYTICS.skipPage]: false }}
     `('when $desc', async ({ values, result }) => {
       const set = jest.fn()

--- a/packages/gafl-webapp-service/src/handlers/analytics-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/analytics-handler.js
@@ -9,10 +9,7 @@ import { ANALYTICS } from '../constants.js'
 export const checkAnalytics = async (request, pageSkip) => {
   try {
     const analytics = await request.cache().helpers.analytics.get()
-    if (analytics[ANALYTICS.acceptTracking] === true) {
-      if (pageSkip === true) {
-        return false
-      }
+    if (analytics[ANALYTICS.acceptTracking] === true && pageSkip !== true) {
       return true
     }
   } catch {}

--- a/packages/gafl-webapp-service/src/handlers/analytics-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/analytics-handler.js
@@ -6,12 +6,11 @@ import { ANALYTICS } from '../constants.js'
  * @returns {Promise}
  */
 
-export const checkAnalytics = async request => {
+export const checkAnalytics = async (request, pageSkip) => {
   try {
     const analytics = await request.cache().helpers.analytics.get()
-    if (analytics && analytics[ANALYTICS.acceptTracking] === true) {
-      const pageSkip = await skipPage(request)
-      if (pageSkip) {
+    if (analytics[ANALYTICS.acceptTracking] === true) {
+      if (pageSkip === true) {
         return false
       }
       return true
@@ -21,15 +20,16 @@ export const checkAnalytics = async request => {
   return false
 }
 
-export const skipPage = async request => {
-  console.log('hit 2')
-  const analytics = await request.cache().helpers.analytics.get()
-  if (analytics[ANALYTICS.seenMessage] === true && analytics[ANALYTICS.skipPage] === undefined) {
-    return true
-  }
+export const checkPage = async request => {
+  try {
+    const analytics = await request.cache().helpers.analytics.get()
+    if (analytics[ANALYTICS.skipPage] === true) {
+      return true
+    }
+  } catch {}
+
   return false
 }
-
 export const getAnalyticsSessionId = async request => {
   try {
     return request.cache().getId()

--- a/packages/gafl-webapp-service/src/handlers/analytics-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/analytics-handler.js
@@ -6,7 +6,7 @@ import { ANALYTICS } from '../constants.js'
  * @returns {Promise}
  */
 
-export const checkAnalytics = async (request, pageSkip) => {
+export const trackAnalyticsAccepted = async (request, pageSkip) => {
   try {
     const analytics = await request.cache().helpers.analytics.get()
     if (analytics[ANALYTICS.acceptTracking] === true && pageSkip !== true) {
@@ -17,10 +17,10 @@ export const checkAnalytics = async (request, pageSkip) => {
   return false
 }
 
-export const checkPage = async request => {
+export const pageOmitted = async request => {
   try {
     const analytics = await request.cache().helpers.analytics.get()
-    if (analytics[ANALYTICS.skipPage] === true) {
+    if (analytics[ANALYTICS.omitPageFromAnalytics] === true) {
       return true
     }
   } catch {}

--- a/packages/gafl-webapp-service/src/handlers/analytics-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/analytics-handler.js
@@ -10,10 +10,23 @@ export const checkAnalytics = async request => {
   try {
     const analytics = await request.cache().helpers.analytics.get()
     if (analytics && analytics[ANALYTICS.acceptTracking] === true) {
+      const pageSkip = await skipPage(request)
+      if (pageSkip) {
+        return false
+      }
       return true
     }
   } catch {}
 
+  return false
+}
+
+export const skipPage = async request => {
+  console.log('hit 2')
+  const analytics = await request.cache().helpers.analytics.get()
+  if (analytics[ANALYTICS.seenMessage] === true && analytics[ANALYTICS.skipPage] === undefined) {
+    return true
+  }
   return false
 }
 

--- a/packages/gafl-webapp-service/src/handlers/page-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/page-handler.js
@@ -35,10 +35,9 @@ const omitPageFromAnalytics = async request => {
     analytics[ANALYTICS.omitPageFromAnalytics] !== true
   ) {
     await request.cache().helpers.analytics.set({ [ANALYTICS.omitPageFromAnalytics]: true, [ANALYTICS.pageSkipped]: true })
-    return
+  } else {
+    await request.cache().helpers.analytics.set({ [ANALYTICS.omitPageFromAnalytics]: false })
   }
-
-  await request.cache().helpers.analytics.set({ [ANALYTICS.omitPageFromAnalytics]: false })
 }
 
 /**

--- a/packages/gafl-webapp-service/src/handlers/page-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/page-handler.js
@@ -25,21 +25,20 @@ const displayAnalytics = request => {
   return request.path.startsWith('/buy')
 }
 
-const skipPage = async request => {
+const omitPageFromAnalytics = async request => {
   const analytics = await request.cache().helpers.analytics.get()
 
   if (
     analytics &&
     analytics[ANALYTICS.pageSkipped] !== true &&
     analytics[ANALYTICS.seenMessage] &&
-    analytics[ANALYTICS.skipPage] !== true
+    analytics[ANALYTICS.omitPageFromAnalytics] !== true
   ) {
-    await request.cache().helpers.analytics.set({ [ANALYTICS.skipPage]: true, [ANALYTICS.pageSkipped]: true })
-    return true
+    await request.cache().helpers.analytics.set({ [ANALYTICS.omitPageFromAnalytics]: true, [ANALYTICS.pageSkipped]: true })
+    return
   }
 
-  await request.cache().helpers.analytics.set({ [ANALYTICS.skipPage]: false })
-  return false
+  await request.cache().helpers.analytics.set({ [ANALYTICS.omitPageFromAnalytics]: false })
 }
 
 /**
@@ -133,7 +132,7 @@ export default (path, view, completion, getData) => ({
 
     pageData.displayAnalytics = displayAnalytics(request)
 
-    await skipPage(request)
+    await omitPageFromAnalytics(request)
 
     if (pagesJourneyBeginning.includes(request.path)) {
       pageData.journeyBeginning = true

--- a/packages/gafl-webapp-service/src/handlers/page-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/page-handler.js
@@ -28,11 +28,14 @@ const displayAnalytics = request => {
 const skipPage = async request => {
   const analytics = await request.cache().helpers.analytics.get()
 
-  if (analytics) {
-    if (analytics[ANALYTICS.pageSkipped] !== true && analytics[ANALYTICS.seenMessage] && analytics[ANALYTICS.skipPage] !== true) {
-      await request.cache().helpers.analytics.set({ [ANALYTICS.skipPage]: true, [ANALYTICS.pageSkipped]: true })
-      return true
-    }
+  if (
+    analytics &&
+    analytics[ANALYTICS.pageSkipped] !== true &&
+    analytics[ANALYTICS.seenMessage] &&
+    analytics[ANALYTICS.skipPage] !== true
+  ) {
+    await request.cache().helpers.analytics.set({ [ANALYTICS.skipPage]: true, [ANALYTICS.pageSkipped]: true })
+    return true
   }
 
   await request.cache().helpers.analytics.set({ [ANALYTICS.skipPage]: false })

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -10,7 +10,7 @@ import Cookie from '@hapi/cookie'
 import HapiI18n from 'hapi-i18n'
 import { useSessionCookie } from './session-cache/session-manager.js'
 import { getCsrfTokenCookieName } from './server.js'
-import { checkAnalytics, getAnalyticsSessionId, checkPage } from '../src/handlers/analytics-handler.js'
+import { trackAnalyticsAccepted, getAnalyticsSessionId, pageOmitted } from '../src/handlers/analytics-handler.js'
 import Dirname from '../dirname.cjs'
 import path from 'path'
 
@@ -21,15 +21,15 @@ const debug = db('webapp:plugin')
 const scriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
 
 const trackAnalytics = async request => {
-  const pageSkip = await checkPage(request)
-  const canTrack = await checkAnalytics(request, pageSkip)
+  const pageOmit = await pageOmitted(request)
+  const canTrack = await trackAnalyticsAccepted(request, pageOmit)
   const optDebug = process.env.ENABLE_ANALYTICS_OPT_IN_DEBUGGING?.toLowerCase() === 'true'
   if (optDebug) {
     const sessionId = await getAnalyticsSessionId(request)
     if (canTrack === true) {
       debug(`Session is being tracked for: ${sessionId}`)
     } else {
-      if (pageSkip === true) {
+      if (pageOmit === true) {
         debug(`Session is not tracking current page for: ${sessionId}`)
       } else {
         debug(`Session is not being tracked for: ${sessionId}`)

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -10,7 +10,8 @@ import Cookie from '@hapi/cookie'
 import HapiI18n from 'hapi-i18n'
 import { useSessionCookie } from './session-cache/session-manager.js'
 import { getCsrfTokenCookieName } from './server.js'
-import { checkAnalytics, getAnalyticsSessionId } from '../src/handlers/analytics-handler.js'
+import { checkAnalytics, getAnalyticsSessionId, skipPage } from '../src/handlers/analytics-handler.js'
+import { ANALYTICS } from './constants.js'
 import Dirname from '../dirname.cjs'
 import path from 'path'
 
@@ -21,14 +22,20 @@ const debug = db('webapp:plugin')
 const scriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
 
 const trackAnalytics = async request => {
+  console.log('ANALYTICS')
   const canTrack = await checkAnalytics(request)
   const optDebug = process.env.ENABLE_ANALYTICS_OPT_IN_DEBUGGING?.toLowerCase() === 'true'
   if (optDebug) {
     const sessionId = await getAnalyticsSessionId(request)
     if (canTrack === true) {
-      debug(`Session is being tracked for: ${sessionId}`)
+      const pageSkip = await skipPage(request)
+      if (pageSkip) {
+        // await request.cache().helpers.analytics.set({ [ANALYTICS.skipPage]: true })
+        // debug(`Session is being tracked. Not tracking current page for: ${sessionId}`)
+      }
+      // debug(`Session is being tracked for: ${sessionId}`)
     } else {
-      debug(`Session is not being tracked for: ${sessionId}`)
+      // debug(`Session is not being tracked for: ${sessionId}`)
     }
   }
   return canTrack

--- a/packages/gafl-webapp-service/src/server.js
+++ b/packages/gafl-webapp-service/src/server.js
@@ -190,7 +190,6 @@ const init = async () => {
   if (process.env.CHANNEL === 'telesales') {
     await initialiseOIDC(server)
   }
-
   server.route(routes)
   await server.start()
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3566

When users accept tracking and hide banner the page tracks each refresh page view.