### PR TITLE
Keyboard focus inconsistency

### DIFF
--- a/packages/gafl-webapp-service/package-lock.json
+++ b/packages/gafl-webapp-service/package-lock.json
@@ -9,8 +9,6 @@
       "version": "1.43.0-rc.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/business-rules-lib": "1.43.0-rc.2",
-        "@defra-fish/connectors-lib": "1.43.0-rc.2",
         "@defra/hapi-gapi": "^2.0.0",
         "@hapi/boom": "^9.1.2",
         "@hapi/catbox-redis": "^6.0.2",

--- a/packages/gafl-webapp-service/package-lock.json
+++ b/packages/gafl-webapp-service/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.43.0-rc.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@defra-fish/business-rules-lib": "1.43.0-rc.2",
+        "@defra-fish/connectors-lib": "1.43.0-rc.2",
         "@defra/hapi-gapi": "^2.0.0",
         "@hapi/boom": "^9.1.2",
         "@hapi/catbox-redis": "^6.0.2",

--- a/packages/gafl-webapp-service/src/pages/contact/address/select/address-select.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/address/select/address-select.njk
@@ -25,7 +25,7 @@
     <p class="govuk-body-m">
         {{ data.addresses.length }} {{ mssgs.address_select_link if data.addresses.length === 1 else mssgs.address_select_addresses }} {{ mssgs.address_select_found_for }}
         {{ data.searchTerms.premises }}{{ mssgs.and }}{{ data.searchTerms.postcode }}&nbsp;&nbsp;
-        <a href="{{ data.lookupPage }}">
+        <a class="govuk-link" href="{{ data.lookupPage }}">
             {{ mssgs.licence_summary_change }}<span class="govuk-visually-hidden">{{ mssgs.address_select_link }}</span>
         </a>
     </p>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3838

A recent accessibility assessment identified a number of issues. This ticket is to make keyboard focus consistent on Change links with the GOV.UK Design System. The issue and suggested solution is detailed on page 118-119 of the DAC assessment.

This affects keyboard only users, as this link was styled inconsistently from other links, using the browser default styling. It now uses the yellow and black, thick underline, styling used everywhere else.