### PR TITLE
Pricing summary duplicate id

### DIFF
--- a/packages/gafl-webapp-service/src/pages/macros/pricing-summary.njk
+++ b/packages/gafl-webapp-service/src/pages/macros/pricing-summary.njk
@@ -7,7 +7,7 @@
         <dl>
             {% for k, v in load %}
                 {% if content[k].desc %}
-                    <div class="govuk-body pricing-summary-element-cost">
+                    <div class="govuk-body pricing-summary-element-cost {{content[k].desc}}">
                         <dt>
                             <span>{{content[k].desc}}</span>
                         </dt>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3681

On the ‘Which type of licence do you want?’ page, every price element in pricing summary  has the same ID of ‘pricing-summary-element-cost’.