### PR TITLE
Pause telesales call recording during payments

### DIFF
--- a/packages/gafl-webapp-service/package-lock.json
+++ b/packages/gafl-webapp-service/package-lock.json
@@ -9,8 +9,6 @@
       "version": "1.43.0-rc.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/business-rules-lib": "1.43.0-rc.2",
-        "@defra-fish/connectors-lib": "1.43.0-rc.2",
         "@defra/hapi-gapi": "^2.0.0",
         "@hapi/boom": "^9.1.2",
         "@hapi/catbox-redis": "^6.0.2",
@@ -24,6 +22,7 @@
         "blankie": "^5.0.0",
         "debug": "^4.3.3",
         "disinfect": "^1.1.0",
+        "easy-soap-request": "^5.6.1",
         "find": "^0.3.0",
         "flatpickr": "^4.6.9",
         "govuk-frontend": "^5.1.0",
@@ -1171,9 +1170,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
@@ -2133,6 +2132,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/easy-soap-request": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/easy-soap-request/-/easy-soap-request-5.6.1.tgz",
+      "integrity": "sha512-Sbq59ZHUYcND8w0Y2XZ13X7hbF6gUZQlWC8pBwCaqULLE44FY7Ph6UdG0c+ndBUJt9r77M4VCteieHg1JooeJA==",
+      "dependencies": {
+        "axios": "^1.6.7"
       }
     },
     "node_modules/end-of-stream": {

--- a/packages/gafl-webapp-service/package-lock.json
+++ b/packages/gafl-webapp-service/package-lock.json
@@ -23,6 +23,7 @@
         "debug": "^4.3.3",
         "disinfect": "^1.1.0",
         "easy-soap-request": "^5.6.1",
+        "fast-xml-parser": "^4.3.5",
         "find": "^0.3.0",
         "flatpickr": "^4.6.9",
         "govuk-frontend": "^5.1.0",
@@ -2428,6 +2429,27 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
       "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz",
+      "integrity": "sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -6825,6 +6847,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",

--- a/packages/gafl-webapp-service/package.json
+++ b/packages/gafl-webapp-service/package.json
@@ -52,6 +52,7 @@
     "debug": "^4.3.3",
     "disinfect": "^1.1.0",
     "easy-soap-request": "^5.6.1",
+    "fast-xml-parser": "^4.3.5",
     "find": "^0.3.0",
     "flatpickr": "^4.6.9",
     "govuk-frontend": "^5.1.0",

--- a/packages/gafl-webapp-service/package.json
+++ b/packages/gafl-webapp-service/package.json
@@ -51,6 +51,7 @@
     "blankie": "^5.0.0",
     "debug": "^4.3.3",
     "disinfect": "^1.1.0",
+    "easy-soap-request": "^5.6.1",
     "find": "^0.3.0",
     "flatpickr": "^4.6.9",
     "govuk-frontend": "^5.1.0",
@@ -79,6 +80,9 @@
   "jest": {
     "setupFilesAfterEnv": [
       "./gafl-jest-matchers.js"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!axios)/"
     ]
   }
 }

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -270,7 +270,7 @@
   "free": "free",
   "gov_uk": " - GOV.UK",
   "header_service_name": "Get a rod fishing licence",
-  "header_service_name_title": " - Get a rod fishing licence",  
+  "header_service_name_title": " - Get a rod fishing licence",
   "identification": "Identification",
   "identify_body_protect_info": "To find your licence details we first need to identify you. This helps us protect your personal information.",
   "identify_error_empty_postcode": "You did not enter a postcode",

