### PR TITLE
Improving usability to page title to meet WGAC 2.1 criteria

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -271,6 +271,7 @@
   "free": "Am ddim",
   "gov_uk": " - GOV.UK",
   "header_service_name": "Trwydded bysgota â gwialen",
+  "header_service_name_title": " - Trwydded bysgota â gwialen",
   "identification": "Rhif adnabod",
   "identify_body_protect_info": "Er mwyn dod o hyd i fanylion eich trwydded, bydd angen i ni wybod pwy ydych chi. Mae hyn yn ein helpu i ddiogelu eich gwybodaeth bersonol.",
   "identify_error_empty_postcode": "Nid ydych wedi nodi cod post",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -270,6 +270,7 @@
   "free": "free",
   "gov_uk": " - GOV.UK",
   "header_service_name": "Get a rod fishing licence",
+  "header_service_name_title": " - Get a rod fishing licence",  
   "identification": "Identification",
   "identify_body_protect_info": "To find your licence details we first need to identify you. This helps us protect your personal information.",
   "identify_error_empty_postcode": "You did not enter a postcode",

--- a/packages/gafl-webapp-service/src/pages/macros/standard-form.njk
+++ b/packages/gafl-webapp-service/src/pages/macros/standard-form.njk
@@ -4,7 +4,7 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "error-summary.njk" import errorSummary %}
 
-{% block pageTitle %}{{ title }}{{ mssgs.header_service_name_title }}{{ mssgs.gov_uk }}{% endblock %}
+{% block pageTitle %}{{ title }}{{mssgs.header_service_name_title}}{{ mssgs.gov_uk }}{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">

--- a/packages/gafl-webapp-service/src/pages/macros/standard-form.njk
+++ b/packages/gafl-webapp-service/src/pages/macros/standard-form.njk
@@ -4,7 +4,7 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "error-summary.njk" import errorSummary %}
 
-{% block pageTitle %}{{ title }}{{mssgs.header_service_name_title}}{{ mssgs.gov_uk }}{% endblock %}
+{% block pageTitle %}{{ title }}{{ mssgs.header_service_name_title }}{{ mssgs.gov_uk }}{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">

--- a/packages/gafl-webapp-service/src/pages/macros/standard-form.njk
+++ b/packages/gafl-webapp-service/src/pages/macros/standard-form.njk
@@ -4,7 +4,7 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "error-summary.njk" import errorSummary %}
 
-{% block pageTitle %}{{ title }}{{ mssgs.gov_uk }}{% endblock %}
+{% block pageTitle %}{{ title }}{{ mssgs.header_service_name_title }}{{ mssgs.gov_uk }}{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3824
 
A recent accessibility assessment identified a number of issues. This ticket is to make the Page titles meet the criteria of the WCAG 2.1 criteria. The issue and suggested solution is detailed on page 91-93 of the DAC Assessment.
 
This issue affects all users, but in particular, screen reader users who are dependant on having unique and accurate page titles to orient themselves within the
 service.