### PR TITLE
Fix wrong price in CRM

### DIFF
--- a/packages/business-rules-lib/src/util/permissions.js
+++ b/packages/business-rules-lib/src/util/permissions.js
@@ -1,4 +1,4 @@
-import { START_AFTER_PAYMENT_MINUTES } from '../constants'
+import { START_AFTER_PAYMENT_MINUTES } from '../constants.js'
 
 const getPermissionStartDate = () => {
   const startDate = new Date()

--- a/packages/business-rules-lib/src/util/permissions.js
+++ b/packages/business-rules-lib/src/util/permissions.js
@@ -1,5 +1,13 @@
+import { START_AFTER_PAYMENT_MINUTES } from '../constants'
+
+const getPermissionStartDate = () => {
+  const startDate = new Date()
+  startDate.setMinutes(startDate.getMinutes() + START_AFTER_PAYMENT_MINUTES)
+  return startDate.toISOString()
+}
+
 export const getPermissionCost = (permission, createdDate) => {
-  const permissionStartDate = createdDate || permission.startDate || new Date().toISOString()
+  const permissionStartDate = createdDate || permission.startDate || getPermissionStartDate()
   if (Date.parse(permissionStartDate) >= Date.parse(permission.permit.newCostStartDate)) {
     return permission.permit.newCost
   }

--- a/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
@@ -187,6 +187,8 @@ describe('transaction service', () => {
       mockRecord.permissions[0].isLicenceForYou = true
       AwsMock.DynamoDB.DocumentClient.__setResponse('get', { Item: mockRecord })
       await processQueue({ id: mockRecord.id })
+
+      // assert
       const persistMockFirstAgument = persist.mock.calls[0]
       expect(persistMockFirstAgument[0][4].isLicenceForYou).toBeDefined()
       expect(persistMockFirstAgument[0][4]).toMatchObject({ isLicenceForYou: { id: 1, label: 'Yes', description: 'Yes' } })
@@ -245,7 +247,7 @@ describe('transaction service', () => {
       }
     })
 
-    describe.each([20, 38.46, 287])('uses provisional transaction for final transaction value - £%d', cost => {
+    describe.each([20, 38.46, 287])('the provisional transaction amount of £%d is used for final transaction amount', cost => {
       const setup = async () => {
         const mockRecord = mockFinalisedTransactionRecord()
         mockRecord.payment.amount = cost

--- a/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
@@ -24,8 +24,7 @@ import {
 } from '../../../__mocks__/test-data.js'
 import { TRANSACTION_STAGING_TABLE, TRANSACTION_STAGING_HISTORY_TABLE } from '../../../config.js'
 import AwsMock from 'aws-sdk'
-import { POCL_DATA_SOURCE, DDE_DATA_SOURCE, getPermissionCost } from '@defra-fish/business-rules-lib'
-import { getReferenceDataForEntityAndId } from '../../reference-data.service.js'
+import { POCL_DATA_SOURCE, DDE_DATA_SOURCE } from '@defra-fish/business-rules-lib'
 
 jest.mock('../../reference-data.service.js', () => ({
   ...jest.requireActual('../../reference-data.service.js'),
@@ -61,8 +60,7 @@ jest.mock('@defra-fish/business-rules-lib', () => ({
   POCL_DATA_SOURCE: 'POCL_DATA_SOURCE',
   DDE_DATA_SOURCE: 'DDE_DATA_SOURCE',
   POCL_TRANSACTION_SOURCES: ['POCL_DATA_SOURCE', 'DDE_DATA_SOURCE'],
-  START_AFTER_PAYMENT_MINUTES: 30,
-  getPermissionCost: jest.fn(() => 1)
+  START_AFTER_PAYMENT_MINUTES: 30
 }))
 
 describe('transaction service', () => {
@@ -247,10 +245,10 @@ describe('transaction service', () => {
       }
     })
 
-    describe.each([20, 38.46, 287])('uses getPermissionCost (%d) value ', cost => {
+    describe.each([20, 38.46, 287])('uses provisional transaction for final transaction value - £%d', cost => {
       const setup = async () => {
-        getPermissionCost.mockReturnValueOnce(cost)
         const mockRecord = mockFinalisedTransactionRecord()
+        mockRecord.payment.amount = cost
         AwsMock.DynamoDB.DocumentClient.__setResponse('get', { Item: mockRecord })
         await processQueue({ id: mockRecord.id })
         const {
@@ -276,22 +274,6 @@ describe('transaction service', () => {
         expect(paymentJournal.total).toBe(cost)
       })
     })
-  })
-
-  it('passes start date and permit to getPermissionCost', async () => {
-    const mockRecord = mockFinalisedTransactionRecord()
-    const {
-      permissions: [permission]
-    } = mockRecord
-    getReferenceDataForEntityAndId.mockReturnValueOnce(MOCK_12MONTH_SENIOR_PERMIT)
-    AwsMock.DynamoDB.DocumentClient.__setResponse('get', { Item: mockRecord })
-    await processQueue({ id: mockRecord.id })
-    expect(getPermissionCost).toHaveBeenCalledWith(
-      expect.objectContaining({
-        startDate: permission.startDate,
-        permit: MOCK_12MONTH_SENIOR_PERMIT
-      })
-    )
   })
 
   describe('.getTransactionJournalRefNumber', () => {

--- a/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
+++ b/packages/sales-api-service/src/services/transactions/__tests__/process-transaction-queue.spec.js
@@ -187,8 +187,6 @@ describe('transaction service', () => {
       mockRecord.permissions[0].isLicenceForYou = true
       AwsMock.DynamoDB.DocumentClient.__setResponse('get', { Item: mockRecord })
       await processQueue({ id: mockRecord.id })
-
-      // assert
       const persistMockFirstAgument = persist.mock.calls[0]
       expect(persistMockFirstAgument[0][4].isLicenceForYou).toBeDefined()
       expect(persistMockFirstAgument[0][4]).toMatchObject({ isLicenceForYou: { id: 1, label: 'Yes', description: 'Yes' } })

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -11,7 +11,7 @@ import {
   RecurringPayment,
   RecurringPaymentInstruction
 } from '@defra-fish/dynamics-lib'
-import { DDE_DATA_SOURCE, getPermissionCost, POCL_TRANSACTION_SOURCES } from '@defra-fish/business-rules-lib'
+import { DDE_DATA_SOURCE, POCL_TRANSACTION_SOURCES } from '@defra-fish/business-rules-lib'
 import { getReferenceDataForEntityAndId, getGlobalOptionSetValue, getReferenceDataForEntity } from '../reference-data.service.js'
 import { resolveContactPayload } from '../contacts.service.js'
 import { retrieveStagedTransaction } from './retrieve-transaction.js'
@@ -41,7 +41,7 @@ export async function processQueue ({ id }) {
   const { recurringPayment, payer } = await processRecurringPayment(transactionRecord)
   recurringPayment && entities.push(recurringPayment, payer)
 
-  let totalTransactionValue = 0.0
+  const totalTransactionValue = transactionRecord.payment.amount
   const dataSource = await getGlobalOptionSetValue(Permission.definition.mappings.dataSource.ref, transactionRecord.dataSource)
   for (const {
     licensee,
@@ -67,11 +67,6 @@ export async function processQueue ({ id }) {
       isLicenceForYou,
       isRenewal
     )
-
-    totalTransactionValue += getPermissionCost({
-      startDate,
-      permit
-    })
 
     permission.bindToEntity(Permission.definition.relationships.licensee, contact)
     permission.bindToEntity(Permission.definition.relationships.permit, permit)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3932

Fix the problem where, when buying a twelve month licence to start in 30 minutes, where the price hasn’t yet gone up but will have done by the time the licence starts, the current (lower) price is quoted and charged, but the higher price is recorded in the CRM.