--- a/packages/gafl-webapp-service/src/services/call-recording/__tests__/__snapshots__/call-recording-service.spec.js.snap
+++ b/packages/gafl-webapp-service/src/services/call-recording/__tests__/__snapshots__/call-recording-service.spec.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`call-recording-service pauseRecording sends a soap request with the correct xml 1`] = `
+"<soap:Envelope xmlns:soap=\\"http://www.w3.org/2003/05/soap-envelope\\" xmlns:cal=\\"http://redcentrex.redwoodtech.com/calls\\">
+  <soap:Header>
+    <wsse:Security soap:mustUnderstand=\\"true\\" xmlns:wsse=\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\\" xmlns:wsu=\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\\">
+      <wsse:UsernameToken wsu:Id=\\"UsernameToken-1\\">
+        <wsse:Username>username</wsse:Username>
+        <wsse:Password Type=\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\\">password</wsse:Password>
+      </wsse:UsernameToken>
+    </wsse:Security>
+  </soap:Header>
+  <soap:Body>
+    <cal:RecordingRequest>
+      <cal:UserID>agent@example.com</cal:UserID>
+      <cal:Record>pause</cal:Record>
+      <cal:Muted>0</cal:Muted>
+    </cal:RecordingRequest>
+  </soap:Body>
+</soap:Envelope>
+"
+`;
+
+exports[`call-recording-service resumeRecording sends a soap request with the correct xml 1`] = `
+"<soap:Envelope xmlns:soap=\\"http://www.w3.org/2003/05/soap-envelope\\" xmlns:cal=\\"http://redcentrex.redwoodtech.com/calls\\">
+  <soap:Header>
+    <wsse:Security soap:mustUnderstand=\\"true\\" xmlns:wsse=\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\\" xmlns:wsu=\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\\">
+      <wsse:UsernameToken wsu:Id=\\"UsernameToken-1\\">
+        <wsse:Username>username</wsse:Username>
+        <wsse:Password Type=\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\\">password</wsse:Password>
+      </wsse:UsernameToken>
+    </wsse:Security>
+  </soap:Header>
+  <soap:Body>
+    <cal:RecordingRequest>
+      <cal:UserID>agent@example.com</cal:UserID>
+      <cal:Record>resume</cal:Record>
+      <cal:Muted>0</cal:Muted>
+    </cal:RecordingRequest>
+  </soap:Body>
+</soap:Envelope>
+"
+`;

--- a/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
@@ -15,7 +15,7 @@ describe('call-recording-service', () => {
     soapRequest.mockReturnValue({
       response: {
         headers: 'headers',
-        body: 'body',
+        body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>0</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
         statusCode: '200'
       }
     })
@@ -46,6 +46,11 @@ describe('call-recording-service', () => {
       await pauseRecording('agent@example.com')
       expect(debug).toHaveBeenCalledWith('Pause recording response code: %s', '200')
     })
+
+    it('logs the result', async () => {
+      await pauseRecording('agent@example.com')
+      expect(debug).toHaveBeenCalledWith('Pause recording response result: %s', 0)
+    })
   })
 
   describe('resumeRecording', () => {
@@ -69,6 +74,11 @@ describe('call-recording-service', () => {
     it('logs the response code', async () => {
       await resumeRecording('agent@example.com')
       expect(debug).toHaveBeenCalledWith('Resume recording response code: %s', '200')
+    })
+
+    it('logs the result', async () => {
+      await resumeRecording('agent@example.com')
+      expect(debug).toHaveBeenCalledWith('Resume recording response result: %s', 0)
     })
   })
 })

--- a/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
@@ -51,6 +51,30 @@ describe('call-recording-service', () => {
       await pauseRecording('agent@example.com')
       expect(debug).toHaveBeenCalledWith('Pause recording response result: %s', 0)
     })
+
+    it('raises an error when the response code is not 200', async () => {
+      soapRequest.mockReturnValueOnce({
+        response: {
+          headers: 'headers',
+          body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>0</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
+          statusCode: '401'
+        }
+      })
+
+      await expect(pauseRecording('agent@example.com')).rejects.toThrow('Call request returned status code %s', '401')
+    })
+
+    it('raises an error when the result is not 0', async () => {
+      soapRequest.mockReturnValueOnce({
+        response: {
+          headers: 'headers',
+          body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>1</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
+          statusCode: '200'
+        }
+      })
+
+      await expect(pauseRecording('agent@example.com')).rejects.toThrow('Call request returned result code %s', 1)
+    })
   })
 
   describe('resumeRecording', () => {
@@ -79,6 +103,30 @@ describe('call-recording-service', () => {
     it('logs the result', async () => {
       await resumeRecording('agent@example.com')
       expect(debug).toHaveBeenCalledWith('Resume recording response result: %s', 0)
+    })
+
+    it('raises an error when the response code is not 200', async () => {
+      soapRequest.mockReturnValueOnce({
+        response: {
+          headers: 'headers',
+          body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>0</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
+          statusCode: '401'
+        }
+      })
+
+      await expect(resumeRecording('agent@example.com')).rejects.toThrow('Call request returned status code %s', '401')
+    })
+
+    it('raises an error when the result is not 0', async () => {
+      soapRequest.mockReturnValueOnce({
+        response: {
+          headers: 'headers',
+          body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>1</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
+          statusCode: '200'
+        }
+      })
+
+      await expect(resumeRecording('agent@example.com')).rejects.toThrow('Call request returned result code %s', 1)
     })
   })
 })

