### PR TITLE
Strip fragments when processing URIs

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/uri-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/uri-helper.spec.js
@@ -7,7 +7,9 @@ describe('URI Helpers: addLanguageCodeToURI', () => {
     ['?extra-info=123&extra-rods=2&lang=cy&cold-beer=yes-please', '^/any/page\\?lang=cy', undefined],
     ['', '^/path/to/a/page$', '/path/to/a/page', undefined],
     ['?other-info=bbb-111', '^/any/page$', undefined],
-    ['?misc-data=999&extra-rods=1&marmite=no-thanks', '^/any/old/page$', '/any/old/page']
+    ['?misc-data=999&extra-rods=1&marmite=no-thanks', '^/any/old/page$', '/any/old/page'],
+    ['?lang=cy', '^/path/to/a/page\\?lang=cy$', '/path/to/a/page#fragment'],
+    ['', '^/path/to/a/page$', '/path/to/a/page#fragment']
   ])('persists the lang code when reloading the page in the event of an error', (search, expected, uri) => {
     const mockRequest = {
       path: '/any/page',
@@ -58,6 +60,30 @@ describe('URI Helpers: addLanguageCodeToURI', () => {
         url: {
           search: '?lang=cy'
         }
+      }
+      const result = addLanguageCodeToUri(mockRequest, suppliedPath)
+      expect(result).toEqual(expectedPath)
+    })
+  })
+
+  describe.each([
+    ['?lang=cy', 'https://my-url.com/path?lang=cy#main-content', 'https://my-url.com/path?lang=cy'],
+    ['?lang=cy', 'https://my-url.com/path?data=true&lang=cy#main-content', 'https://my-url.com/path?data=true&lang=cy'],
+    ['?lang=cy', 'https://my-url.com/path?lang=en#main-content', 'https://my-url.com/path?lang=cy'],
+    ['?lang=cy', 'https://my-url.com/path?data=true&lang=en#main-content', 'https://my-url.com/path?data=true&lang=cy'],
+    ['?lang=en', 'https://my-url.com/path?lang=cy#main-content', 'https://my-url.com/path'],
+    ['?lang=en', 'https://my-url.com/path?data=true&lang=cy#main-content', 'https://my-url.com/path?data=true'],
+    ['?lang=en', 'https://my-url.com/path?lang=en#main-content', 'https://my-url.com/path'],
+    ['?lang=en', 'https://my-url.com/path?data=true&lang=en#main-content', 'https://my-url.com/path?data=true'],
+    [undefined, 'https://my-url.com/path?lang=en#main-content', 'https://my-url.com/path'],
+    [undefined, 'https://my-url.com/path?data=true&lang=en#main-content', 'https://my-url.com/path?data=true'],
+    [undefined, 'https://my-url.com/path?lang=en#main-content', 'https://my-url.com/path'],
+    [undefined, 'https://my-url.com/path?data=true&lang=en#main-content', 'https://my-url.com/path?data=true']
+  ])('', (search, suppliedPath, expectedPath) => {
+    it('trims any uri fragments from the path', () => {
+      const mockRequest = {
+        path: suppliedPath,
+        url: { search }
       }
       const result = addLanguageCodeToUri(mockRequest, suppliedPath)
       expect(result).toEqual(expectedPath)

--- a/packages/gafl-webapp-service/src/processors/uri-helper.js
+++ b/packages/gafl-webapp-service/src/processors/uri-helper.js
@@ -3,7 +3,9 @@ export const addLanguageCodeToUri = (request, uri) => {
 
   // Remove any existing lang parameters
   const cleanPath = path.replace(/[?|&]lang=[a-z]{2}/, '')
+  // Remove any fragments from the path
+  const defraggedPath = cleanPath.split('#')[0]
 
-  const languageSpecifier = /.*\?.*/.test(cleanPath) ? '&lang=cy' : '?lang=cy'
-  return `${cleanPath}${/\?.*lang=cy.*$/.test(request.url.search) ? languageSpecifier : ''}`
+  const languageSpecifier = /.*\?.*/.test(defraggedPath) ? '&lang=cy' : '?lang=cy'
+  return `${defraggedPath}${/\?.*lang=cy.*$/.test(request.url.search) ? languageSpecifier : ''}`
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3673

Selecting the 'skip to main content' link will append a #main-content fragment to the URL of the page. However this fragment then persists through the rest of the journey, which basically means that if you skipped once, you are forced to skip for the rest of the journey.

This PR updates how we process URIs to remove any fragments as well as adding or retaining the language code.