### PR TITLE
Update govuk-frontend to v5 for new crown

### DIFF
--- a/packages/gafl-webapp-service/assets/sass/main.scss
+++ b/packages/gafl-webapp-service/assets/sass/main.scss
@@ -3,7 +3,7 @@ $govuk-assets-path: '/public/';
 $govuk-images-path: '#{$govuk-assets-path}images/';
 $govuk-fonts-path: '#{$govuk-assets-path}fonts/';
 
-@import '../node_modules/govuk-frontend/govuk/all';
+@import '../node_modules/govuk-frontend/dist/govuk/all';
 @import '../assets/sass/rod-licensing/general';
 @import '../node_modules/flatpickr/dist/flatpickr';
 @import '../assets/sass/rod-licensing/address';

--- a/packages/gafl-webapp-service/build/gulpfile.cjs
+++ b/packages/gafl-webapp-service/build/gulpfile.cjs
@@ -17,7 +17,7 @@ const concat = require('gulp-concat')
 const paths = {
   assets: path.join('..', 'assets/'),
   public: path.join('..', 'public/'),
-  govUk: path.join('..', 'node_modules', 'govuk-frontend', 'govuk/'),
+  govUk: path.join('..', 'node_modules', 'govuk-frontend', 'dist', 'govuk/'),
   flatpickr: path.join('..', 'node_modules/flatpickr/dist/')
 }
 
@@ -43,10 +43,17 @@ const copyRobots = () => {
   return gulp.src(`${paths.assets}robots.txt`).pipe(gulp.dest(paths.public))
 }
 
-const copyJs = () => {
+const copyFrontendJs = () => {
   return gulp
-    .src([`${paths.govUk}all.js`, `${paths.flatpickr}flatpickr.js`])
-    .pipe(concat('all.js'))
+    .src(`${paths.govUk}govuk-frontend.min.js`)
+    .pipe(concat('govuk-frontend.js'))
+    .pipe(minify({ noSource: true }))
+    .pipe(gulp.dest(`${paths.public}javascript`))
+}
+
+const copyFlatpickrJs = () => {
+  return gulp
+    .src(`${paths.flatpickr}flatpickr.js`)
     .pipe(minify({ noSource: true }))
     .pipe(gulp.dest(`${paths.public}javascript`))
 }
@@ -67,4 +74,4 @@ const buildSass = () => {
 }
 
 // The default Gulp task builds the resources
-gulp.task('default', gulp.series(clean, copyAssets, copyJs, copyRobots, buildSass))
+gulp.task('default', gulp.series(clean, copyAssets, copyFrontendJs, copyFlatpickrJs, copyRobots, buildSass))

--- a/packages/gafl-webapp-service/package-lock.json
+++ b/packages/gafl-webapp-service/package-lock.json
@@ -9,8 +9,6 @@
       "version": "1.40.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/business-rules-lib": "1.40.0",
-        "@defra-fish/connectors-lib": "1.40.0",
         "@defra/hapi-gapi": "^2.0.0",
         "@hapi/boom": "^9.1.2",
         "@hapi/catbox-redis": "^6.0.2",
@@ -26,7 +24,7 @@
         "disinfect": "^1.1.0",
         "find": "^0.3.0",
         "flatpickr": "^4.6.9",
-        "govuk-frontend": "^4.0.1",
+        "govuk-frontend": "^5.1.0",
         "hapi-i18n": "^3.0.1",
         "joi": "^17.6.0",
         "moment": "^2.29.1",
@@ -3272,9 +3270,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.1.0.tgz",
+      "integrity": "sha512-Dc3J+uOI4i2VR3BVyfxbf6qVjTT4n4bBqbD0/Io6feP8pt/4IfKdP1vWimZf+BwMKKMXacw10hmdy5UcD6Cr8w==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/packages/gafl-webapp-service/package.json
+++ b/packages/gafl-webapp-service/package.json
@@ -53,7 +53,7 @@
     "disinfect": "^1.1.0",
     "find": "^0.3.0",
     "flatpickr": "^4.6.9",
-    "govuk-frontend": "^4.0.1",
+    "govuk-frontend": "^5.1.0",
     "hapi-i18n": "^3.0.1",
     "joi": "^17.6.0",
     "moment": "^2.29.1",

--- a/packages/gafl-webapp-service/src/pages/contact/contact/contact.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/contact/contact.njk
@@ -159,8 +159,11 @@
 {% endblock %}
 
 {% block bodyEnd %}
-    <script src="/public/javascript/all-min.js"></script>
-    <script nonce={{nonce}}>window.GOVUKFrontend.initAll()</script>
+    <script type="module" src="/public/javascript/govuk-frontend-min.js"></script>
+    <script nonce="{{nonce}}" type="module">
+        import { initAll } from '/public/javascript/govuk-frontend-min.js'
+        initAll()
+    </script>
     <script nonce={{nonce}}>(function () {
         if ('{{ data.mobileConfirmation }}' === true && !'{{ error.email }}') {
             document.getElementById("email-ro").style.display = "none"
@@ -174,4 +177,3 @@
         }
     })()</script>
 {% endblock %}
-

--- a/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/licence-confirmation-method.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/digital-licence/licence-confirmation-method/licence-confirmation-method.njk
@@ -127,8 +127,11 @@
 {% endblock %}
 
 {% block bodyEnd %}
-    <script src="/public/javascript/all-min.js"></script>
-    <script nonce={{nonce}}>window.GOVUKFrontend.initAll()</script>
+    <script type="module" src="/public/javascript/govuk-frontend-min.js"></script>
+    <script nonce="{{nonce}}" type="module">
+        import { initAll } from '/public/javascript/govuk-frontend-min.js'
+        initAll()
+    </script>
     <script nonce={{nonce}}>(function () {
         if ('{{ data.licensee.email }}' && !'{{ data.changeEmail }}' && !'{{ error.email }}' ) {
             document.getElementById("email-ro").style.display = "block"

--- a/packages/gafl-webapp-service/src/pages/layout/layout.njk
+++ b/packages/gafl-webapp-service/src/pages/layout/layout.njk
@@ -119,7 +119,8 @@
         serviceUrl: "/",
         classes: "no-print",
         containerClasses: "govuk-width-container",
-        serviceName: mssgs.header_service_name if not TELESALES else "Get a rod fishing licence (TELESALES)"
+        serviceName: mssgs.header_service_name if not TELESALES else "Get a rod fishing licence (TELESALES)",
+        useTudorCrown: true
     }) }}
 {% endblock %}
 
