### PR TITLE
Stop easy renewals from copying shortTermPreferredMethodOfConfirmation

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
@@ -208,16 +208,22 @@ describe('renewals-write-cache', () => {
       )
     })
 
-    it('should not assign shortTermPreferredMethodOfConfirmation to the licensee', async () => {
-      await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
-      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
-        expect.objectContaining({
-          licensee: expect.not.objectContaining({
-            shortTermPreferredMethodOfConfirmation: expect.any(Object)
-          })
-        })
-      )
-    })
+    // it('should not assign shortTermPreferredMethodOfConfirmation to the licensee', async () => {
+    //   await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+    //   expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+    //     expect.objectContaining({
+    //       licensee: expect.not.objectContaining({
+    //         shortTermPreferredMethodOfConfirmation: expect.any(Object)
+    //       })
+    //     })
+    //   )
+    // })
+    it.each(['country', 'shortTermPreferredMethodOfConfirmation'])(
+        'should not assign %s to the licensee', async prop => {
+        await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+        const [[{licensee}]] = mockTransactionCacheSet.mock.calls
+        expect(licensee[prop]).toBeUndefined()
+      })
 
     it('should have an empty array if no concessions are present', async () => {
       await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)

--- a/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
@@ -57,6 +57,11 @@ describe('renewals-write-cache', () => {
             label: 'Text',
             description: 'Text'
           },
+          shortTermPreferredMethodOfConfirmation: {
+            id: 910400002,
+            label: 'Text',
+            description: 'Text'
+          },
           street: 'Blackthorn Mews',
           town: 'Chippenham'
         },
@@ -198,6 +203,17 @@ describe('renewals-write-cache', () => {
             preferredMethodOfNewsletter: 'Email',
             preferredMethodOfConfirmation: 'Text',
             preferredMethodOfReminder: 'Text'
+          })
+        })
+      )
+    })
+
+    it('should not assign shortTermPreferredMethodOfConfirmation to the licensee', async () => {
+      await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+      expect(mockTransactionCacheSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          licensee: expect.not.objectContaining({
+            shortTermPreferredMethodOfConfirmation: expect.any(Object)
           })
         })
       )

--- a/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/renewals-write-cache.spec.js
@@ -208,22 +208,11 @@ describe('renewals-write-cache', () => {
       )
     })
 
-    // it('should not assign shortTermPreferredMethodOfConfirmation to the licensee', async () => {
-    //   await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
-    //   expect(mockTransactionCacheSet).toHaveBeenCalledWith(
-    //     expect.objectContaining({
-    //       licensee: expect.not.objectContaining({
-    //         shortTermPreferredMethodOfConfirmation: expect.any(Object)
-    //       })
-    //     })
-    //   )
-    // })
-    it.each(['country', 'shortTermPreferredMethodOfConfirmation'])(
-        'should not assign %s to the licensee', async prop => {
-        await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
-        const [[{licensee}]] = mockTransactionCacheSet.mock.calls
-        expect(licensee[prop]).toBeUndefined()
-      })
+    it.each(['country', 'shortTermPreferredMethodOfConfirmation'])('should not assign %s to the licensee', async prop => {
+      await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)
+      const [[{ licensee }]] = mockTransactionCacheSet.mock.calls
+      expect(licensee[prop]).toBeUndefined()
+    })
 
     it('should have an empty array if no concessions are present', async () => {
       await setUpCacheFromAuthenticationResult(mockRequest, authenticationResult)

--- a/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
+++ b/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
@@ -35,9 +35,6 @@ export const setUpCacheFromAuthenticationResult = async (request, authentication
   permission.licensee = Object.assign(
     (({
       country: _country,
-      preferredMethodOfConfirmation: _preferredMethodOfConfirmation,
-      preferredMethodOfNewsletter: _preferredMethodOfNewsletter,
-      preferredMethodOfReminder: _preferredMethodOfReminder,
       shortTermPreferredMethodOfConfirmation: _shortTermPreferredMethodOfConfirmation,
       ...l
     }) => l)(authenticationResult.permission.licensee),

--- a/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
+++ b/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
@@ -33,11 +33,9 @@ export const setUpCacheFromAuthenticationResult = async (request, authentication
   permission.renewedEndDate = endDateMoment.toISOString()
   permission.renewedHasExpired = renewedHasExpired
   permission.licensee = Object.assign(
-    (({
-      country: _country,
-      shortTermPreferredMethodOfConfirmation: _shortTermPreferredMethodOfConfirmation,
-      ...l
-    }) => l)(authenticationResult.permission.licensee),
+    (({ country: _country, shortTermPreferredMethodOfConfirmation: _shortTermPreferredMethodOfConfirmation, ...l }) => l)(
+      authenticationResult.permission.licensee
+    ),
     {
       countryCode: authenticationResult.permission.licensee.country.description
     }

--- a/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
+++ b/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
@@ -34,11 +34,11 @@ export const setUpCacheFromAuthenticationResult = async (request, authentication
   permission.renewedHasExpired = renewedHasExpired
   permission.licensee = Object.assign(
     (({
-      country,
-      preferredMethodOfConfirmation,
-      preferredMethodOfNewsletter,
-      preferredMethodOfReminder,
-      shortTermPreferredMethodOfConfirmation,
+      country: _country,
+      preferredMethodOfConfirmation: _preferredMethodOfConfirmation,
+      preferredMethodOfNewsletter: _preferredMethodOfNewsletter,
+      preferredMethodOfReminder: _preferredMethodOfReminder,
+      shortTermPreferredMethodOfConfirmation: _shortTermPreferredMethodOfConfirmation,
       ...l
     }) => l)(authenticationResult.permission.licensee),
     {

--- a/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
+++ b/packages/gafl-webapp-service/src/processors/renewals-write-cache.js
@@ -33,9 +33,14 @@ export const setUpCacheFromAuthenticationResult = async (request, authentication
   permission.renewedEndDate = endDateMoment.toISOString()
   permission.renewedHasExpired = renewedHasExpired
   permission.licensee = Object.assign(
-    (({ country, preferredMethodOfConfirmation, preferredMethodOfNewsletter, preferredMethodOfReminder, ...l }) => l)(
-      authenticationResult.permission.licensee
-    ),
+    (({
+      country,
+      preferredMethodOfConfirmation,
+      preferredMethodOfNewsletter,
+      preferredMethodOfReminder,
+      shortTermPreferredMethodOfConfirmation,
+      ...l
+    }) => l)(authenticationResult.permission.licensee),
     {
       countryCode: authenticationResult.permission.licensee.country.description
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3614

This is causing a bug which causes easy renewals for contacts who have already got this field set in the CRM to fail, as the Sales API does not expect to be receiving the field in the data from the GAFL Web App.

By not copying the field when we do an easy renewal, we can leave the Sales API to assign the field itself as appropriate.