### PR TITLE
Add necessary domains for GA4 to Content Policy

### DIFF
--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -56,7 +56,7 @@ const initialiseBlankiePlugin = () => ({
      * It must allow web-fonts from 'fonts.gstatic.com'
      */
     fontSrc: ['self', 'fonts.gstatic.com', 'data:'],
-    scriptSrc: ['self', 'unsafe-inline', scriptHash, 'www.googletagmanager.com'],
+    scriptSrc: ['self', 'unsafe-inline', scriptHash, 'www.googletagmanager.com', '*.google-analytics.com'],
     generateNonces: true,
     frameAncestors: 'none'
   }

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -56,7 +56,8 @@ const initialiseBlankiePlugin = () => ({
      * It must allow web-fonts from 'fonts.gstatic.com'
      */
     fontSrc: ['self', 'fonts.gstatic.com', 'data:'],
-    scriptSrc: ['self', 'unsafe-inline', scriptHash, 'www.googletagmanager.com', '*.google-analytics.com'],
+    scriptSrc: ['self', 'unsafe-inline', scriptHash, 'www.googletagmanager.com'],
+    connectSrc: ['self', '*.google-analytics.com'],
     generateNonces: true,
     frameAncestors: 'none'
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3865

Add region1.google-analytics.com domain, plus any others that're necessary, to the Content Policy