@@ -226,6 +227,9 @@
 {% endblock %}
 
 {% block bodyEnd %}
-    <script src="/public/javascript/all-min.js"></script>
-    <script nonce="{{nonce}}">window.GOVUKFrontend.initAll()</script>
+    <script type="module" src="/public/javascript/govuk-frontend-min.js"></script>
+    <script nonce="{{nonce}}" type="module">
+        import { initAll } from '/public/javascript/govuk-frontend-min.js'
+        initAll()
+    </script>
 {% endblock %}

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-length/licence-length.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-length/licence-length.njk
@@ -62,7 +62,10 @@
 {% endblock %}
 
 {% block bodyEnd %}
-    <script src="/public/javascript/all-min.js"></script>
-    <script nonce={{nonce}}>window.GOVUKFrontend.initAll()</script>
+    <script type="module" src="/public/javascript/govuk-frontend-min.js"></script>
+    <script nonce="{{nonce}}" type="module">
+        import { initAll } from '/public/javascript/govuk-frontend-min.js'
+        initAll()
+    </script>
     {{ pricingSummaryScript(data.pricing.byLength, nonce) }}
 {% endblock %}

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
@@ -85,9 +85,13 @@
 {% endblock %}
 
 {% block bodyEnd %}
-    <script src="/public/javascript/all-min.js"></script>
-    <script nonce={{nonce}}>window.GOVUKFrontend.initAll()</script>
-    <script nonce={{nonce}}>(function () {
+    <script type="module" src="/public/javascript/govuk-frontend-min.js"></script>
+    <script nonce="{{nonce}}" type="module">
+        import { initAll } from '/public/javascript/govuk-frontend-min.js'
+        initAll()
+    </script>
+    <script src="/public/javascript/flatpickr-min.js"></script>
+    <script nonce="{{nonce}}">(function () {
         const dataInputDiv = document.getElementById('licence-start-date')
         const calImageDiv = document.createElement('div')
         calImageDiv.id = 'cal-image-div'

--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-type/licence-type.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-type/licence-type.njk
@@ -15,8 +15,8 @@
 
 {% set troutAndCoarse2Rod %}
     <p class="govuk-body-m">
-        {{ mssgs.licence_type_troute_two_rod }} 
-        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">{{ mssgs.licence_type_rules }}</a>{{ mssgs.and }}<a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{{ data.uri.localByelaws }}">{{ mssgs.licence_type_byelaws }}</a>{{ mssgs.period }}   
+        {{ mssgs.licence_type_troute_two_rod }}
+        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{{ data.uri.freshWaterFishingRules }}">{{ mssgs.licence_type_rules }}</a>{{ mssgs.and }}<a class="govuk-link" rel="noreferrer noopener" target="_blank" href="{{ data.uri.localByelaws }}">{{ mssgs.licence_type_byelaws }}</a>{{ mssgs.period }}
      </p>
 {% endset -%}
 
@@ -35,7 +35,7 @@
       classes: "govuk-!-margin-top-6"
     }) }}
     <p class="govuk-body-m">
