### PR TITLE
Jest tests run twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,9 +96,6 @@
         "statements": 90
       }
     },
-    "projects": [
-      "<rootDir>/packages/*"
-    ],
     "setupFilesAfterEnv": [
       "./packages/gafl-webapp-service/gafl-jest-matchers.js"
     ],

--- a/packages/gafl-webapp-service/src/pages/contact/address/select/__tests__/address-select.spec.js
+++ b/packages/gafl-webapp-service/src/pages/contact/address/select/__tests__/address-select.spec.js
@@ -30,7 +30,7 @@ beforeAll(() => new Promise(resolve => initialize(resolve)))
 afterAll(d => stop(d))
 
 jest.mock('node-fetch')
-const fetch = require('node-fetch')
+const fetch = require('node-fetch').default
 
 describe('The address select page', () => {
   it('returns success on requesting', async () => {


### PR DESCRIPTION
Jest tests are all running twice, which is causing tests to run for longer than necessary and some old tests to fail as setup / teardown isn't done in an idempotent way