--- a/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
@@ -1,6 +1,8 @@
+import soapRequest from 'easy-soap-request'
 import db from 'debug'
 import { pauseRecording, resumeRecording } from '../call-recording-service'
 
+jest.mock('easy-soap-request')
 jest.mock('debug', () => jest.fn(() => jest.fn()))
 const { value: debug } = db.mock.results[db.mock.calls.findIndex(c => c[0] === 'webapp:call-recording-service')]
 
@@ -11,6 +13,11 @@ describe('call-recording-service', () => {
       await pauseRecording(agent)
       expect(debug).toHaveBeenCalledWith('Sending pause recording request to Storm for agent: %s', agent)
     })
+
+    it('sends a soap request', async () => {
+      await pauseRecording('agent')
+      expect(soapRequest).toHaveBeenCalledWith({ url: 'foo', headers: 'bar', xml: 'pause' })
+    })
   })
 })
 
@@ -20,6 +27,11 @@ describe('call-recording-service', () => {
       const agent = 'foo'
       await resumeRecording(agent)
       expect(debug).toHaveBeenCalledWith('Sending resume recording request to Storm for agent: %s', agent)
+    })
+
+    it('sends a soap request', async () => {
+      await resumeRecording('agent')
+      expect(soapRequest).toHaveBeenCalledWith({ url: 'foo', headers: 'bar', xml: 'resume' })
     })
   })
 })

--- a/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
@@ -7,31 +7,50 @@ jest.mock('debug', () => jest.fn(() => jest.fn()))
 const { value: debug } = db.mock.results[db.mock.calls.findIndex(c => c[0] === 'webapp:call-recording-service')]
 
 describe('call-recording-service', () => {
+  beforeAll(() => {
+    process.env.TELESALES_ENDPOINT = 'endpoint'
+    process.env.TELESALES_AUTH_USERNAME = 'username'
+    process.env.TELESALES_AUTH_PASSWORD = 'password'
+  })
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('pauseRecording', () => {
     it('logs that it is requesting to pause the recording', async () => {
-      const agent = 'foo'
-      await pauseRecording(agent)
-      expect(debug).toHaveBeenCalledWith('Sending pause recording request to Storm for agent: %s', agent)
+      const agentEmail = 'agent@example.com'
+      await pauseRecording(agentEmail)
+      expect(debug).toHaveBeenCalledWith('Sending pause recording request to Storm for agentEmail: %s', agentEmail)
     })
 
     it('sends a soap request', async () => {
-      await pauseRecording('agent')
-      expect(soapRequest).toHaveBeenCalledWith({ url: 'foo', headers: 'bar', xml: 'pause' })
+      await pauseRecording('agent@example.com')
+      const expectedArgs = { url: 'endpoint', headers: { 'Content-Type': 'text/xml;charset=UTF-8' } }
+      expect(soapRequest).toHaveBeenCalledWith(expect.objectContaining(expectedArgs))
+    })
+
+    it('sends a soap request with the correct xml', async () => {
+      await pauseRecording('agent@example.com')
+      expect(soapRequest.mock.calls[0][0].xml).toMatchSnapshot()
     })
   })
-})
 
