### PR TITLE
Apply correct html lang to static pages also

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/__tests__/__snapshots__/page-handler.spec.js.snap
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/__snapshots__/page-handler.spec.js.snap
@@ -13,7 +13,7 @@ exports[`The page handler function sets the value of pageData with displayAnalyt
         "backRef": null,
         "displayAnalytics": false,
         "mssgs": undefined,
-        "pageLanguageSetToWelsh": false,
+        "pageLanguageSetToWelsh": undefined,
         "uri": Object {
           "analyticsFormAction": "/buy/process-analytics-preferences",
         },
@@ -42,7 +42,7 @@ exports[`The page handler function sets the value of pageData with displayAnalyt
         "backRef": null,
         "displayAnalytics": true,
         "mssgs": undefined,
-        "pageLanguageSetToWelsh": false,
+        "pageLanguageSetToWelsh": undefined,
         "uri": Object {
           "analyticsFormAction": "/buy/process-analytics-preferences",
         },

--- a/packages/gafl-webapp-service/src/handlers/__tests__/__snapshots__/page-handler.spec.js.snap
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/__snapshots__/page-handler.spec.js.snap
@@ -13,7 +13,7 @@ exports[`The page handler function sets the value of pageData with displayAnalyt
         "backRef": null,
         "displayAnalytics": false,
         "mssgs": undefined,
-        "pageLanguageSetToWelsh": undefined,
+        "pageLanguageSetToWelsh": false,
         "uri": Object {
           "analyticsFormAction": "/buy/process-analytics-preferences",
         },
@@ -42,7 +42,7 @@ exports[`The page handler function sets the value of pageData with displayAnalyt
         "backRef": null,
         "displayAnalytics": true,
         "mssgs": undefined,
-        "pageLanguageSetToWelsh": undefined,
+        "pageLanguageSetToWelsh": false,
         "uri": Object {
           "analyticsFormAction": "/buy/process-analytics-preferences",
         },

--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -140,6 +140,7 @@ describe('The page handler function', () => {
 
   it('sets the value of pageData with displayAnalytics true', async () => {
     addLanguageCodeToUri.mockReturnValueOnce('/buy/process-analytics-preferences')
+    welshEnabledAndApplied.mockReturnValueOnce(false)
     const { get } = pageHandler('', 'view', '/next/page')
     const toolkit = getMockToolkit()
     await get(getMockRequest(), toolkit)
@@ -148,6 +149,7 @@ describe('The page handler function', () => {
 
   it('sets the value of pageData with displayAnalytics false', async () => {
     addLanguageCodeToUri.mockReturnValueOnce('/buy/process-analytics-preferences')
+    welshEnabledAndApplied.mockReturnValueOnce(false)
     const { get } = pageHandler('', 'view', '/next/page')
     const toolkit = getMockToolkit()
     await get(getMockRequest({ path: '/we/are/here' }), toolkit)

--- a/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/page-handler.spec.js
@@ -1,12 +1,14 @@
 import pageHandler from '../page-handler.js'
 import journeyDefinition from '../../routes/journey-definition.js'
 import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
+import { welshEnabledAndApplied } from '../../processors/page-language-helper.js'
 import GetDataRedirect from '../get-data-redirect.js'
 import { ANALYTICS } from '../../constants.js'
 import { AGREED, IDENTIFY, LICENCE_DETAILS, LICENCE_FOR, ORDER_COMPLETE, PAYMENT_CANCELLED, PAYMENT_FAILED } from '../../uri.js'
 
 jest.mock('../../routes/journey-definition.js', () => [])
 jest.mock('../../processors/uri-helper.js')
+jest.mock('../../processors/page-language-helper.js')
 
 jest.mock('../../constants', () => ({
   ANALYTICS: {
@@ -243,8 +245,9 @@ describe('The page handler function', () => {
   })
 
   describe('pageLanguageSetToWelsh', () => {
-    it('returns false when SHOW_WELSH_CONTENT is not true', async () => {
-      process.env.SHOW_WELSH_CONTENT = false
+    it('returns the value of welshEnabledAndApplied', async () => {
+      const expectedValue = Symbol('expected')
+      welshEnabledAndApplied.mockReturnValueOnce(expectedValue)
       const { get } = pageHandler('', 'view', '/next/page')
       const toolkit = getMockToolkit()
 
@@ -253,39 +256,7 @@ describe('The page handler function', () => {
       expect(toolkit.view).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          pageLanguageSetToWelsh: false
-        })
-      )
-    })
-
-    it('returns false when SHOW_WELSH_CONTENT is true but the lang is not set to cy', async () => {
-      process.env.SHOW_WELSH_CONTENT = true
-      const { get } = pageHandler('', 'view', '/next/page')
-      const toolkit = getMockToolkit()
-
-      await get(getMockRequest(), toolkit)
-
-      expect(toolkit.view).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          pageLanguageSetToWelsh: false
-        })
-      )
-    })
-
-    it('returns true when SHOW_WELSH_CONTENT is true and the lang is set to cy', async () => {
-      process.env.SHOW_WELSH_CONTENT = true
-      const { get } = pageHandler('', 'view', '/next/page')
-      const query = { lang: 'cy' }
-      const request = getMockRequest({ query })
-      const toolkit = getMockToolkit()
-
-      await get(request, toolkit)
-
-      expect(toolkit.view).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          pageLanguageSetToWelsh: true
+          pageLanguageSetToWelsh: expectedValue
         })
       )
     })
@@ -298,7 +269,7 @@ const getAnalytics = overides => ({
   ...overides
 })
 
-const getMockRequest = ({ setCurrentPermission = () => {}, path = '/buy/we/are/here', query = {}, analytics, set = () => {} } = {}) => ({
+const getMockRequest = ({ setCurrentPermission = () => {}, path = '/buy/we/are/here', analytics, set = () => {} } = {}) => ({
   cache: () => ({
     helpers: {
       page: {
@@ -324,7 +295,6 @@ const getMockRequest = ({ setCurrentPermission = () => {}, path = '/buy/we/are/h
     getLocale: () => ''
   },
   path,
-  query,
   url: {
     search: ''
   }

--- a/packages/gafl-webapp-service/src/handlers/page-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/page-handler.js
@@ -14,6 +14,7 @@ import {
 import GetDataRedirect from './get-data-redirect.js'
 import journeyDefinition from '../routes/journey-definition.js'
 import { addLanguageCodeToUri } from '../processors/uri-helper.js'
+import { welshEnabledAndApplied } from '../processors/page-language-helper.js'
 
 const pagesToOmitAnalyticsBanner = [AGREED.uri, LICENCE_DETAILS.uri, ORDER_COMPLETE.uri, PAYMENT_CANCELLED.uri, PAYMENT_FAILED.uri]
 const pagesJourneyBeginning = [LICENCE_FOR.uri, IDENTIFY.uri]
@@ -38,11 +39,6 @@ const omitPageFromAnalytics = async request => {
   } else {
     await request.cache().helpers.analytics.set({ [ANALYTICS.omitPageFromAnalytics]: false })
   }
-}
-
-const pageLanguageSetToWelsh = request => {
-  const showWelshContent = process.env.SHOW_WELSH_CONTENT?.toLowerCase() === 'true'
-  return showWelshContent && request.query.lang === 'cy'
 }
 
 /**
@@ -128,7 +124,7 @@ export default (path, view, completion, getData) => ({
     pageData.altLang = request.i18n.getLocales().filter(locale => locale !== request.i18n.getLocale())
     pageData.backRef = await getBackReference(request, view)
     pageData.uri = { ...(pageData.uri || {}), analyticsFormAction: addLanguageCodeToUri(request, PROCESS_ANALYTICS_PREFERENCES.uri) }
-    pageData.pageLanguageSetToWelsh = pageLanguageSetToWelsh(request)
+    pageData.pageLanguageSetToWelsh = welshEnabledAndApplied(request)
 
     const analytics = await request.cache().helpers.analytics.get()
     pageData.analyticsMessageDisplayed = analytics ? analytics[ANALYTICS.seenMessage] : false

--- a/packages/gafl-webapp-service/src/pages/layout/layout.njk
+++ b/packages/gafl-webapp-service/src/pages/layout/layout.njk
@@ -42,7 +42,7 @@
                                     {{ mssgs.analytics_banner_preamble_1 }}
                                     </p>
                                     <p class="govuk-body">
-                                    {{ mssgs.analytics_banner_preamble_2 }} <a class="govuk-link" href="/guidance/cookies">{{ mssgs.cookie_banner_link }}</a>
+                                    {{ mssgs.analytics_banner_preamble_2 }} <a class="govuk-link" href="{{ _uri.cookies }}">{{ mssgs.cookie_banner_link }}</a>
                                     </p>
                                 </div>
                                 <div class="govuk-button-group">

--- a/packages/gafl-webapp-service/src/processors/__tests__/page-language-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/page-language-helper.spec.js
@@ -1,0 +1,29 @@
+import { welshEnabledAndApplied } from '../page-language-helper.js'
+
+describe('welshEnabledAndApplied', () => {
+  describe('welshEnabledAndApplied', () => {
+    it('returns false when SHOW_WELSH_CONTENT is not true', async () => {
+      process.env.SHOW_WELSH_CONTENT = false
+      const request = { query: { lang: 'cy' } }
+
+      const result = welshEnabledAndApplied(request)
+      expect(result).toEqual(false)
+    })
+
+    it('returns false when SHOW_WELSH_CONTENT is true but the lang is not set to cy', async () => {
+      process.env.SHOW_WELSH_CONTENT = true
+      const request = { query: { lang: 'en' } }
+
+      const result = welshEnabledAndApplied(request)
+      expect(result).toEqual(false)
+    })
+
+    it('returns true when SHOW_WELSH_CONTENT is true and the lang is set to cy', async () => {
+      process.env.SHOW_WELSH_CONTENT = true
+      const request = { query: { lang: 'cy' } }
+
+      const result = welshEnabledAndApplied(request)
+      expect(result).toEqual(true)
+    })
+  })
+})

--- a/packages/gafl-webapp-service/src/processors/__tests__/page-language-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/page-language-helper.spec.js
@@ -2,24 +2,14 @@ import { welshEnabledAndApplied } from '../page-language-helper.js'
 
 describe('welshEnabledAndApplied', () => {
   describe('welshEnabledAndApplied', () => {
-    it('returns false when SHOW_WELSH_CONTENT is not true', async () => {
-      process.env.SHOW_WELSH_CONTENT = false
-      const request = { query: { lang: 'cy' } }
-
-      const result = welshEnabledAndApplied(request)
-      expect(result).toEqual(false)
-    })
-
-    it('returns false when SHOW_WELSH_CONTENT is true but the lang is not set to cy', async () => {
-      process.env.SHOW_WELSH_CONTENT = true
+    it('returns false when the lang is not set to cy', async () => {
       const request = { query: { lang: 'en' } }
 
       const result = welshEnabledAndApplied(request)
       expect(result).toEqual(false)
     })
 
-    it('returns true when SHOW_WELSH_CONTENT is true and the lang is set to cy', async () => {
-      process.env.SHOW_WELSH_CONTENT = true
+    it('returns true when the lang is set to cy', async () => {
       const request = { query: { lang: 'cy' } }
 
       const result = welshEnabledAndApplied(request)

--- a/packages/gafl-webapp-service/src/processors/page-language-helper.js
+++ b/packages/gafl-webapp-service/src/processors/page-language-helper.js
@@ -1,4 +1,3 @@
 export const welshEnabledAndApplied = request => {
-  const showWelshContent = process.env.SHOW_WELSH_CONTENT?.toLowerCase() === 'true'
-  return showWelshContent && request.query.lang === 'cy'
+  return request.query.lang === 'cy'
 }

--- a/packages/gafl-webapp-service/src/processors/page-language-helper.js
+++ b/packages/gafl-webapp-service/src/processors/page-language-helper.js
@@ -1,0 +1,4 @@
+export const welshEnabledAndApplied = request => {
+  const showWelshContent = process.env.SHOW_WELSH_CONTENT?.toLowerCase() === 'true'
+  return showWelshContent && request.query.lang === 'cy'
+}

--- a/packages/gafl-webapp-service/src/processors/page-language-helper.js
+++ b/packages/gafl-webapp-service/src/processors/page-language-helper.js
@@ -1,3 +1,1 @@
-export const welshEnabledAndApplied = request => {
-  return request.query.lang === 'cy'
-}
+export const welshEnabledAndApplied = request => request.query.lang === 'cy'

--- a/packages/gafl-webapp-service/src/routes/__tests__/misc-routes-handlers.spec.js
+++ b/packages/gafl-webapp-service/src/routes/__tests__/misc-routes-handlers.spec.js
@@ -2,6 +2,7 @@ import uri from '../../uri.js'
 import miscRoutes from '../misc-routes.js'
 import constants from '../../constants.js'
 import { addLanguageCodeToUri } from '../../processors/uri-helper.js'
+import { welshEnabledAndApplied } from '../../processors/page-language-helper.js'
 
 jest.mock('../../uri.js', () => ({
   ...jest.requireActual('../../uri.js'),
@@ -20,6 +21,7 @@ jest.mock('../../constants.js', () => ({
 }))
 
 jest.mock('../../processors/uri-helper.js')
+jest.mock('../../processors/page-language-helper.js')
 
 describe('guidance page handlers', () => {
   const cookiesPageHandler = miscRoutes.find(r => r.path === uri.COOKIES.uri).handler
@@ -215,7 +217,8 @@ describe('guidance page handlers', () => {
     { pageHandler: accessibilityPageHandler, handlerName: 'Accessibility' },
     { pageHandler: privacyPolicyPageHandler, handlerName: 'Privacy policy' },
     { pageHandler: refundPolicyPageHandler, handlerName: 'Refund policy' },
-    { pageHandler: osTermsPageHandler, handlerName: 'OS Terms' }
+    { pageHandler: osTermsPageHandler, handlerName: 'OS Terms' },
+    { pageHandler: newPricesPageHandler, handlerName: 'New Prices Page Handler' }
   ])('language code tests for $handlerName page', ({ pageHandler }) => {
     it('uses addLanguageCodeToUri to get back url', async () => {
       const toolkit = getMockToolkit()
@@ -240,6 +243,22 @@ describe('guidance page handlers', () => {
           uri: expect.objectContaining({
             back: backUrl
           })
+        })
+      )
+    })
+
+    it('returns the value of welshEnabledAndApplied for pageLanguageSetToWelsh', async () => {
+      const toolkit = getMockToolkit()
+      const request = getMockRequest()
+      const expectedValue = Symbol('expected')
+      welshEnabledAndApplied.mockReturnValueOnce(expectedValue)
+
+      await pageHandler(request, toolkit)
+
+      expect(toolkit.view).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          pageLanguageSetToWelsh: expectedValue
         })
       )
     })

--- a/packages/gafl-webapp-service/src/routes/misc-routes.js
+++ b/packages/gafl-webapp-service/src/routes/misc-routes.js
@@ -99,8 +99,8 @@ export default [
 
       return h.view(COOKIES.page, {
         altLang,
-        mssgs: request.i18n.getCatalog(),
         pageLanguageSetToWelsh,
+        mssgs: request.i18n.getCatalog(),
         cookie: {
           csrf: process.env.CSRF_TOKEN_COOKIE_NAME || CSRF_TOKEN_COOKIE_NAME_DEFAULT,
           sess: process.env.SESSION_COOKIE_NAME || SESSION_COOKIE_NAME_DEFAULT,

--- a/packages/gafl-webapp-service/src/routes/misc-routes.js
+++ b/packages/gafl-webapp-service/src/routes/misc-routes.js
@@ -24,6 +24,7 @@ import controllerHandler from '../handlers/controller-handler.js'
 import authenticationHandler from '../handlers/authentication-handler.js'
 import { addLanguageCodeToUri } from '../processors/uri-helper.js'
 import analytics from '../handlers/analytics-handler.js'
+import { welshEnabledAndApplied } from '../processors/page-language-helper.js'
 
 const simpleView = view => ({
   method: 'GET',
@@ -31,9 +32,11 @@ const simpleView = view => ({
   handler: async (request, h) => {
     const mssgs = request.i18n.getCatalog()
     const altLang = request.i18n.getLocales().filter(locale => locale !== request.i18n.getLocale())
+    const pageLanguageSetToWelsh = welshEnabledAndApplied(request)
     return h.view(view.page, {
       mssgs,
       altLang,
+      pageLanguageSetToWelsh,
       uri: {
         back: addLanguageCodeToUri(request, CONTROLLER.uri)
       }
@@ -92,10 +95,12 @@ export default [
     path: COOKIES.uri,
     handler: async (request, h) => {
       const altLang = request.i18n.getLocales().filter(locale => locale !== request.i18n.getLocale())
+      const pageLanguageSetToWelsh = welshEnabledAndApplied(request)
 
       return h.view(COOKIES.page, {
         altLang,
         mssgs: request.i18n.getCatalog(),
+        pageLanguageSetToWelsh,
         cookie: {
           csrf: process.env.CSRF_TOKEN_COOKIE_NAME || CSRF_TOKEN_COOKIE_NAME_DEFAULT,
           sess: process.env.SESSION_COOKIE_NAME || SESSION_COOKIE_NAME_DEFAULT,
@@ -113,9 +118,11 @@ export default [
     path: NEW_PRICES.uri,
     handler: async (request, h) => {
       const altLang = request.i18n.getLocales().filter(locale => locale !== request.i18n.getLocale())
+      const pageLanguageSetToWelsh = welshEnabledAndApplied(request)
 
       return h.view(NEW_PRICES.page, {
         altLang,
+        pageLanguageSetToWelsh,
         mssgs: request.i18n.getCatalog(),
         uri: {
           back: addLanguageCodeToUri(request, CONTROLLER.uri)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3674

This change makes sure we also apply the correct html lang tag to pages that don't use the pageHandler, like the privacy policy.