### PR TITLE
Inserting spaces into screen reader text for usability.

### DIFF
--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
@@ -82,7 +82,8 @@ class RowGenerator {
           items: [
             {
               href,
-              visuallyHiddenText: `\u00A0${visuallyHiddenText ? visuallyHiddenText.toString() : ''}`,              text: this.labels.contact_summary_change,
+              visuallyHiddenText: `\u00A0${visuallyHiddenText ? visuallyHiddenText.toString() : ''}`,
+              text: this.labels.contact_summary_change,
               attributes: { id }
             }
           ]

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
@@ -82,8 +82,7 @@ class RowGenerator {
           items: [
             {
               href,
-              visuallyHiddenText,
-              text: this.labels.contact_summary_change,
+              visuallyHiddenText: `\u00A0${visuallyHiddenText ? visuallyHiddenText.toString() : ''}`,              text: this.labels.contact_summary_change,
               attributes: { id }
             }
           ]

--- a/packages/gafl-webapp-service/src/pages/summary/licence-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/licence-summary/route.js
@@ -47,8 +47,7 @@ class RowGenerator {
           items: [
             {
               href,
-              visuallyHiddenText,
-              text: this.labels.contact_summary_change,
+              visuallyHiddenText: `\u00A0${visuallyHiddenText ? visuallyHiddenText.toString() : ''}`,              text: this.labels.contact_summary_change,
               attributes: { id }
             }
           ]

--- a/packages/gafl-webapp-service/src/pages/summary/licence-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/licence-summary/route.js
@@ -47,7 +47,8 @@ class RowGenerator {
           items: [
             {
               href,
-              visuallyHiddenText: `\u00A0${visuallyHiddenText ? visuallyHiddenText.toString() : ''}`,              text: this.labels.contact_summary_change,
+              visuallyHiddenText: `\u00A0${visuallyHiddenText ? visuallyHiddenText.toString() : ''}`,
+              text: this.labels.contact_summary_change,
               attributes: { id }
             }
           ]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3841

A recent accessibility assessment identified a number of issues. This ticket is to make Change links have space between words. The issue and suggested solution is detailed on page 125-127 of the DAC assessment.

On the 'Check the licence details’, the ‘Change’ links have correctly included visually hidden text that defines its context for out-of-context browsing for screen readers. However, the text and visually hidden text run up against each other, lacking a space between words. E.g., ‘ChangeName’ rather than ‘Change Name’.