### PR TITLE
Fix issues with processing postal order records

### DIFF
--- a/packages/pocl-job/src/staging/__tests__/__snapshots__/pocl-validation-errors.spec.js.snap
+++ b/packages/pocl-job/src/staging/__tests__/__snapshots__/pocl-validation-errors.spec.js.snap
@@ -14,7 +14,7 @@ Object {
       "issueDate": "2020-01-01T14:00:00Z",
       "licensee": Object {
         "birthDate": "1989-07-01",
-        "country": "GB",
+        "country": "GB-ENG",
         "email": "daniel-ricc@example.couk",
         "firstName": "Daniel",
         "lastName": "Ricciardo",
@@ -55,7 +55,7 @@ Array [
           "issueDate": "2020-01-01T14:00:00Z",
           "licensee": Object {
             "birthDate": "1989-07-01",
-            "country": "GB",
+            "country": "GB-ENG",
             "email": "daniel-ricc@example.couk",
             "firstName": "Daniel",
             "lastName": "Ricciardo",
@@ -123,7 +123,7 @@ Object {
       "issueDate": "2020-01-01T14:00:00Z",
       "licensee": Object {
         "birthDate": "1989-07-01",
-        "country": "GB",
+        "country": "GB-ENG",
         "email": "daniel-ricc@example.couk",
         "firstName": "Daniel",
         "lastName": "Ricciardo",
@@ -164,7 +164,7 @@ Array [
           "issueDate": "2020-01-01T14:00:00Z",
           "licensee": Object {
             "birthDate": "1989-07-01",
-            "country": "GB",
+            "country": "GB-ENG",
             "email": "daniel-ricc@example.couk",
             "firstName": "Daniel",
             "lastName": "Ricciardo",
@@ -216,7 +216,7 @@ Object {
       "issueDate": "2020-01-01T14:00:00Z",
       "licensee": Object {
         "birthDate": "1989-07-01",
-        "country": "GB",
+        "country": "GB-ENG",
         "email": "daniel-ricc@example.co.uk",
         "firstName": "Daniel",
         "lastName": "Ricciardo",
@@ -273,7 +273,7 @@ Array [
           "issueDate": "2020-01-01T14:00:00Z",
           "licensee": Object {
             "birthDate": "1989-07-01",
-            "country": "GB",
+            "country": "GB-ENG",
             "email": "daniel-ricc@example.co.uk",
             "firstName": "Daniel",
             "lastName": "Ricciardo",
@@ -328,7 +328,7 @@ Array [
           "issueDate": "2020-01-01T14:00:00Z",
           "licensee": Object {
             "birthDate": "1989-07-01",
-            "country": "GB",
+            "country": "GB-ENG",
             "email": "daniel-ricc@example.co.uk",
             "firstName": "Daniel",
             "lastName": "Ricciardo",

--- a/packages/pocl-job/src/staging/pocl-validation-errors.js
+++ b/packages/pocl-job/src/staging/pocl-validation-errors.js
@@ -24,7 +24,7 @@ const mapRecords = records =>
             locality: record.locality,
             town: record.town,
             postcode: record.postcode,
-            country: record.country || record.countryUnvalidated,
+            country: getCountryValue(record),
             preferredMethodOfConfirmation: record.preferredMethodOfConfirmation.label,
             preferredMethodOfNewsletter: record.preferredMethodOfNewsletter.label,
             preferredMethodOfReminder: record.preferredMethodOfReminder.label,
@@ -42,9 +42,9 @@ const mapRecords = records =>
       payment: {
         timestamp: formatDateToShortenedISO(record.transactionDate),
         amount: record.amount,
-        source: record.paymentSource || record.paymentSourceUnvalidated,
+        source: getSourceValue(record),
         channelId: record.channelId || 'N/A',
-        method: backfillPaymentMethod(record.methodOfPayment, record.newPaymentSource)
+        method: backfillPaymentMethod(record.methodOfPayment, record.paymentSource)
       }
     }
   }))
@@ -52,7 +52,7 @@ const mapRecords = records =>
 const backfillDataSource = record => {
   if (record.dataSource) {
     return record.dataSource.label
-  } else if (record.newPaymentSource && record.newPaymentSource.label === POSTAL_ORDER_PAYMENTSOURCE) {
+  } else if (record.paymentSource && record.paymentSource.label === POSTAL_ORDER_PAYMENTSOURCE) {
     return POSTAL_ORDER_DATASOURCE
   }
   return undefined
@@ -61,19 +61,33 @@ const backfillDataSource = record => {
 const backfillSerialNumber = record => {
   if (record.serialNumber) {
     return record.serialNumber
-  } else if (record.newPaymentSource && record.newPaymentSource.label === POSTAL_ORDER_PAYMENTSOURCE) {
+  } else if (record.paymentSource && record.paymentSource.label === POSTAL_ORDER_PAYMENTSOURCE) {
     return POSTAL_ORDER_DATASOURCE
   }
   return undefined
 }
 
-const backfillPaymentMethod = (method, newPaymentSource) => {
+const backfillPaymentMethod = (method, paymentSource) => {
   if (method) {
     return method.label
-  } else if (newPaymentSource && newPaymentSource.label === POSTAL_ORDER_PAYMENTSOURCE) {
+  } else if (paymentSource && paymentSource.label === POSTAL_ORDER_PAYMENTSOURCE) {
     return POSTAL_ORDER_PAYMENTMETHOD
   }
   return undefined
+}
+
+const getCountryValue = record => {
+  if (record.country && record.country.label) {
+    return record.country.label
+  }
+  return record.countryUnvalidated
+}
+
+const getSourceValue = record => {
+  if (record.paymentSource && record.paymentSource.label) {
+    return record.paymentSource.label
+  }
+  return record.paymentSourceUnvalidated
 }
 
 const formatDateToShortenedISO = date => {
@@ -119,10 +133,9 @@ const createTransactions = async records => {
 const finaliseTransaction = async rec => {
   const payment = rec.record.finaliseTransactionPayload.payment
   const finaliseTransactionPayload = {
-    payment: { method: backfillPaymentMethod(payment.method, payment.newPaymentSource) },
+    payment: { method: backfillPaymentMethod(payment.method, payment.paymentSource) },
     ...rec.record.finaliseTransactionPayload
   }
-  debug('finalising transaction: %o', finaliseTransactionPayload)
   return salesApi.finaliseTransaction(rec.result.response.id, finaliseTransactionPayload)
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3418

This PR fixes a few issues that came up while adding postal order records via the new CRM process.

There were a few mentions of fields prefixed with new* which had since been renamed - so these needed to be updated here as well.

Once this was changed, further errors revealed that we were passing through objects with labels rather than just the label string, which is what the sales API expected. So this PR also includes tweaks to make sure we pass through just a string when that is expected.