-describe('call-recording-service', () => {
   describe('resumeRecording', () => {
     it('logs that it is requesting to resume the recording', async () => {
-      const agent = 'foo'
-      await resumeRecording(agent)
-      expect(debug).toHaveBeenCalledWith('Sending resume recording request to Storm for agent: %s', agent)
+      const agentEmail = 'agent@example.com'
+      await resumeRecording(agentEmail)
+      expect(debug).toHaveBeenCalledWith('Sending resume recording request to Storm for agentEmail: %s', agentEmail)
     })
 
-    it('sends a soap request', async () => {
-      await resumeRecording('agent')
-      expect(soapRequest).toHaveBeenCalledWith({ url: 'foo', headers: 'bar', xml: 'resume' })
+    it('sends a soap request with the correct headers and endpoint', async () => {
+      const expectedArgs = { url: 'endpoint', headers: { 'Content-Type': 'text/xml;charset=UTF-8' } }
+      await resumeRecording('agent@example.com')
+      expect(soapRequest).toHaveBeenCalledWith(expect.objectContaining(expectedArgs))
+    })
+
+    it('sends a soap request with the correct xml', async () => {
+      await resumeRecording('agent@example.com')
+      expect(soapRequest.mock.calls[0][0].xml).toMatchSnapshot()
     })
   })
 })

--- a/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
@@ -11,6 +11,14 @@ describe('call-recording-service', () => {
     process.env.TELESALES_ENDPOINT = 'endpoint'
     process.env.TELESALES_AUTH_USERNAME = 'username'
     process.env.TELESALES_AUTH_PASSWORD = 'password'
+
+    soapRequest.mockReturnValue({
+      response: {
+        headers: 'headers',
+        body: 'body',
+        statusCode: '200'
+      }
+    })
   })
   beforeEach(() => {
     jest.clearAllMocks()
@@ -33,6 +41,11 @@ describe('call-recording-service', () => {
       await pauseRecording('agent@example.com')
       expect(soapRequest.mock.calls[0][0].xml).toMatchSnapshot()
     })
+
+    it('logs the response code', async () => {
+      await pauseRecording('agent@example.com')
+      expect(debug).toHaveBeenCalledWith('Pause recording response code: %s', '200')
+    })
   })
 
   describe('resumeRecording', () => {
@@ -51,6 +64,11 @@ describe('call-recording-service', () => {
     it('sends a soap request with the correct xml', async () => {
       await resumeRecording('agent@example.com')
       expect(soapRequest.mock.calls[0][0].xml).toMatchSnapshot()
+    })
+
+    it('logs the response code', async () => {
+      await resumeRecording('agent@example.com')
+      expect(debug).toHaveBeenCalledWith('Resume recording response code: %s', '200')
     })
   })
 })

--- a/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
@@ -1,0 +1,25 @@
+import db from 'debug'
+import { pauseRecording, resumeRecording } from '../call-recording-service'
+
+jest.mock('debug', () => jest.fn(() => jest.fn()))
+const { value: debug } = db.mock.results[db.mock.calls.findIndex(c => c[0] === 'webapp:call-recording-service')]
+
+describe('call-recording-service', () => {
+  describe('pauseRecording', () => {
+    it('logs that it is requesting to pause the recording', async () => {
+      const agent = 'foo'
+      await pauseRecording(agent)
+      expect(debug).toHaveBeenCalledWith('Sending pause recording request to Storm for agent: %s', agent)
+    })
+  })
+})
+
+describe('call-recording-service', () => {
+  describe('resumeRecording', () => {
+    it('logs that it is requesting to resume the recording', async () => {
+      const agent = 'foo'
+      await resumeRecording(agent)
+      expect(debug).toHaveBeenCalledWith('Sending resume recording request to Storm for agent: %s', agent)
+    })
+  })
+})

--- a/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/__tests__/call-recording-service.spec.js
@@ -16,7 +16,7 @@ describe('call-recording-service', () => {
       response: {
         headers: 'headers',
         body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>0</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
-        statusCode: '200'
+        statusCode: 200
       }
     })
   })
