### PR TITLE
Add current path as action for forms

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/__tests__/__snapshots__/page-handler.spec.js.snap
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/__snapshots__/page-handler.spec.js.snap
@@ -11,6 +11,7 @@ exports[`The page handler function sets the value of pageData with displayAnalyt
         "analyticsMessageDisplayed": false,
         "analyticsSelected": false,
         "backRef": null,
+        "currentPath": "/we/are/here",
         "displayAnalytics": false,
         "mssgs": undefined,
         "uri": Object {
@@ -39,6 +40,7 @@ exports[`The page handler function sets the value of pageData with displayAnalyt
         "analyticsMessageDisplayed": false,
         "analyticsSelected": false,
         "backRef": null,
+        "currentPath": "/buy/we/are/here",
         "displayAnalytics": true,
         "mssgs": undefined,
         "uri": Object {

--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -113,6 +113,22 @@ describe('The page handler function', () => {
     )
   })
 
+  it('pageData.currentPath is set to the request path', async () => {
+    const path = '/this/is/the/path/i/want'
+    const { get } = pageHandler(null, 'view', '/next/page')
+    const request = getMockRequest({ path })
+    const toolkit = getMockToolkit()
+
+    await get(request, toolkit)
+
+    expect(toolkit.view).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        currentPath: path
+      })
+    )
+  })
+
   it('GetDataRedirect being thrown will redirectWithLanguageCode to the target', async () => {
     journeyDefinition.push({ current: { page: 'view' }, backLink: '/previous/page' })
     const url = Symbol('/go/somewhere/else')

--- a/packages/gafl-webapp-service/src/handlers/page-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/page-handler.js
@@ -122,6 +122,7 @@ export default (path, view, completion, getData) => ({
     pageData.mssgs = request.i18n.getCatalog()
     pageData.altLang = request.i18n.getLocales().filter(locale => locale !== request.i18n.getLocale())
     pageData.backRef = await getBackReference(request, view)
+    pageData.currentPath = request.path
     pageData.uri = { ...(pageData.uri || {}), analyticsFormAction: addLanguageCodeToUri(request, PROCESS_ANALYTICS_PREFERENCES.uri) }
 
     const analytics = await request.cache().helpers.analytics.get()

--- a/packages/gafl-webapp-service/src/pages/contact/address/lookup/address-lookup.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/address/lookup/address-lookup.njk
@@ -36,7 +36,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         {{ errorSummary(error, errorMap, mssgs.there_is_a_problem) }}
-        <form method="post">
+        <form action="{{ currentPath }}" method="post">
 
             {% call govukFieldset({
               legend: {

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/licence-start-time.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/licence-start-time.njk
@@ -70,7 +70,7 @@
             }) %}
         </div>
         <div class="govuk-grid-column-full">
-            <form method="post" novalidate>
+            <form action="{{ currentPath }}" method="post" novalidate>
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-one-half">
                         {{ govukRadios({

--- a/packages/gafl-webapp-service/src/pages/licence-details/no-licence-required/no-licence-required.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/no-licence-required/no-licence-required.njk
@@ -23,7 +23,7 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <form method="get">
+        <form action="{{ currentPath }}" method="get">
 
             {% call govukFieldset({
               legend: {

--- a/packages/gafl-webapp-service/src/pages/macros/standard-form.njk
+++ b/packages/gafl-webapp-service/src/pages/macros/standard-form.njk
@@ -21,7 +21,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         {{ errorSummary(error, errorMap, mssgs.there_is_a_problem) }}
-        <form method="post" novalidate>
+        <form action="{{ currentPath }}" method="post" novalidate>
 
           {% block notificationContent %}{% endblock %}
 
@@ -36,7 +36,7 @@
                 {% block pageContent %}{% endblock %}
 
             {% endcall %}
-            
+
             {{ govukButton({
                 attributes: { id: 'continue' },
                 preventDoubleClick: true,
@@ -50,4 +50,3 @@
     {% block pricingSummary %}{% endblock %}
 </div>
 {% endblock %}
-

--- a/packages/gafl-webapp-service/src/pages/payment/cancelled/payment-cancelled.njk
+++ b/packages/gafl-webapp-service/src/pages/payment/cancelled/payment-cancelled.njk
@@ -9,7 +9,7 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-third">
-        <form method="post">
+        <form action="{{ currentPath }}" method="post">
             {% call govukFieldset({
               legend: {
                 text: title,

--- a/packages/gafl-webapp-service/src/pages/payment/failed/payment-failed.njk
+++ b/packages/gafl-webapp-service/src/pages/payment/failed/payment-failed.njk
@@ -18,7 +18,7 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-third">
-        <form method="post">
+        <form action="{{ currentPath }}" method="post">
             {% call govukFieldset({
               legend: {
                 text: title,

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -61,7 +61,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         {{ errorSummary(error, errorMap, mssgs.there_is_a_problem) }}
-        <form method="post" class="govuk-!-margin-bottom-6">
+        <form action="{{ currentPath }}" method="post" class="govuk-!-margin-bottom-6">
             {% call govukFieldset({
               legend: {
                 text: title,

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/contact-summary.njk
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/contact-summary.njk
@@ -33,7 +33,7 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <form method="post">
+        <form action="{{ currentPath }}" method="post">
 
             {{ licenseeDetailsSummary | trim | safe }}
 

--- a/packages/gafl-webapp-service/src/pages/summary/licence-summary/licence-summary.njk
+++ b/packages/gafl-webapp-service/src/pages/summary/licence-summary/licence-summary.njk
@@ -43,7 +43,7 @@
             {{ notificationBanner(data.uri.newPrices, mssgs) }}
           {% endif%}
         {% endblock %}
-        <form method="post">
+        <form action="{{ currentPath }}" method="post">
             {{ licenseDetailsSummary | trim | safe }}
 
             {{ govukButton({

--- a/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
@@ -34,7 +34,7 @@
 
         {{ errorSummary(error, errorMap, mssgs.there_is_a_problem) }}
 
-        <form method="post">
+        <form action="{{ currentPath }}" method="post">
 
             {% call govukFieldset({
               legend: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3673

This change is intended to fix an accessibility issue in which the #main-content fragment, once applied by the skip link, was carried forward through the rest of the journey, forcibly skipping the user to the main content on each subsequent page.