-        {{ mssgs.licence_type_salmon_acr_note_1 }}<a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/catch-return">{{ mssgs.licence_type_salmon_acr_note_2 }}</a> 
+        {{ mssgs.licence_type_salmon_acr_note_1 }}<a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/catch-return">{{ mssgs.licence_type_salmon_acr_note_2 }}</a>
         {{ mssgs.licence_type_salmon_acr_note_3 }}</p>
 {% endset -%}
 
@@ -87,7 +87,10 @@
 {% endblock %}
 
 {% block bodyEnd %}
-    <script src="/public/javascript/all-min.js"></script>
-    <script nonce={{nonce}}>window.GOVUKFrontend.initAll()</script>
+    <script type="module" src="/public/javascript/govuk-frontend-min.js"></script>
+    <script nonce="{{nonce}}" type="module">
+        import { initAll } from '/public/javascript/govuk-frontend-min.js'
+        initAll()
+    </script>
     {{ pricingSummaryScript(data.pricing.byType, nonce) }}
 {% endblock %}

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -154,8 +154,11 @@
 {% endblock %}
 
 {% block bodyEnd %}
-    <script src="/public/javascript/all-min.js"></script>
-    <script nonce={{nonce}}>window.GOVUKFrontend.initAll()</script>
+    <script type="module" src="/public/javascript/govuk-frontend-min.js"></script>
+    <script nonce="{{nonce}}" type="module">
+        import { initAll } from '/public/javascript/govuk-frontend-min.js'
+        initAll()
+    </script>
     <script nonce={{nonce}}>(function () {
         if ({{ true if data.referenceNumber else false }} && !'{{ error.referenceNumber }}') {
             document.getElementById("ref-ro").style.display = "block"

--- a/packages/gafl-webapp-service/src/plugins.js
+++ b/packages/gafl-webapp-service/src/plugins.js
@@ -16,9 +16,10 @@ import path from 'path'
 
 const debug = db('webapp:plugin')
 
-// This is a hash of the inline script at line 31 of the GDS template. It is added to the CSP to except the in-line
-// script. It needs the quotes.
-const scriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
+// This is a hash provided by the GOV.UK Frontend:
+// https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#use-a-hash-to-unblock-inline-javascript
+// It is added to the CSP to except the in-line script. It needs the quotes.
+const scriptHash = "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='"
 
 const trackAnalytics = async request => {
   const pageOmit = await pageOmitted(request)

--- a/packages/gafl-webapp-service/src/server.js
+++ b/packages/gafl-webapp-service/src/server.js
@@ -140,8 +140,8 @@ const init = async () => {
 
     // This needs all absolute paths to work with jest and in normal operation
     path: [
-      path.join(Dirname, 'node_modules', 'govuk-frontend', 'govuk'),
-      path.join(Dirname, 'node_modules', 'govuk-frontend', 'govuk', 'components'),
+      path.join(Dirname, 'node_modules', 'govuk-frontend', 'dist', 'govuk'),
+      path.join(Dirname, 'node_modules', 'govuk-frontend', 'dist', 'govuk', 'components'),
       path.join(Dirname, 'src/pages/layout'),
       path.join(Dirname, 'src/pages/macros'),
       ...viewPaths


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3970

Notable changes here:

- The govuk-frontend package has added a `dist` dir which has to be included in paths
- Script tags in the layout template now must call the frontend JS as a module. This clashes with Flatpickr (our calendar date picker tool) which we were previously concatinating into a single minified JS file but isn't set up with exports etc to work in the same way. For that reason I've split them into two different files. This also means we aren't including the Flatpickr JS on every page, just the one we need
- There are a few other bits of JS on various pages but none of them were trying to use the minified file so wasn't an issue