@@ -44,7 +44,7 @@ describe('call-recording-service', () => {
 
     it('logs the response code', async () => {
       await pauseRecording('agent@example.com')
-      expect(debug).toHaveBeenCalledWith('Pause recording response code: %s', '200')
+      expect(debug).toHaveBeenCalledWith('Pause recording response code: %s', 200)
     })
 
     it('logs the result', async () => {
@@ -57,7 +57,7 @@ describe('call-recording-service', () => {
         response: {
           headers: 'headers',
           body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>0</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
-          statusCode: '401'
+          statusCode: 401
         }
       })
 
@@ -69,7 +69,7 @@ describe('call-recording-service', () => {
         response: {
           headers: 'headers',
           body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>1</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
-          statusCode: '200'
+          statusCode: 200
         }
       })
 
@@ -97,7 +97,7 @@ describe('call-recording-service', () => {
 
     it('logs the response code', async () => {
       await resumeRecording('agent@example.com')
-      expect(debug).toHaveBeenCalledWith('Resume recording response code: %s', '200')
+      expect(debug).toHaveBeenCalledWith('Resume recording response code: %s', 200)
     })
 
     it('logs the result', async () => {
@@ -110,7 +110,7 @@ describe('call-recording-service', () => {
         response: {
           headers: 'headers',
           body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>0</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
-          statusCode: '401'
+          statusCode: 401
         }
       })
 
@@ -122,7 +122,7 @@ describe('call-recording-service', () => {
         response: {
           headers: 'headers',
           body: '<soap:Envelope><soap:Body><cal:RecordingResponse><cal:Result>1</cal:Result></cal:RecordingResponse></soap:Body></soap:Envelope>',
-          statusCode: '200'
+          statusCode: 200
         }
       })
 

--- a/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
@@ -1,0 +1,10 @@
+import db from 'debug'
+const debug = db('webapp:call-recording-service')
+
+export const pauseRecording = async agent => {
+  debug('Sending pause recording request to Storm for agent: %s', agent)
+}
+
+export const resumeRecording = async agent => {
+  debug('Sending resume recording request to Storm for agent: %s', agent)
+}

--- a/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
@@ -1,18 +1,20 @@
 import soapRequest from 'easy-soap-request'
-import { XMLBuilder } from 'fast-xml-parser'
+import { XMLBuilder, XMLParser } from 'fast-xml-parser'
 import db from 'debug'
 const debug = db('webapp:call-recording-service')
 
 export const pauseRecording = async agentEmail => {
   debug('Sending pause recording request to Storm for agentEmail: %s', agentEmail)
-  const responseCode = await sendRequestToTelesales('pause', agentEmail)
-  debug('Pause recording response code: %s', responseCode)
+  const { statusCode, result } = await sendRequestToTelesales('pause', agentEmail)
+  debug('Pause recording response code: %s', statusCode)
+  debug('Pause recording response result: %s', result)
 }
 
 export const resumeRecording = async agentEmail => {
   debug('Sending resume recording request to Storm for agentEmail: %s', agentEmail)
-  const responseCode = await sendRequestToTelesales('resume', agentEmail)
-  debug('Resume recording response code: %s', responseCode)
+  const { statusCode, result } = await sendRequestToTelesales('resume', agentEmail)
+  debug('Resume recording response code: %s', statusCode)
+  debug('Resume recording response result: %s', result)
 }
 
 const sendRequestToTelesales = async (action, agentEmail) => {
@@ -73,10 +75,10 @@ const buildXml = async (action, agentEmail) => {
 }
 
 const parseResponse = async response => {
-  console.log(response)
-  const { headers, body, statusCode } = response
-  console.log(headers)
-  console.log(body)
-  console.log(statusCode)
-  return statusCode
+  const { body, statusCode } = response
+  const parser = new XMLParser()
+  const parsedResponse = parser.parse(body)
+  const result = parsedResponse['soap:Envelope']['soap:Body']['cal:RecordingResponse']['cal:Result']
+
+  return { statusCode, result }
 }

--- a/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
@@ -5,19 +5,22 @@ const debug = db('webapp:call-recording-service')
 
 export const pauseRecording = async agentEmail => {
   debug('Sending pause recording request to Storm for agentEmail: %s', agentEmail)
-  sendRequestToTelesales('pause', agentEmail)
+  const responseCode = await sendRequestToTelesales('pause', agentEmail)
+  debug('Pause recording response code: %s', responseCode)
 }
 
 export const resumeRecording = async agentEmail => {
   debug('Sending resume recording request to Storm for agentEmail: %s', agentEmail)
-  sendRequestToTelesales('resume', agentEmail)
+  const responseCode = await sendRequestToTelesales('resume', agentEmail)
+  debug('Resume recording response code: %s', responseCode)
 }
 
 const sendRequestToTelesales = async (action, agentEmail) => {
   const url = process.env.TELESALES_ENDPOINT
   const headers = { 'Content-Type': 'text/xml;charset=UTF-8' }
   const xml = await buildXml(action, agentEmail)
-  await soapRequest({ url, headers, xml })
+  const { response } = await soapRequest({ url, headers, xml })
+  return parseResponse(response)
 }
 
 const buildXml = async (action, agentEmail) => {
@@ -67,4 +70,13 @@ const buildXml = async (action, agentEmail) => {
     }
   })
   return xml
+}
+
+const parseResponse = async response => {
+  console.log(response)
+  const { headers, body, statusCode } = response
+  console.log(headers)
+  console.log(body)
+  console.log(statusCode)
+  return statusCode
 }

--- a/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
@@ -1,10 +1,13 @@
+import soapRequest from 'easy-soap-request'
 import db from 'debug'
 const debug = db('webapp:call-recording-service')
 
 export const pauseRecording = async agent => {
   debug('Sending pause recording request to Storm for agent: %s', agent)
+  await soapRequest({ url: 'foo', headers: 'bar', xml: 'pause' })
 }
 
 export const resumeRecording = async agent => {
   debug('Sending resume recording request to Storm for agent: %s', agent)
+  await soapRequest({ url: 'foo', headers: 'bar', xml: 'resume' })
 }

--- a/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
@@ -1,13 +1,70 @@
 import soapRequest from 'easy-soap-request'
+import { XMLBuilder } from 'fast-xml-parser'
 import db from 'debug'
 const debug = db('webapp:call-recording-service')
 
-export const pauseRecording = async agent => {
-  debug('Sending pause recording request to Storm for agent: %s', agent)
-  await soapRequest({ url: 'foo', headers: 'bar', xml: 'pause' })
+export const pauseRecording = async agentEmail => {
+  debug('Sending pause recording request to Storm for agentEmail: %s', agentEmail)
+  sendRequestToTelesales('pause', agentEmail)
 }
 
-export const resumeRecording = async agent => {
-  debug('Sending resume recording request to Storm for agent: %s', agent)
-  await soapRequest({ url: 'foo', headers: 'bar', xml: 'resume' })
+export const resumeRecording = async agentEmail => {
+  debug('Sending resume recording request to Storm for agentEmail: %s', agentEmail)
+  sendRequestToTelesales('resume', agentEmail)
+}
+
+const sendRequestToTelesales = async (action, agentEmail) => {
+  const url = process.env.TELESALES_ENDPOINT
+  const headers = { 'Content-Type': 'text/xml;charset=UTF-8' }
+  const xml = await buildXml(action, agentEmail)
+  await soapRequest({ url, headers, xml })
+}
+
+const buildXml = async (action, agentEmail) => {
+  const authUsername = process.env.TELESALES_AUTH_USERNAME
+  const authPassword = process.env.TELESALES_AUTH_PASSWORD
+
+  const builder = new XMLBuilder({
+    attributesGroupName: '@',
+    format: true,
+    ignoreAttributes: false,
+    suppressBooleanAttributes: false
+  })
+  const xml = builder.build({
+    'soap:Envelope': {
+      '@': {
+        'xmlns:soap': 'http://www.w3.org/2003/05/soap-envelope',
+        'xmlns:cal': 'http://redcentrex.redwoodtech.com/calls'
+      },
+      'soap:Header': {
+        'wsse:Security': {
+          '@': {
+            'soap:mustUnderstand': 'true',
+            'xmlns:wsse': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+            'xmlns:wsu': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'
+          },
+          'wsse:UsernameToken': {
+            '@': {
+              'wsu:Id': 'UsernameToken-1'
+            },
+            'wsse:Username': authUsername,
+            'wsse:Password': {
+              '@': {
+                Type: 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText'
+              },
+              '#text': authPassword
+            }
+          }
+        }
+      },
+      'soap:Body': {
+        'cal:RecordingRequest': {
+          'cal:UserID': agentEmail,
+          'cal:Record': action,
+          'cal:Muted': '0'
+        }
+      }
+    }
+  })
+  return xml
 }

--- a/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
+++ b/packages/gafl-webapp-service/src/services/call-recording/call-recording-service.js
@@ -79,7 +79,7 @@ const buildXml = async (action, agentEmail) => {
 const parseResponse = async response => {
   const { body, statusCode } = response
 
-  if (statusCode === '200') {
+  if (statusCode === 200) {
     const parser = new XMLParser()
     const parsedResponse = parser.parse(body)
     const result = parsedResponse['soap:Envelope']['soap:Body']['cal:RecordingResponse']['cal:Result']


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3857

In order to enable the option to record calls for telesales agents, we need to be able to automatically switch off call recording during the payment process so as not to record any sensitive details.

The recording should resume once the payment process is complete.