### PR TITLE
Only prefill payment details when user buys for themself

### DIFF
--- a/packages/gafl-webapp-service/src/processors/payment.js
+++ b/packages/gafl-webapp-service/src/processors/payment.js
@@ -34,7 +34,7 @@ export const preparePayment = (request, transaction) => {
     language: /\?.*lang=cy.*$/.test(url.search) ? 'cy' : 'en'
   }
 
-  if (transaction.permissions.length === 1) {
+  if (transaction.permissions.length === 1 && transaction.permissions[0].isLicenceForYou) {
     result.email = transaction.permissions[0].licensee.email
     result.prefilled_cardholder_details = {
       cardholder_name: `${transaction.permissions[0].licensee.firstName} ${transaction.permissions[0].licensee.lastName}`,

--- a/packages/gafl-webapp-service/src/services/payment/__test__/data/mock-transaction.js
+++ b/packages/gafl-webapp-service/src/services/payment/__test__/data/mock-transaction.js
@@ -2,6 +2,7 @@ export default {
   payment: {},
   permissions: [
     {
+      isLicenceForYou: true,
       licensee: {
         birthDate: '1910-01-01',
         firstName: 'Graham',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3543

If a user is buying on behalf of someone else, we do not want to pre-populate GOV.UK Pay fields with the licensee info, as the person who is buying on behalf may be paying instead.

This PR changes the code to only pre-populate those fields when a user is buying a single licence for themself.

It also includes some test refactoring for the payment processor to bring it more in line with the rest of the test suite.