### PR TITLE
Permit cost increase

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
@@ -121,8 +121,8 @@ describe('preparePayment', () => {
     })
 
     it('when there are multiple permissions', () => {
-      const additionalPermission = [{ licensee: { firstName: 'Test' } }]
-      const transaction = createTransaction({ additionalPermission })
+      const additionalPermissions = [{ licensee: { firstName: 'Test' } }]
+      const transaction = createTransaction({ additionalPermissions })
       const result = preparePayment(createRequest(), transaction)
       expect(result.description).toBe('Multiple permits')
     })

--- a/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/payment.spec.js
@@ -17,9 +17,9 @@ const createRequest = (opts = {}, catalog = {}) => ({
   server: { info: { protocol: opts.protocol || '' } }
 })
 
-const createTransaction = (isLicenceForYou = true, additionalPermissions = [], licenseeOverrides) => ({
+const createTransaction = ({ isLicenceForYou = true, additionalPermissions = [], cost = 12, licenseeOverrides = {} } = {}) => ({
   id: 'transaction-id',
-  cost: 12,
+  cost,
   permissions: [
     {
       licensee: {
@@ -68,9 +68,13 @@ describe('preparePayment', () => {
     })
   })
 
-  it('provides the correct transaction amount', () => {
-    const result = preparePayment(createRequest(), createTransaction())
-    expect(result.amount).toBe(1200)
+  it.each`
+    transaction                          | expectedAmount
+    ${createTransaction()}               | ${1200}
+    ${createTransaction({ cost: 35.8 })} | ${3580}
+  `('provides the correct transaction amount of $expectedAmount when cost is $transaction.cost', ({ transaction, expectedAmount }) => {
+    const result = preparePayment(createRequest(), transaction)
+    expect(result.amount).toBe(expectedAmount)
   })
 
   it('provides the correct reference', () => {
@@ -117,8 +121,8 @@ describe('preparePayment', () => {
     })
 
     it('when there are multiple permissions', () => {
-      const additionalPermission = { licensee: { firstName: 'Test' } }
-      const transaction = createTransaction(true, [additionalPermission])
+      const additionalPermission = [{ licensee: { firstName: 'Test' } }]
+      const transaction = createTransaction({ additionalPermission })
       const result = preparePayment(createRequest(), transaction)
       expect(result.description).toBe('Multiple permits')
     })
@@ -143,7 +147,7 @@ describe('preparePayment', () => {
       })
 
       it('line1 does not include street name if not provided', () => {
-        const transaction = createTransaction(true, [], { street: null })
+        const transaction = createTransaction({ licenseeOverrides: { street: null } })
         const licensee = transaction.permissions[0].licensee
         const result = preparePayment(createRequest(), transaction)
 
@@ -182,7 +186,7 @@ describe('preparePayment', () => {
       })
 
       it('line2 is undefined if locality is not present', () => {
-        const transaction = createTransaction(true, [], { locality: null })
+        const transaction = createTransaction({ licenseeOverrides: { locality: null } })
         const result = preparePayment(createRequest(), transaction)
 
         expect(result.prefilled_cardholder_details.billing_address.line2).toBe(undefined)
@@ -192,13 +196,13 @@ describe('preparePayment', () => {
 
   describe('if there is only 1 permission and the user is buying on behalf of another, does not provide licensee info', () => {
     it('does not provide the prefilled_cardholder_details', () => {
-      const boboTransaction = createTransaction(false)
+      const boboTransaction = createTransaction({ isLicenceForYou: false })
       const result = preparePayment(createRequest(), boboTransaction)
       expect(result.prefilled_cardholder_details).toBe(undefined)
     })
 
     it('does not provide the email', () => {
-      const boboTransaction = createTransaction(false)
+      const boboTransaction = createTransaction({ isLicenceForYou: false })
       const result = preparePayment(createRequest(), boboTransaction)
       expect(result.email).toBe(undefined)
     })

--- a/packages/gafl-webapp-service/src/processors/payment.js
+++ b/packages/gafl-webapp-service/src/processors/payment.js
@@ -23,7 +23,7 @@ export const preparePayment = (request, transaction) => {
 
   const result = {
     return_url: url.href,
-    amount: transaction.cost * 100,
+    amount: Math.round(transaction.cost * 100),
     reference: transaction.id,
     description:
       transaction.permissions.length === 1


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3434

Mop-up ticket for various issues with applying the cost increase:
- incorrect price displayed on licence type page for licenses starting in 30 minutes that cross the price increase threashold
- incorrect price sent to GovPay