### PR TITLE
Stop redirect from always preserving skip link fragment

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-happy-path.spec.js
@@ -105,7 +105,7 @@ describe('The agreed handler', () => {
     it('loads the order complete page on return from the GOV.UK Payment pages', async () => {
       await injectWithCookies('GET', AGREED.uri)
       const response = await injectWithCookies('GET', AGREED.uri)
-      expect(response.headers.location).toBe(ORDER_COMPLETE.uri)
+      expect(response.headers.location).toBe(`${ORDER_COMPLETE.uri}#`)
     })
 
     it('updates the journal entry with the complete status', async () => {
@@ -190,7 +190,7 @@ describe('The agreed handler', () => {
 
     it('redirects to the order complete page', async () => {
       const response = await injectWithCookies('GET', AGREED.uri)
-      expect(response.headers.location).toBe(ORDER_COMPLETE.uri)
+      expect(response.headers.location).toBe(`${ORDER_COMPLETE.uri}#`)
     })
 
     it('updates the cache', async () => {
@@ -263,7 +263,7 @@ describe('The agreed handler', () => {
     it('loads the order complete page', async () => {
       await injectWithCookies('GET', TEST_STATUS.uri)
       const response = await injectWithCookies('GET', AGREED.uri)
-      expect(response.headers.location).toBe(ORDER_COMPLETE.uri)
+      expect(response.headers.location).toBe(`${ORDER_COMPLETE.uri}#`)
     })
 
     const getMockRequest = (overrides = {}) => ({

--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-payment-failure.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-payment-failure.spec.js
@@ -175,7 +175,7 @@ describe('The agreed handler', () => {
     salesApi.updatePaymentJournal = jest.fn()
     const data2 = await injectWithCookies('GET', AGREED.uri)
     expect(data2.statusCode).toBe(302)
-    expect(data2.headers.location).toBe(PAYMENT_FAILED.uri)
+    expect(data2.headers.location).toBe(`${PAYMENT_FAILED.uri}#`)
 
     // Ensure that the journal status has been updated correctly
     expect(salesApi.updatePaymentJournal).toHaveBeenCalledWith(ADULT_FULL_1_DAY_LICENCE.transactionResponse.id, {
@@ -198,7 +198,7 @@ describe('The agreed handler', () => {
     await injectWithCookies('GET', PAYMENT_FAILED.uri)
     const data4 = await injectWithCookies('POST', PAYMENT_FAILED.uri, {})
     expect(data4.statusCode).toBe(302)
-    expect(data4.headers.location).toBe(AGREED.uri)
+    expect(data4.headers.location).toBe(`${AGREED.uri}#`)
 
     // Test that the status has been updated correctly
     const { payload: status2 } = await injectWithCookies('GET', TEST_STATUS.uri)
@@ -277,7 +277,7 @@ describe('The agreed handler', () => {
     salesApi.updatePaymentJournal = jest.fn()
     const data2 = await injectWithCookies('GET', AGREED.uri)
     expect(data2.statusCode).toBe(302)
-    expect(data2.headers.location).toBe(PAYMENT_CANCELLED.uri)
+    expect(data2.headers.location).toBe(`${PAYMENT_CANCELLED.uri}#`)
 
     // Ensure the the jounal status is set to cancelled
     expect(salesApi.updatePaymentJournal).toHaveBeenCalledWith(ADULT_FULL_1_DAY_LICENCE.transactionResponse.id, {
@@ -301,7 +301,7 @@ describe('The agreed handler', () => {
     await injectWithCookies('GET', PAYMENT_CANCELLED.uri)
     const data3 = await injectWithCookies('POST', PAYMENT_CANCELLED.uri, {})
     expect(data3.statusCode).toBe(302)
-    expect(data3.headers.location).toBe(AGREED.uri)
+    expect(data3.headers.location).toBe(`${AGREED.uri}#`)
 
     // Test that the status has been updated correctly
     const { payload: status2 } = await injectWithCookies('GET', TEST_STATUS.uri)

--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-sales-api-failure.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-sales-api-failure.spec.js
@@ -93,7 +93,7 @@ describe('The agreed handler', () => {
     const data3 = await injectWithCookies('GET', AGREED.uri)
     expect(data3.statusCode).toBe(302)
 
-    expect(data3.headers.location).toBe(ORDER_COMPLETE.uri)
+    expect(data3.headers.location).toBe(`${ORDER_COMPLETE.uri}#`)
     const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
     expect(JSON.parse(payload).id).toBe(ADULT_FULL_1_DAY_LICENCE.transactionResponse.id)
     const { payload: status } = await injectWithCookies('GET', TEST_STATUS.uri)
@@ -106,6 +106,6 @@ describe('The agreed handler', () => {
 
     const data4 = await injectWithCookies('GET', AGREED.uri)
     expect(data4.statusCode).toBe(302)
-    expect(data4.headers.location).toBe(ORDER_COMPLETE.uri)
+    expect(data4.headers.location).toBe(`${ORDER_COMPLETE.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/handlers/__tests__/controller-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/controller-handler.spec.js
@@ -9,24 +9,24 @@ describe('The controller handler', () => {
   it('If there is no transaction then initialize redirect to the controller', async () => {
     const data = await injectWithCookies('GET', '/')
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(CONTROLLER.uri)
+    expect(data.headers.location).toBe(`${CONTROLLER.uri}#`)
   })
 
   it('Adding a new transaction returns a redirect to the start of the journey', async () => {
     const data = await injectWithCookies('GET', NEW_TRANSACTION.uri)
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(CONTROLLER.uri)
+    expect(data.headers.location).toBe(`${CONTROLLER.uri}#`)
   })
 
   it('Adding a new permission returns a redirect to the controller', async () => {
     const data = await injectWithCookies('GET', ADD_PERMISSION.uri)
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(CONTROLLER.uri)
+    expect(data.headers.location).toBe(`${CONTROLLER.uri}#`)
   })
 
   it('The controller returns a redirect to the start of the journey', async () => {
     const data = await injectWithCookies('GET', CONTROLLER.uri)
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(LICENCE_FOR.uri)
+    expect(data.headers.location).toBe(`${LICENCE_FOR.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/pages/concessions/date-of-birth/__tests__/date-of-birth.spec.js
+++ b/packages/gafl-webapp-service/src/pages/concessions/date-of-birth/__tests__/date-of-birth.spec.js
@@ -16,7 +16,7 @@ afterAll(d => stop(d))
 describe('The date of birth page', () => {
   it('redirects back to LICENCE_FOR if not been on already', async () => {
     const response = await injectWithCookies('GET', DATE_OF_BIRTH.uri)
-    expect(response.headers.location).toBe(LICENCE_FOR.uri)
+    expect(response.headers.location).toBe(`${LICENCE_FOR.uri}#`)
   })
 
   it('return success on requesting the page', async () => {
@@ -28,7 +28,7 @@ describe('The date of birth page', () => {
   it('redirects back to itself on posting no response', async () => {
     const response = await injectWithCookies('POST', DATE_OF_BIRTH.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(DATE_OF_BIRTH.uri)
+    expect(response.headers.location).toBe(`${DATE_OF_BIRTH.uri}#`)
   })
 
   it('redirects back to itself on posting an invalid date', async () => {
@@ -38,19 +38,19 @@ describe('The date of birth page', () => {
       'date-of-birth-year': '1970'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(DATE_OF_BIRTH.uri)
+    expect(response.headers.location).toBe(`${DATE_OF_BIRTH.uri}#`)
   })
 
   it('redirects to the disability-concession page on posting a date of birth for an adult licence', async () => {
     const response = await injectWithCookies('POST', DATE_OF_BIRTH.uri, dobHelper(SENIOR_TODAY))
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(DISABILITY_CONCESSION.uri)
+    expect(response.headers.location).toBe(`${DISABILITY_CONCESSION.uri}#`)
   })
 
   it('redirects to the disability-concession page on posting a date of birth for an adult licence', async () => {
     const response = await injectWithCookies('POST', DATE_OF_BIRTH.uri, dobHelper(ADULT_TODAY))
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(DISABILITY_CONCESSION.uri)
+    expect(response.headers.location).toBe(`${DISABILITY_CONCESSION.uri}#`)
   })
 
   it(`redirects to the disability-concession page if a junior on ${DATE_AT_ADVANCED_PURCHASE_MAX_DAYS.format(
@@ -58,7 +58,7 @@ describe('The date of birth page', () => {
   )} - i.e. born ${JUNIOR_AT_ADVANCE_PURCHASE_MAX.format('YYYY-MM-DD')}`, async () => {
     const response = await injectWithCookies('POST', DATE_OF_BIRTH.uri, dobHelper(JUNIOR_AT_ADVANCE_PURCHASE_MAX))
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(DISABILITY_CONCESSION.uri)
+    expect(response.headers.location).toBe(`${DISABILITY_CONCESSION.uri}#`)
   })
 
   it(`redirects to the no-licence-required page if a minor on ${DATE_AT_ADVANCED_PURCHASE_MAX_DAYS.format(
@@ -66,6 +66,6 @@ describe('The date of birth page', () => {
   )} - i.e. born ${MINOR_AT_ADVANCE_PURCHASE_MAX.format('YYYY-MM-DD')}`, async () => {
     const response = await injectWithCookies('POST', DATE_OF_BIRTH.uri, dobHelper(MINOR_AT_ADVANCE_PURCHASE_MAX))
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NO_LICENCE_REQUIRED.uri)
+    expect(response.headers.location).toBe(`${NO_LICENCE_REQUIRED.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/pages/concessions/disability/__tests__/disability-concession.spec.js
+++ b/packages/gafl-webapp-service/src/pages/concessions/disability/__tests__/disability-concession.spec.js
@@ -19,7 +19,7 @@ describe('The disability concession page', () => {
   it('redirects back to itself on posting an empty payload', async () => {
     const response = await injectWithCookies('POST', DISABILITY_CONCESSION.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(DISABILITY_CONCESSION.uri)
+    expect(response.headers.location).toBe(`${DISABILITY_CONCESSION.uri}#`)
   })
 
   it('redirects back to itself on posting PIP with an invalid NI number', async () => {
@@ -28,7 +28,7 @@ describe('The disability concession page', () => {
       'ni-number': 'not-valid'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(DISABILITY_CONCESSION.uri)
+    expect(response.headers.location).toBe(`${DISABILITY_CONCESSION.uri}#`)
   })
 
   it('redirects back to itself on posting blue badge with an empty blue number', async () => {
@@ -37,7 +37,7 @@ describe('The disability concession page', () => {
       'blue-badge-number': ''
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(DISABILITY_CONCESSION.uri)
+    expect(response.headers.location).toBe(`${DISABILITY_CONCESSION.uri}#`)
   })
 
   it('on setting a correct ni number it redirects to the licence-to-start page', async () => {
@@ -46,7 +46,7 @@ describe('The disability concession page', () => {
       'ni-number': 'NH 34 67 44 A'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TO_START.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TO_START.uri}#`)
   })
 
   it('on setting a correct ni number adds a disabled concession to the cache', async () => {
@@ -68,7 +68,7 @@ describe('The disability concession page', () => {
       'blue-badge-number': '1234'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TO_START.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TO_START.uri}#`)
   })
 
   it('on setting a correct blue badge number adds a disabled concession to the cache', async () => {
@@ -114,6 +114,6 @@ describe('The disability concession page', () => {
       'disability-concession': disabilityConcessionTypes.no
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TO_START.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TO_START.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/pages/contact/address/entry/__tests__/address-entry.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/entry/__tests__/address-entry.spec.js
@@ -56,7 +56,7 @@ describe('The manual address entry page', () => {
   it('redirects back to itself on posting no response', async () => {
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   it('redirects back to itself on posting address with no premises', async () => {
@@ -64,7 +64,7 @@ describe('The manual address entry page', () => {
     delete addr.premises
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   it('redirects back to itself on posting too long premises', async () => {
@@ -72,7 +72,7 @@ describe('The manual address entry page', () => {
     addr.premises = 'A'.repeat(101)
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   it('redirects back to itself on posting too long street', async () => {
@@ -80,7 +80,7 @@ describe('The manual address entry page', () => {
     addr.street = 'A'.repeat(101)
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   it('redirects back to itself on posting too long locality', async () => {
@@ -88,7 +88,7 @@ describe('The manual address entry page', () => {
     addr.locality = 'A'.repeat(101)
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   it('redirects back to itself on posting address with no town', async () => {
@@ -96,7 +96,7 @@ describe('The manual address entry page', () => {
     delete addr.town
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   it('redirects back to itself on posting too long town', async () => {
@@ -104,7 +104,7 @@ describe('The manual address entry page', () => {
     addr.town = 'A'.repeat(101)
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   it('redirects back to itself on posting with missing country code', async () => {
@@ -112,7 +112,7 @@ describe('The manual address entry page', () => {
     delete addr['country-code']
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   it('redirects back to itself on posting invalid UK postcode', async () => {
@@ -120,7 +120,7 @@ describe('The manual address entry page', () => {
     addr.postcode = 'foo'
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   describe('on successful valid UK address submission', () => {
@@ -128,7 +128,7 @@ describe('The manual address entry page', () => {
       const addr = Object.assign({}, goodAddress)
       const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
 
       const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
       expect(JSON.parse(payload).permissions[0].licensee).toEqual({
@@ -147,7 +147,7 @@ describe('The manual address entry page', () => {
       await injectWithCookies('POST', LICENCE_LENGTH.uri, { 'licence-length': '1D' })
       const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it('redirects to the contact page if it is 8 day adult licence', async () => {
@@ -156,7 +156,7 @@ describe('The manual address entry page', () => {
       await injectWithCookies('POST', LICENCE_LENGTH.uri, { 'licence-length': '1D' })
       const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it('redirects to the licence fulfilment page if it is a 12 month adult licence', async () => {
@@ -166,7 +166,7 @@ describe('The manual address entry page', () => {
       isPhysical.mockReturnValueOnce(true)
       const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_FULFILMENT.uri)
+      expect(response.headers.location).toBe(`${LICENCE_FULFILMENT.uri}#`)
     })
 
     it('redirects to the contact page if it is a 12 month junior licence on posting a valid UK address', async () => {
@@ -175,7 +175,7 @@ describe('The manual address entry page', () => {
       await injectWithCookies('POST', LICENCE_LENGTH.uri, { 'licence-length': '12M' })
       const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
   })
 
@@ -185,7 +185,7 @@ describe('The manual address entry page', () => {
     addr.postcode = 'not checked'
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, addr)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(CONTACT.uri)
+    expect(response.headers.location).toBe(`${CONTACT.uri}#`)
 
     const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
     expect(JSON.parse(payload).permissions[0].licensee).toMatchObject({
@@ -213,6 +213,6 @@ describe('The manual address entry page', () => {
     await injectWithCookies('GET', CONTACT_SUMMARY.uri)
     const response = await injectWithCookies('POST', ADDRESS_ENTRY.uri, goodAddress)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(CONTACT_SUMMARY.uri)
+    expect(response.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/pages/contact/address/lookup/__tests__/address-lookup.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/lookup/__tests__/address-lookup.spec.js
@@ -23,31 +23,31 @@ describe('The address lookup page', () => {
   it('redirects back to itself on posting an empty payload', async () => {
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_LOOKUP.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_LOOKUP.uri}#`)
   })
 
   it('redirects back to itself on posting an empty premises', async () => {
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, { premises: '', postcode: 'BS9 1HJ' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_LOOKUP.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_LOOKUP.uri}#`)
   })
 
   it('redirects back to itself on posting an empty postcode', async () => {
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, { premises: '5', postcode: '' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_LOOKUP.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_LOOKUP.uri}#`)
   })
 
   it('redirects back to itself on posting a bad postcode', async () => {
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, { premises: '5', postcode: 'foo' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_LOOKUP.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_LOOKUP.uri}#`)
   })
 
   it('redirects back to itself on posting a too long premises', async () => {
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, { premises: 'a'.repeat(101), postcode: 'BS9 1HJ' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_LOOKUP.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_LOOKUP.uri}#`)
   })
 
   it('on finding list of multiple found addresses redirects to the select page', async () => {
@@ -58,7 +58,7 @@ describe('The address lookup page', () => {
 
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, { premises: 'Howecroft Court', postcode: 'BS9 1HJ' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_SELECT.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_SELECT.uri}#`)
   })
 
   it('on finding list of a single found address redirects to the select page', async () => {
@@ -70,7 +70,7 @@ describe('The address lookup page', () => {
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, { premises: 'Howecroft Court', postcode: 'BS9 1HJ' })
 
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_SELECT.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_SELECT.uri}#`)
   })
 
   it("redirects to the entry page where there is no result - and displays the 'not-found' insert text ", async () => {
@@ -81,7 +81,7 @@ describe('The address lookup page', () => {
 
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, { premises: 'Howecroft Court', postcode: 'BS9 1HJ' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
 
     const response2 = await injectWithCookies('GET', ADDRESS_ENTRY.uri)
     expect(response2.payload).toContain('We could not find an address')
@@ -95,7 +95,7 @@ describe('The address lookup page', () => {
 
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, { premises: 'Howecroft Court', postcode: 'BS9 1HJ' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 
   it('redirects to the entry page where there is no lookup set up', async () => {
@@ -103,6 +103,6 @@ describe('The address lookup page', () => {
     delete process.env.ADDRESS_LOOKUP_KEY
     const response = await injectWithCookies('POST', ADDRESS_LOOKUP.uri, { premises: 'Howecroft Court', postcode: 'BS9 1HJ' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_ENTRY.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_ENTRY.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/pages/contact/address/select/__tests__/address-select.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/select/__tests__/address-select.spec.js
@@ -41,13 +41,13 @@ describe('The address select page', () => {
   it('redirects back to itself on posting an empty payload', async () => {
     const response = await injectWithCookies('POST', ADDRESS_SELECT.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_SELECT.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_SELECT.uri}#`)
   })
 
   it('redirects back to itself on posting an no address', async () => {
     const response = await injectWithCookies('POST', ADDRESS_SELECT.uri, { address: '' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(ADDRESS_SELECT.uri)
+    expect(response.headers.location).toBe(`${ADDRESS_SELECT.uri}#`)
   })
 
   describe('on successful submission', () => {
@@ -82,7 +82,7 @@ describe('The address select page', () => {
       await injectWithCookies('POST', LICENCE_LENGTH.uri, { 'licence-length': '1D' })
       const response = await injectWithCookies('POST', ADDRESS_SELECT.uri, { address: '5' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it('redirects to the contact page if licence length is 8 day', async () => {
@@ -90,7 +90,7 @@ describe('The address select page', () => {
       await injectWithCookies('POST', LICENCE_LENGTH.uri, { 'licence-length': '8D' })
       const response = await injectWithCookies('POST', ADDRESS_SELECT.uri, { address: '5' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it('redirects to the contact page if licence length is is 12 months and junior', async () => {
@@ -98,7 +98,7 @@ describe('The address select page', () => {
       await injectWithCookies('POST', LICENCE_LENGTH.uri, { 'licence-length': '12M' })
       const response = await injectWithCookies('POST', ADDRESS_SELECT.uri, { address: '5' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it('redirects to the licence fulfilment page if licence length is 12 months and not junior', async () => {
@@ -107,7 +107,7 @@ describe('The address select page', () => {
       isPhysical.mockReturnValueOnce(true)
       const response = await injectWithCookies('POST', ADDRESS_SELECT.uri, { address: '5' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_FULFILMENT.uri)
+      expect(response.headers.location).toBe(`${LICENCE_FULFILMENT.uri}#`)
     })
 
     it('redirects to the summary page if the summary page is seen', async () => {
@@ -115,7 +115,7 @@ describe('The address select page', () => {
       await injectWithCookies('GET', CONTACT_SUMMARY.uri)
       const response = await injectWithCookies('POST', ADDRESS_SELECT.uri, { address: '5' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT_SUMMARY.uri)
+      expect(response.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
     })
 
     it('The contact information has been set in the transaction', async () => {

--- a/packages/gafl-webapp-service/src/pages/contact/contact/__tests__/contact.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/contact/__tests__/contact.spec.js
@@ -49,14 +49,14 @@ describe('The contact preferences page', () => {
     it('redirects to the date-of-birth page if no date of birth has been set', async () => {
       const response = await injectWithCookies('GET', CONTACT.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(DATE_OF_BIRTH.uri)
+      expect(response.headers.location).toBe(`${DATE_OF_BIRTH.uri}#`)
     })
 
     it('redirects to the licence to start page if no licence start date has been set has been set', async () => {
       await injectWithCookies('POST', DATE_OF_BIRTH.uri, dobHelper(ADULT_TODAY))
       const response = await injectWithCookies('GET', CONTACT.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_TO_START.uri)
+      expect(response.headers.location).toBe(`${LICENCE_TO_START.uri}#`)
     })
 
     it('redirects to the licence length page if no length has been set', async () => {
@@ -64,7 +64,7 @@ describe('The contact preferences page', () => {
       await injectWithCookies('POST', LICENCE_TO_START.uri, { 'licence-to-start': licenceToStart.AFTER_PAYMENT })
       const response = await injectWithCookies('GET', CONTACT.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_LENGTH.uri)
+      expect(response.headers.location).toBe(`${LICENCE_LENGTH.uri}#`)
     })
   })
 
@@ -86,31 +86,31 @@ describe('The contact preferences page', () => {
     it('redirects to itself on an empty response', async () => {
       const response = await injectWithCookies('POST', CONTACT.uri, {})
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it('redirects to itself on an invalid contact method', async () => {
       const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'skype' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it('redirects to itself on an empty email', async () => {
       const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'email', email: '' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it('redirects to itself on an invalid email', async () => {
       const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'email', email: 'foo' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it('redirects to itself on an empty mobile number', async () => {
       const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'text', text: '' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
 
     it.each(['+44(0)7513438168', '923246734', 'email@com', '01179835413', '+457513 438 167'])(
@@ -118,7 +118,7 @@ describe('The contact preferences page', () => {
       async mobileNumber => {
         const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'text', text: mobileNumber })
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toBe(CONTACT.uri)
+        expect(response.headers.location).toBe(`${CONTACT.uri}#`)
       }
     )
 
@@ -163,28 +163,28 @@ describe('The contact preferences page', () => {
       await injectWithCookies('POST', LICENCE_FOR.uri, { 'licence-for': 'you' })
       const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'email', email: 'example@email.com' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(NEWSLETTER.uri)
+      expect(response.headers.location).toBe(`${NEWSLETTER.uri}#`)
     })
 
     it('controller redirects to the contact-summary page if an email is given and licence is for someone else', async () => {
       await injectWithCookies('POST', LICENCE_FOR.uri, { 'licence-for': 'someone-else' })
       const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'email', email: 'example@email.com' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT_SUMMARY.uri)
+      expect(response.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
     })
 
     it('controller redirects to the newsletter page if a text number is given and licence is for you', async () => {
       await injectWithCookies('POST', LICENCE_FOR.uri, { 'licence-for': 'you' })
       const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'text', text: '07513 438167' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(NEWSLETTER.uri)
+      expect(response.headers.location).toBe(`${NEWSLETTER.uri}#`)
     })
 
     it('controller redirects to the contact-summary page if an text number is given and licence is for someone else', async () => {
       await injectWithCookies('POST', LICENCE_FOR.uri, { 'licence-for': 'someone-else' })
       const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'text', text: '07513 438167' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT_SUMMARY.uri)
+      expect(response.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
     })
   })
 
@@ -246,7 +246,7 @@ describe('The contact preferences page', () => {
     it('controller redirects to the summary page', async () => {
       const response = await injectWithCookies('POST', CONTACT.uri, { 'how-contacted': 'none' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT_SUMMARY.uri)
+      expect(response.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
     })
   })
 })

--- a/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/__tests__/licence-confirmation-method.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/__tests__/licence-confirmation-method.spec.js
@@ -55,13 +55,13 @@ describe('The licence confirmation method page', () => {
     it('redirects to itself on an empty response', async () => {
       const response = await injectWithCookies('POST', LICENCE_CONFIRMATION_METHOD.uri, {})
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_CONFIRMATION_METHOD.uri)
+      expect(response.headers.location).toBe(`${LICENCE_CONFIRMATION_METHOD.uri}#`)
     })
 
     it('redirects to itself on an invalid contact method', async () => {
       const response = await injectWithCookies('POST', LICENCE_CONFIRMATION_METHOD.uri, { 'licence-confirmation-method': 'skype' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_CONFIRMATION_METHOD.uri)
+      expect(response.headers.location).toBe(`${LICENCE_CONFIRMATION_METHOD.uri}#`)
     })
 
     it('redirects to itself on an empty email', async () => {
@@ -70,7 +70,7 @@ describe('The licence confirmation method page', () => {
         email: ''
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_CONFIRMATION_METHOD.uri)
+      expect(response.headers.location).toBe(`${LICENCE_CONFIRMATION_METHOD.uri}#`)
     })
 
     it('redirects to itself on an invalid email', async () => {
@@ -79,13 +79,13 @@ describe('The licence confirmation method page', () => {
         email: 'foo'
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_CONFIRMATION_METHOD.uri)
+      expect(response.headers.location).toBe(`${LICENCE_CONFIRMATION_METHOD.uri}#`)
     })
 
     it('redirects to itself on an empty mobile number', async () => {
       const response = await injectWithCookies('POST', LICENCE_CONFIRMATION_METHOD.uri, { 'licence-confirmation-method': 'text', text: '' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_CONFIRMATION_METHOD.uri)
+      expect(response.headers.location).toBe(`${LICENCE_CONFIRMATION_METHOD.uri}#`)
     })
 
     it.each(['+44(0)7513438168', '923246734', 'email@com', '01179835413', '+457513 438 167'])(
@@ -96,7 +96,7 @@ describe('The licence confirmation method page', () => {
           text: mobileNumber
         })
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toBe(LICENCE_CONFIRMATION_METHOD.uri)
+        expect(response.headers.location).toBe(`${LICENCE_CONFIRMATION_METHOD.uri}#`)
       }
     )
 
@@ -140,7 +140,7 @@ describe('The licence confirmation method page', () => {
     it('redirects to the contact page', async () => {
       const response = await injectWithCookies('GET', LICENCE_CONFIRMATION_METHOD.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
   })
 
@@ -163,7 +163,7 @@ describe('The licence confirmation method page', () => {
         email: 'example@email.com'
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
   })
 })

--- a/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-fulfilment/__tests__/licence-fulfilment.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-fulfilment/__tests__/licence-fulfilment.spec.js
@@ -58,7 +58,7 @@ describe('The licence fulfilment page', () => {
         'licence-option': 'none'
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_FULFILMENT.uri)
+      expect(response.headers.location).toBe(`${LICENCE_FULFILMENT.uri}#`)
     })
 
     it('post response digital sets postalFulfilment - no, in the cache', async () => {
@@ -91,7 +91,7 @@ describe('The licence fulfilment page', () => {
     it('redirects to the contact page', async () => {
       const response = await injectWithCookies('GET', LICENCE_FULFILMENT.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
   })
 
@@ -111,7 +111,7 @@ describe('The licence fulfilment page', () => {
       await injectWithCookies('GET', CONTACT_SUMMARY.uri)
       const response = await injectWithCookies('POST', LICENCE_FULFILMENT.uri, { 'licence-option': 'digital' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_CONFIRMATION_METHOD.uri)
+      expect(response.headers.location).toBe(`${LICENCE_CONFIRMATION_METHOD.uri}#`)
     })
   })
 })

--- a/packages/gafl-webapp-service/src/pages/contact/name/__tests__/name.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/name/__tests__/name.spec.js
@@ -14,7 +14,7 @@ describe('The name page', () => {
   it('Redirects back to itself on posting an empty name', async () => {
     const response = await injectWithCookies('POST', NAME.uri, { 'first-name': '', 'last-name': '' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NAME.uri)
+    expect(response.headers.location).toBe(`${NAME.uri}#`)
   })
 
   it('Redirects back to itself on posting a too long first name', async () => {
@@ -23,7 +23,7 @@ describe('The name page', () => {
       'last-name': 'OK'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NAME.uri)
+    expect(response.headers.location).toBe(`${NAME.uri}#`)
   })
 
   it('Redirects back to itself on posting a too long last name', async () => {
@@ -32,7 +32,7 @@ describe('The name page', () => {
       'first-name': 'OK'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NAME.uri)
+    expect(response.headers.location).toBe(`${NAME.uri}#`)
   })
 
   it('Redirects back to itself on posting a too short first name', async () => {
@@ -41,7 +41,7 @@ describe('The name page', () => {
       'last-name': 'OK'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NAME.uri)
+    expect(response.headers.location).toBe(`${NAME.uri}#`)
   })
 
   it('Redirects back to itself on posting a too short last name', async () => {
@@ -50,7 +50,7 @@ describe('The name page', () => {
       'first-name': 'OK'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NAME.uri)
+    expect(response.headers.location).toBe(`${NAME.uri}#`)
   })
 
   it('Redirects back to itself on posting a first name with invalid characters', async () => {
@@ -59,7 +59,7 @@ describe('The name page', () => {
       'first-name': '%%%%'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NAME.uri)
+    expect(response.headers.location).toBe(`${NAME.uri}#`)
   })
 
   it('Redirects back to itself on posting a last name with invalid characters', async () => {
@@ -68,7 +68,7 @@ describe('The name page', () => {
       'first-name': 'OK'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NAME.uri)
+    expect(response.headers.location).toBe(`${NAME.uri}#`)
   })
 
   it('Check character substitutions are made on a successful submission', async () => {
@@ -77,7 +77,7 @@ describe('The name page', () => {
       'first-name': 'GRAHAM    MICHAEL'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(DATE_OF_BIRTH.uri)
+    expect(response.headers.location).toBe(`${DATE_OF_BIRTH.uri}#`)
     const { payload } = await injectWithCookies('GET', TEST_TRANSACTION.uri)
 
     expect(JSON.parse(payload).permissions[0].licensee).toEqual({ firstName: 'Graham Michael', lastName: 'Willis' })

--- a/packages/gafl-webapp-service/src/pages/contact/newsletter/__tests__/newsletter.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/newsletter/__tests__/newsletter.spec.js
@@ -30,13 +30,13 @@ describe('The newsletter page', () => {
   it('redirects to itself posting an empty response', async () => {
     const response = await injectWithCookies('POST', NEWSLETTER.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NEWSLETTER.uri)
+    expect(response.headers.location).toBe(`${NEWSLETTER.uri}#`)
   })
 
   it('redirects to itself posting an invalid email response', async () => {
     const response = await injectWithCookies('POST', NEWSLETTER.uri, { newsletter: 'yes', email: 'foo', 'email-entry': 'yes' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NEWSLETTER.uri)
+    expect(response.headers.location).toBe(`${NEWSLETTER.uri}#`)
   })
 
   describe('if the user has set the preferred method of contact to email ', () => {
@@ -72,7 +72,7 @@ describe('The newsletter page', () => {
         'email-entry': 'no'
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT_SUMMARY.uri)
+      expect(response.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
     })
 
     it('if posting yes it sets the newsletter contact method to email and preserves the contact methods and email', async () => {
@@ -118,7 +118,7 @@ describe('The newsletter page', () => {
         'email-entry': 'no'
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT_SUMMARY.uri)
+      expect(response.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
     })
   })
 
@@ -154,7 +154,7 @@ describe('The newsletter page', () => {
         'email-entry': 'yes'
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT_SUMMARY.uri)
+      expect(response.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
     })
 
     it('if posting yes it sets the newsletter contact method to email and sets the email address', async () => {
@@ -183,7 +183,7 @@ describe('The newsletter page', () => {
         email: 'example@email.com'
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT_SUMMARY.uri)
+      expect(response.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
     })
 
     it('if having previously posting yes and subsequently posting no, it sets the email', async () => {

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-length/__tests__/licence-length.spec.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-length/__tests__/licence-length.spec.js
@@ -17,13 +17,13 @@ describe('The licence length page', () => {
   it('redirects back to itself on posting no response', async () => {
     const response = await injectWithCookies('POST', LICENCE_LENGTH.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_LENGTH.uri)
+    expect(response.headers.location).toBe(`${LICENCE_LENGTH.uri}#`)
   })
 
   it('redirects back to itself on posting an invalid response', async () => {
     const response = await injectWithCookies('POST', LICENCE_LENGTH.uri, { 'licence-length': '8M' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_LENGTH.uri)
+    expect(response.headers.location).toBe(`${LICENCE_LENGTH.uri}#`)
   })
 
   it.each([
@@ -39,7 +39,7 @@ describe('The licence length page', () => {
   it('redirects into the licence summary page for licence length of 12 months', async () => {
     const response = await injectWithCookies('POST', LICENCE_LENGTH.uri, { 'licence-length': '12M' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_SUMMARY.uri)
+    expect(response.headers.location).toBe(`${LICENCE_SUMMARY.uri}#`)
   })
 
   it.each([
@@ -48,7 +48,7 @@ describe('The licence length page', () => {
   ])('redirects into the time to start page for licence length %s', async (desc, lenCode) => {
     const response = await injectWithCookies('POST', LICENCE_LENGTH.uri, { 'licence-length': lenCode })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_START_TIME.uri)
+    expect(response.headers.location).toBe(`${LICENCE_START_TIME.uri}#`)
   })
 
   it("where contact is 'none' setting a 12 month licence changes it to 'post'", async () => {

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/__tests__/licence-start-time.spec.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-start-time/__tests__/licence-start-time.spec.js
@@ -27,14 +27,14 @@ describe('The licence start time page', () => {
   it('redirects back to itself on posting no response', async () => {
     const response = await injectWithCookies('POST', LICENCE_START_TIME.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_START_TIME.uri)
+    expect(response.headers.location).toBe(`${LICENCE_START_TIME.uri}#`)
   })
   it('redirects back to itself on an invalid time', async () => {
     const response = await injectWithCookies('POST', LICENCE_START_TIME.uri, {
       'licence-start-time': '25'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_START_TIME.uri)
+    expect(response.headers.location).toBe(`${LICENCE_START_TIME.uri}#`)
   })
   it.each([
     ['Start of the day', '0'],
@@ -97,6 +97,6 @@ describe('The licence start time page', () => {
     await injectWithCookies('GET', LICENCE_SUMMARY.uri)
     const response = await injectWithCookies('POST', LICENCE_START_TIME.uri, { 'licence-start-time': '12' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_SUMMARY.uri)
+    expect(response.headers.location).toBe(`${LICENCE_SUMMARY.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/__tests__/licence-to-start.spec.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/__tests__/licence-to-start.spec.js
@@ -39,7 +39,7 @@ describe("The 'when would you like you licence to start?' page", () => {
   it('redirects back to itself on posting no response', async () => {
     const response = await injectWithCookies('POST', LICENCE_TO_START.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TO_START.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TO_START.uri}#`)
   })
 
   it('redirects back to itself on posting an invalid date', async () => {
@@ -50,7 +50,7 @@ describe("The 'when would you like you licence to start?' page", () => {
       'licence-start-date-day': '35'
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TO_START.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TO_START.uri}#`)
   })
 
   it('redirects back to itself on posting a start date in the past', async () => {
@@ -59,7 +59,7 @@ describe("The 'when would you like you licence to start?' page", () => {
       ...startDateHelper(moment().add(-1, 'days'))
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TO_START.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TO_START.uri}#`)
   })
 
   it(`redirects back to itself on posting a start date ahead of the maximum forward purchase date: ${DATE_AT_ADVANCED_PURCHASE_MAX_DAYS.format(
@@ -70,7 +70,7 @@ describe("The 'when would you like you licence to start?' page", () => {
       ...startDateHelper(moment().add(ADVANCED_PURCHASE_MAX_DAYS + 1, 'days'))
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TO_START.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TO_START.uri}#`)
   })
 
   describe(`for a user who is born on the ${juniorIn16Days.format('YYYY-MM-DD')}`, () => {
@@ -86,7 +86,7 @@ describe("The 'when would you like you licence to start?' page", () => {
         ...startDateHelper(moment().add(16, 'day'))
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_TYPE.uri)
+      expect(response.headers.location).toBe(`${LICENCE_TYPE.uri}#`)
     })
 
     it(`redirects to the no licence required page when posting a licence start date of ${moment()
@@ -97,7 +97,7 @@ describe("The 'when would you like you licence to start?' page", () => {
         ...startDateHelper(moment().add(15, 'day'))
       })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(NO_LICENCE_REQUIRED.uri)
+      expect(response.headers.location).toBe(`${NO_LICENCE_REQUIRED.uri}#`)
     })
   })
 
@@ -109,7 +109,7 @@ describe("The 'when would you like you licence to start?' page", () => {
       'licence-to-start': licenceToStart.AFTER_PAYMENT
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(NO_LICENCE_REQUIRED.uri)
+    expect(response.headers.location).toBe(`${NO_LICENCE_REQUIRED.uri}#`)
   })
 
   it(`for a user who is born on the ${JUNIOR_TODAY.format(
@@ -120,7 +120,7 @@ describe("The 'when would you like you licence to start?' page", () => {
       'licence-to-start': licenceToStart.AFTER_PAYMENT
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TYPE.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TYPE.uri}#`)
   })
 
   it('redirects to the start-time page if it already known that this is a 1 or 8 day licence', async () => {
@@ -131,7 +131,7 @@ describe("The 'when would you like you licence to start?' page", () => {
       ...startDateHelper(moment().add(16, 'day'))
     })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_START_TIME.uri)
+    expect(response.headers.location).toBe(`${LICENCE_START_TIME.uri}#`)
   })
 
   it('changing from a 12 month to a one day licence removes the start time', async () => {
@@ -183,7 +183,7 @@ describe("The 'when would you like you licence to start?' page", () => {
           ...startDateHelper(moment().add(48, 'day'))
         })
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toBe(LICENCE_START_TIME.uri)
+        expect(response.headers.location).toBe(`${LICENCE_START_TIME.uri}#`)
         jest.restoreAllMocks()
       } catch (e) {
         console.error(e)

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-type/__tests__/licence-type.spec.js
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-type/__tests__/licence-type.spec.js
@@ -37,13 +37,13 @@ describe('The licence type page', () => {
   it('redirects back to itself on posting no response', async () => {
     const response = await injectWithCookies('POST', LICENCE_TYPE.uri, {})
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TYPE.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TYPE.uri}#`)
   })
 
   it('redirects back to itself on posting an invalid response', async () => {
     const response = await injectWithCookies('POST', LICENCE_TYPE.uri, { 'licence-type': 'hunting-licence' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_TYPE.uri)
+    expect(response.headers.location).toBe(`${LICENCE_TYPE.uri}#`)
   })
 
   it.each([
@@ -63,7 +63,7 @@ describe('The licence type page', () => {
     await injectWithCookies('POST', LICENCE_TO_START.uri, { 'licence-to-start': licenceToStart.AFTER_PAYMENT })
     const response = await injectWithCookies('POST', LICENCE_TYPE.uri, { 'licence-type': licenseTypes.salmonAndSeaTrout })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_SUMMARY.uri)
+    expect(response.headers.location).toBe(`${LICENCE_SUMMARY.uri}#`)
   })
 
   it('on success redirects directly to the length page for a disabled concession', async () => {
@@ -76,7 +76,7 @@ describe('The licence type page', () => {
     })
     const response = await injectWithCookies('POST', LICENCE_TYPE.uri, { 'licence-type': licenseTypes.salmonAndSeaTrout })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_LENGTH.uri)
+    expect(response.headers.location).toBe(`${LICENCE_LENGTH.uri}#`)
   })
 
   it('on success redirects directly to the summary page for a 3 rod licence', async () => {
@@ -85,7 +85,7 @@ describe('The licence type page', () => {
     await injectWithCookies('POST', LICENCE_TO_START.uri, { 'licence-to-start': licenceToStart.AFTER_PAYMENT })
     const response = await injectWithCookies('POST', LICENCE_TYPE.uri, { 'licence-type': licenseTypes.troutAndCoarse3Rod })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_SUMMARY.uri)
+    expect(response.headers.location).toBe(`${LICENCE_SUMMARY.uri}#`)
   })
 
   it('on success redirects to the length page for an adult', async () => {
@@ -94,6 +94,6 @@ describe('The licence type page', () => {
     await injectWithCookies('POST', LICENCE_TO_START.uri, { 'licence-to-start': licenceToStart.AFTER_PAYMENT })
     const response = await injectWithCookies('POST', LICENCE_TYPE.uri, { 'licence-type': licenseTypes.salmonAndSeaTrout })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_LENGTH.uri)
+    expect(response.headers.location).toBe(`${LICENCE_LENGTH.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/__tests__/identity.spec.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/__tests__/identity.spec.js
@@ -24,6 +24,7 @@ import { addLanguageCodeToUri } from '../../../../processors/uri-helper.js'
 import pageRoute from '../../../../routes/page-route.js'
 
 jest.mock('../../../../processors/uri-helper.js', () => ({
+  ...jest.requireActual('../../../../processors/uri-helper.js'),
   addLanguageCodeToUri: jest.fn((request, uri) => uri || request.path)
 }))
 jest.mock('../../../../routes/page-route.js', () => jest.fn(jest.requireActual('../../../../routes/page-route.js').default))
@@ -54,10 +55,10 @@ describe('The easy renewal identification page', () => {
   it('redirects to identify page when called with an invalid permission reference', async () => {
     const data = await injectWithCookies('GET', RENEWAL_PUBLIC.uri.replace('{referenceNumber}', 'not-a-valid-reference-number'))
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(IDENTIFY.uri)
+    expect(data.headers.location).toBe(`${IDENTIFY.uri}#`)
     const data2 = await injectWithCookies('GET', IDENTIFY.uri)
     expect(data2.statusCode).toBe(302)
-    expect(data2.headers.location).toBe(IDENTIFY.uri)
+    expect(data2.headers.location).toBe(`${IDENTIFY.uri}#`)
     const data3 = await injectWithCookies('GET', IDENTIFY.uri)
     expect(data3.statusCode).toBe(200)
   })
@@ -65,7 +66,7 @@ describe('The easy renewal identification page', () => {
   it('returns successfully when called with a valid reference ', async () => {
     const data = await injectWithCookies('GET', VALID_RENEWAL_PUBLIC)
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(IDENTIFY.uri)
+    expect(data.headers.location).toBe(`${IDENTIFY.uri}#`)
     const data2 = await injectWithCookies('GET', IDENTIFY.uri)
     expect(data2.statusCode).toBe(200)
   })
@@ -75,7 +76,7 @@ describe('The easy renewal identification page', () => {
     await injectWithCookies('GET', IDENTIFY.uri)
     const data = await injectWithCookies('POST', IDENTIFY.uri, Object.assign({ postcode: 'HHHHH' }, dobHelper(ADULT_TODAY)))
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(IDENTIFY.uri)
+    expect(data.headers.location).toBe(`${IDENTIFY.uri}#`)
   })
 
   it('redirects back to itself on posting an invalid data of birth', async () => {
@@ -83,7 +84,7 @@ describe('The easy renewal identification page', () => {
     await injectWithCookies('GET', IDENTIFY.uri)
     const data = await injectWithCookies('POST', IDENTIFY.uri, Object.assign({ postcode: 'BS9 1HJ' }, dobHelper(dobInvalid)))
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(IDENTIFY.uri)
+    expect(data.headers.location).toBe(`${IDENTIFY.uri}#`)
   })
 
   it('redirects back to itself on posting an valid but not authenticated details', async () => {
@@ -96,10 +97,10 @@ describe('The easy renewal identification page', () => {
       Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
     )
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(AUTHENTICATE.uri)
+    expect(data.headers.location).toBe(`${AUTHENTICATE.uri}#`)
     const data2 = await injectWithCookies('GET', AUTHENTICATE.uri)
     expect(data2.statusCode).toBe(302)
-    expect(data2.headers.location).toBe(IDENTIFY.uri)
+    expect(data2.headers.location).toBe(`${IDENTIFY.uri}#`)
     const data3 = await injectWithCookies('GET', IDENTIFY.uri)
     expect(data3.statusCode).toBe(200)
   })
@@ -172,7 +173,7 @@ describe('The easy renewal identification page', () => {
         IDENTIFY.uri,
         Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
       )
-      expect(data.headers.location).toBe(AUTHENTICATE.uri)
+      expect(data.headers.location).toBe(`${AUTHENTICATE.uri}#`)
     })
 
     it('returns a 302 status code on a GET request to the authenticate uri', async () => {
@@ -192,7 +193,7 @@ describe('The easy renewal identification page', () => {
         Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY))
       )
       const data = await injectWithCookies('GET', AUTHENTICATE.uri)
-      expect(data.headers.location).toBe(CONTROLLER.uri)
+      expect(data.headers.location).toBe(`${CONTROLLER.uri}#`)
     })
 
     it('returns a 200 status code on a GET request to the licence summary', async () => {
@@ -294,7 +295,7 @@ describe('The easy renewal identification page', () => {
     await injectWithCookies('POST', IDENTIFY.uri, Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY)))
     const data = await injectWithCookies('GET', AUTHENTICATE.uri)
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(RENEWAL_INACTIVE.uri)
+    expect(data.headers.location).toBe(`${RENEWAL_INACTIVE.uri}#`)
 
     // Fetch the page
     const data2 = await injectWithCookies('GET', RENEWAL_INACTIVE.uri)
@@ -302,7 +303,7 @@ describe('The easy renewal identification page', () => {
 
     const data3 = await injectWithCookies('POST', RENEWAL_INACTIVE.uri, {})
     expect(data3.statusCode).toBe(302)
-    expect(data3.headers.location).toBe(LICENCE_LENGTH.uri)
+    expect(data3.headers.location).toBe(`${LICENCE_LENGTH.uri}#`)
   })
 
   it('that an expiry that has expired causes a redirect to the invalid renewal page', async () => {
@@ -317,7 +318,7 @@ describe('The easy renewal identification page', () => {
     await injectWithCookies('POST', IDENTIFY.uri, Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY)))
     const data = await injectWithCookies('GET', AUTHENTICATE.uri)
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(RENEWAL_INACTIVE.uri)
+    expect(data.headers.location).toBe(`${RENEWAL_INACTIVE.uri}#`)
   })
 
   it('that an expiry for a 1 or 8 day licence causes a redirect to the invalid renewal page', async () => {
@@ -330,6 +331,6 @@ describe('The easy renewal identification page', () => {
     await injectWithCookies('POST', IDENTIFY.uri, Object.assign({ postcode: 'BS9 1HJ', referenceNumber: 'AAAAAA' }, dobHelper(ADULT_TODAY)))
     const data = await injectWithCookies('GET', AUTHENTICATE.uri)
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(RENEWAL_INACTIVE.uri)
+    expect(data.headers.location).toBe(`${RENEWAL_INACTIVE.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/contact-summary.spec.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/contact-summary.spec.js
@@ -60,14 +60,14 @@ describe('The contact summary page', () => {
     it('redirects to the address lookup page if the address entry or address select page has not been visited', async () => {
       const response = await injectWithCookies('GET', CONTACT_SUMMARY.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(ADDRESS_LOOKUP.uri)
+      expect(response.headers.location).toBe(`${ADDRESS_LOOKUP.uri}#`)
     })
 
     it('redirects to the contact page if it has not been visited', async () => {
       await injectWithCookies('POST', ADDRESS_ENTRY.uri, goodAddress)
       const response = await injectWithCookies('GET', CONTACT_SUMMARY.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(CONTACT.uri)
+      expect(response.headers.location).toBe(`${CONTACT.uri}#`)
     })
   })
 
@@ -93,14 +93,14 @@ describe('The contact summary page', () => {
     it('when navigating to the contact summary, it redirects to the licence fulfilment page, if it has not been visited', async () => {
       const response = await injectWithCookies('GET', CONTACT_SUMMARY.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_FULFILMENT.uri)
+      expect(response.headers.location).toBe(`${LICENCE_FULFILMENT.uri}#`)
     })
 
     it('when navigating to the contact summary, it redirects to the licence confirmation method page, if it has not been visited', async () => {
       await injectWithCookies('POST', LICENCE_FULFILMENT.uri, { 'licence-option': 'digital' })
       const response = await injectWithCookies('GET', CONTACT_SUMMARY.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_CONFIRMATION_METHOD.uri)
+      expect(response.headers.location).toBe(`${LICENCE_CONFIRMATION_METHOD.uri}#`)
     })
 
     it('when navigating to the contact summary, it displays the contact summary page, if the licence fulfilment and confirmation method page have been visited', async () => {

--- a/packages/gafl-webapp-service/src/pages/summary/licence-summary/__tests__/licence-summary.spec.js
+++ b/packages/gafl-webapp-service/src/pages/summary/licence-summary/__tests__/licence-summary.spec.js
@@ -42,7 +42,7 @@ describe('The licence summary page', () => {
       await injectWithCookies('POST', NAME.uri, { 'last-name': 'Graham', 'first-name': 'Willis' })
       const response = await injectWithCookies('GET', LICENCE_SUMMARY.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(DATE_OF_BIRTH.uri)
+      expect(response.headers.location).toBe(`${DATE_OF_BIRTH.uri}#`)
     })
 
     it('redirects to the licence to start page if no licence start date has been set', async () => {
@@ -50,7 +50,7 @@ describe('The licence summary page', () => {
       await injectWithCookies('POST', DATE_OF_BIRTH.uri, dobHelper(ADULT_TODAY))
       const response = await injectWithCookies('GET', LICENCE_SUMMARY.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_TO_START.uri)
+      expect(response.headers.location).toBe(`${LICENCE_TO_START.uri}#`)
     })
 
     it('redirects to the licence type page if no licence type has been set', async () => {
@@ -59,7 +59,7 @@ describe('The licence summary page', () => {
       await injectWithCookies('POST', LICENCE_TO_START.uri, { 'licence-to-start': licenceToStart.AFTER_PAYMENT })
       const response = await injectWithCookies('GET', LICENCE_SUMMARY.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_TYPE.uri)
+      expect(response.headers.location).toBe(`${LICENCE_TYPE.uri}#`)
     })
 
     it('redirects to the licence length page if no length has been set', async () => {
@@ -69,7 +69,7 @@ describe('The licence summary page', () => {
       await injectWithCookies('POST', LICENCE_TYPE.uri, { 'licence-type': licenseTypes.troutAndCoarse2Rod })
       const response = await injectWithCookies('GET', LICENCE_SUMMARY.uri)
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe(LICENCE_LENGTH.uri)
+      expect(response.headers.location).toBe(`${LICENCE_LENGTH.uri}#`)
     })
   })
 

--- a/packages/gafl-webapp-service/src/pages/terms-and-conditions/__tests__/terms-and-conditions.spec.js
+++ b/packages/gafl-webapp-service/src/pages/terms-and-conditions/__tests__/terms-and-conditions.spec.js
@@ -48,7 +48,7 @@ describe('The terms and conditions page', () => {
   it('redirects to the licence summary if the licence summary has not been completed', async () => {
     const data = await injectWithCookies('GET', TERMS_AND_CONDITIONS.uri)
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(LICENCE_SUMMARY.uri)
+    expect(data.headers.location).toBe(`${LICENCE_SUMMARY.uri}#`)
   })
 
   it('redirects to the contact summary page if the contact page has not been visited', async () => {
@@ -60,13 +60,13 @@ describe('The terms and conditions page', () => {
     await injectWithCookies('POST', LICENCE_SUMMARY.uri)
     const data = await injectWithCookies('GET', TERMS_AND_CONDITIONS.uri)
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(CONTACT_SUMMARY.uri)
+    expect(data.headers.location).toBe(`${CONTACT_SUMMARY.uri}#`)
   })
 
   it('redirects back to itself on invalid response', async () => {
     const data = await injectWithCookies('POST', TERMS_AND_CONDITIONS.uri, { agree: 'no way' })
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(TERMS_AND_CONDITIONS.uri)
+    expect(data.headers.location).toBe(`${TERMS_AND_CONDITIONS.uri}#`)
   })
 
   it('responds with the terms and conditions page if all data is provided', async () => {
@@ -91,10 +91,10 @@ describe('The terms and conditions page', () => {
     await injectWithCookies('GET', NEW_TRANSACTION.uri)
     const data1 = await injectWithCookies('POST', TERMS_AND_CONDITIONS.uri, { agree: 'yes' })
     expect(data1.statusCode).toBe(302)
-    expect(data1.headers.location).toBe(AGREED.uri)
+    expect(data1.headers.location).toBe(`${AGREED.uri}#`)
     await injectWithCookies('GET', AGREED.uri) // generates dirty great error
     const data2 = await injectWithCookies('GET', CONTACT_SUMMARY.uri)
     expect(data2.statusCode).toBe(302)
-    expect(data2.headers.location).toBe(AGREED.uri)
+    expect(data2.headers.location).toBe(`${AGREED.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/processors/__tests__/uri-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/uri-helper.spec.js
@@ -1,4 +1,4 @@
-import { addLanguageCodeToUri } from '../uri-helper.js'
+import { addEmptyFragmentToUri, addLanguageCodeToUri } from '../uri-helper.js'
 
 describe('URI Helpers: addLanguageCodeToURI', () => {
   it.each([
@@ -62,5 +62,18 @@ describe('URI Helpers: addLanguageCodeToURI', () => {
       const result = addLanguageCodeToUri(mockRequest, suppliedPath)
       expect(result).toEqual(expectedPath)
     })
+  })
+})
+
+describe('URI Helpers: addEmptyFragmentToUri', () => {
+  it.each([
+    ['http://my-url.com/path', 'http://my-url.com/path#'],
+    ['http://my-url.com/path?lang=cy', 'http://my-url.com/path?lang=cy#'],
+    ['http://my-url.com/path#main-content', 'http://my-url.com/path#'],
+    ['http://my-url.com/path?lang=cy#main-content', 'http://my-url.com/path?lang=cy#'],
+    ['http://my-url.com/path?lang=cy&foo=bar#main-content', 'http://my-url.com/path?lang=cy&foo=bar#']
+  ])('appends an empty fragment to the end of the path', async (suppliedPath, expectedPath) => {
+    const result = addEmptyFragmentToUri(suppliedPath)
+    expect(result).toEqual(expectedPath)
   })
 })

--- a/packages/gafl-webapp-service/src/processors/uri-helper.js
+++ b/packages/gafl-webapp-service/src/processors/uri-helper.js
@@ -7,3 +7,9 @@ export const addLanguageCodeToUri = (request, uri) => {
   const languageSpecifier = /.*\?.*/.test(cleanPath) ? '&lang=cy' : '?lang=cy'
   return `${cleanPath}${/\?.*lang=cy.*$/.test(request.url.search) ? languageSpecifier : ''}`
 }
+
+export const addEmptyFragmentToUri = path => {
+  // Remove any existing fragments
+  const cleanPath = path.split('#')[0]
+  return `${cleanPath}#`
+}

--- a/packages/gafl-webapp-service/src/routes/__tests__/misc-routes.spec.js
+++ b/packages/gafl-webapp-service/src/routes/__tests__/misc-routes.spec.js
@@ -12,7 +12,7 @@ describe('The miscellaneous route handlers', () => {
   it('redirect to the main controller when / is requested', async () => {
     const data = await injectWithCookies('GET', '/')
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(CONTROLLER.uri)
+    expect(data.headers.location).toBe(`${CONTROLLER.uri}#`)
   })
 
   it('return the refund policy page when requested', async () => {
@@ -38,6 +38,6 @@ describe('The miscellaneous route handlers', () => {
   it('The easy renewals shortcut route redirects correctly', async () => {
     const data = await injectWithCookies('GET', RENEWAL_PUBLIC.uri.replace('{referenceNumber}', 'AAAAAA'))
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe(IDENTIFY.uri.replace('{referenceNumber}', 'AAAAAA'))
+    expect(data.headers.location).toBe(`${IDENTIFY.uri.replace('{referenceNumber}', 'AAAAAA')}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/routes/__tests__/new-transaction-route.spec.js
+++ b/packages/gafl-webapp-service/src/routes/__tests__/new-transaction-route.spec.js
@@ -16,6 +16,6 @@ describe('The new transaction route clears the cache and invokes the controller 
     })
     expect(spy).toBeCalled()
     expect(data.statusCode).toBe(302)
-    expect(data.headers.location).toBe('/buy')
+    expect(data.headers.location).toBe('/buy#')
   })
 })

--- a/packages/gafl-webapp-service/src/server.js
+++ b/packages/gafl-webapp-service/src/server.js
@@ -25,7 +25,7 @@ import { errorHandler } from './handlers/error-handler.js'
 import { initialise as initialiseOIDC } from './handlers/oidc-handler.js'
 import { getPlugins } from './plugins.js'
 import { airbrake } from '@defra-fish/connectors-lib'
-import { addLanguageCodeToUri } from './processors/uri-helper.js'
+import { addEmptyFragmentToUri, addLanguageCodeToUri } from './processors/uri-helper.js'
 airbrake.initialise()
 let server
 
@@ -183,8 +183,9 @@ const init = async () => {
 
   server.decorate('toolkit', 'redirectWithLanguageCode', function (redirect) {
     const uriWithLanguage = addLanguageCodeToUri(this.request, redirect)
+    const uriWithLanguageAndEmptyFragment = addEmptyFragmentToUri(uriWithLanguage)
 
-    return this.redirect(uriWithLanguage)
+    return this.redirect(uriWithLanguageAndEmptyFragment)
   })
 
   if (process.env.CHANNEL === 'telesales') {

--- a/packages/gafl-webapp-service/src/session-cache/__tests__/cache-manager.spec.js
+++ b/packages/gafl-webapp-service/src/session-cache/__tests__/cache-manager.spec.js
@@ -12,7 +12,7 @@ describe('The session cache removal', () => {
     await injectWithCookies('GET', '/buy/clear-cache')
     const response = await injectWithCookies('GET', LICENCE_TYPE.uri)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(CONTROLLER.uri)
+    expect(response.headers.location).toBe(`${CONTROLLER.uri}#`)
   })
 
   /*
@@ -24,6 +24,6 @@ describe('The session cache removal', () => {
     await injectWithCookies('GET', '/buy/clear-cache')
     const response = await injectWithCookies('POST', LICENCE_TYPE.uri, { 'licence-type': 'hunting-licence' })
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(CONTROLLER.uri)
+    expect(response.headers.location).toBe(`${CONTROLLER.uri}#`)
   })
 })

--- a/packages/gafl-webapp-service/src/session-cache/__tests__/session-manager.spec.js
+++ b/packages/gafl-webapp-service/src/session-cache/__tests__/session-manager.spec.js
@@ -70,14 +70,14 @@ describe('The user', () => {
   it('clearing the session cookie automatically creates a new cookie and cache', async () => {
     const response = await injectWithoutSessionCookie('GET', LICENCE_TYPE.uri)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(CONTROLLER.uri)
+    expect(response.headers.location).toBe(`${CONTROLLER.uri}#`)
   })
 
   it('Clearing the session cookie will redirect to the start of the journey on a post valid response', async () => {
     await injectWithoutSessionCookie('POST', LICENCE_TYPE.uri, { 'licence-type': licenseTypes.troutAndCoarse2Rod })
     const response = await injectWithCookies('GET', CONTROLLER.uri)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_FOR.uri)
+    expect(response.headers.location).toBe(`${LICENCE_FOR.uri}#`)
   })
 
   /*
@@ -89,7 +89,7 @@ describe('The user', () => {
     await injectWithoutSessionCookie('POST', LICENCE_TYPE.uri, {})
     const response = await injectWithCookies('GET', CONTROLLER.uri)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(LICENCE_FOR.uri)
+    expect(response.headers.location).toBe(`${LICENCE_FOR.uri}#`)
   })
 
   /*
@@ -103,7 +103,7 @@ describe('The user', () => {
   ])('redirects to the controller on attempting to access %s', async (desc, page) => {
     const response = await injectWithoutSessionCookie('GET', page.uri)
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(CONTROLLER.uri)
+    expect(response.headers.location).toBe(`${CONTROLLER.uri}#`)
   })
 
   it(`returns 200 when attempting to access ${IDENTIFY.uri}`, async () => {
@@ -114,7 +114,7 @@ describe('The user', () => {
   it('redirects to /buy/renew/identify when attempting to access /renew/ABC123', async () => {
     const response = await injectWithoutSessionCookie('GET', '/renew/ABC123')
     expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe(IDENTIFY.uri)
+    expect(response.headers.location).toBe(`${IDENTIFY.uri}#`)
   })
 })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3673

This change fixes an accessibility issue in which the #main-content fragment, which was applied when a user selected the 'Skip to main content' link, was then applied to all subsequent pages in the journey. This is because the 302 redirects always preserved the existing fragment.

As other possible solutions like updating the action tag then broke the language param, we decided to fix this by making sure a blank fragment is applied on redirects to override #main-content.