### PR TITLE
Stop Sales API requiring concession proof for PO entries

### DIFF
--- a/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
+++ b/packages/sales-api-service/src/schema/validators/__tests__/validators.spec.js
@@ -377,5 +377,26 @@ describe('validators', () => {
       ).resolves.toEqual(undefined)
       expect(spy).toHaveBeenCalledWith(PermitConcession)
     })
+
+    it('returns a validation function which does not throw an error for Postal Order Sales even if the permit requires a concession and none is supplied', async () => {
+      const spy = jest.spyOn(referenceData, 'getReferenceDataForEntity').mockImplementation(async () => [
+        {
+          permitId: 'test-1',
+          concessionId: 'test-1'
+        }
+      ])
+      const validationFunction = createPermitConcessionValidator()
+      await expect(
+        validationFunction({
+          dataSource: 'Postal Order Sales',
+          permissions: [
+            {
+              permitId: 'test-1'
+            }
+          ]
+        })
+      ).resolves.toEqual(undefined)
+      expect(spy).toHaveBeenCalledWith(PermitConcession)
+    })
   })
 })

--- a/packages/sales-api-service/src/schema/validators/validators.js
+++ b/packages/sales-api-service/src/schema/validators/validators.js
@@ -131,7 +131,8 @@ const validatePermissionConcession = async (permission, transaction) => {
     concessionsRequiredForPermit.length &&
     !hasConcessionProofs &&
     transaction.dataSource !== 'Post Office Sales' &&
-    transaction.dataSource !== 'DDE File'
+    transaction.dataSource !== 'DDE File' &&
+    transaction.dataSource !== 'Postal Order Sales'
   ) {
     throw new Error(`The permit '${permission.permitId}' requires proof of concession however none were supplied`)
   } else if (!concessionsRequiredForPermit.length && hasConcessionProofs) {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3418

Permissions generated through the POCL process should not require concession proof.