### PR TITLE
Check if the fulfilment switchover date has passed when processing transactions

### DIFF
--- a/packages/business-rules-lib/src/constants.js
+++ b/packages/business-rules-lib/src/constants.js
@@ -63,3 +63,8 @@ export const START_AFTER_PAYMENT_MINUTES = 30
  * Timezone of the service
  */
 export const SERVICE_LOCAL_TIME = 'Europe/London'
+
+/**
+ * Date for switching paper fulfilment provider
+ */
+export const FULFILMENT_SWITCHOVER_DATE = '2024-05-30T23:00:00.000Z'

--- a/packages/sales-api-service/src/__mocks__/test-data.js
+++ b/packages/sales-api-service/src/__mocks__/test-data.js
@@ -26,8 +26,8 @@ const testExecutionTime = moment()
 export const MOCK_PERMISSION_NUMBER = '11100420-2WT1SFT-KPMW2C'
 export const MOCK_OBFUSCATED_DOB = '87200001013460'
 export const MOCK_START_DATE = testExecutionTime.toISOString()
-export const MOCK_END_DATE = testExecutionTime.add(1, 'year').toISOString()
 export const MOCK_ISSUE_DATE = testExecutionTime.toISOString()
+export const MOCK_END_DATE = testExecutionTime.add(1, 'year').toISOString()
 
 export const mockContactPayload = () => ({
   firstName: 'Fester',

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -11,7 +11,7 @@ import {
   RecurringPayment,
   RecurringPaymentInstruction
 } from '@defra-fish/dynamics-lib'
-import { DDE_DATA_SOURCE, POCL_TRANSACTION_SOURCES } from '@defra-fish/business-rules-lib'
+import { DDE_DATA_SOURCE, FULFILMENT_SWITCHOVER_DATE, POCL_TRANSACTION_SOURCES } from '@defra-fish/business-rules-lib'
 import { getReferenceDataForEntityAndId, getGlobalOptionSetValue, getReferenceDataForEntity } from '../reference-data.service.js'
 import { resolveContactPayload } from '../contacts.service.js'
 import { retrieveStagedTransaction } from './retrieve-transaction.js'
@@ -88,7 +88,7 @@ export async function processQueue ({ id }) {
       entities.push(await createConcessionProof(concession, permission))
     }
 
-    if (permit.isForFulfilment && contact.postalFulfilment) {
+    if (shouldCreateFulfilmentRequest(permission, permit, contact)) {
       entities.push(await createFulfilmentRequest(permission))
     }
   }
@@ -108,6 +108,11 @@ export async function processQueue ({ id }) {
       ConditionExpression: 'attribute_not_exists(id)'
     })
     .promise()
+}
+
+const shouldCreateFulfilmentRequest = (permission, permit, contact) => {
+  const switchoverDate = new Date(process.env.FULFILMENT_SWITCHOVER_DATE || FULFILMENT_SWITCHOVER_DATE)
+  return permit.isForFulfilment && contact.postalFulfilment && moment(permission.issueDate).isBefore(switchoverDate)
 }
 
 const mapToPermission = async (


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3834

We don't want to create new FulfilmentRequest objects in the CRM once the switchover date has passed. This PR adds the date and also updates our transaction queue logic to factor that date in when creating entities.