### PR TITLE
Remove "Continue" button from within the fieldset

### DIFF
--- a/packages/gafl-webapp-service/src/pages/contact/address/lookup/address-lookup.njk
+++ b/packages/gafl-webapp-service/src/pages/contact/address/lookup/address-lookup.njk
@@ -66,15 +66,16 @@
                   errorMessage: { text: mssgs.address_lookup_error_empty_postcode } if error['postcode']
                 }) }}
 
-                {{ govukButton({
-                    attributes: { id: 'continue' },
-                    preventDoubleClick: true,
-                    name: "continue",
-                    text: mssgs.continue,
-                    classes: "govuk-!-margin-top-5"
-                }) }}
-
             {% endcall %}
+
+            {{ govukButton({
+                attributes: { id: 'continue' },
+                preventDoubleClick: true,
+                name: "continue",
+                text: mssgs.continue,
+                classes: "govuk-!-margin-top-5"
+            }) }}
+
             <p class="govuk-body-m">
                 <a class="govuk-link" href="{{ data.uri.entryPage }}">{{ mssgs.address_lookup_manually_enter_you if data.isLicenceForYou else mssgs.address_lookup_manually_enter_other }}</a>
             </p>

--- a/packages/gafl-webapp-service/src/pages/licence-details/no-licence-required/no-licence-required.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/no-licence-required/no-licence-required.njk
@@ -22,13 +22,14 @@
               }
             }) %}
 
+            {% endcall %}
+
                 {{ govukButton({
                     text: mssgs.exit_service_button,
                     classes: "govuk-!-margin-top-6",
                     href: data.uri.servicePage
                 }) }}
-
-            {% endcall %}
+                
         </form>
     </div>
 </div>

--- a/packages/gafl-webapp-service/src/pages/payment/cancelled/payment-cancelled.njk
+++ b/packages/gafl-webapp-service/src/pages/payment/cancelled/payment-cancelled.njk
@@ -20,6 +20,8 @@
 
                 <p class="govuk-body-m">{{ mssgs.payment_failed_not_taken }}</p>
 
+            {% endcall %}
+
                 {{ govukButton({
                     attributes: { id: 'continue' },
                     preventDoubleClick: true,
@@ -27,7 +29,6 @@
                     text: mssgs.try_payment_again,
                     classes: "govuk-!-margin-top-5"
                 }) }}
-            {% endcall %}
 
             {{ csrf() }}
         </form>

--- a/packages/gafl-webapp-service/src/pages/payment/failed/payment-failed.njk
+++ b/packages/gafl-webapp-service/src/pages/payment/failed/payment-failed.njk
@@ -33,6 +33,8 @@
                 {% endif %}
                 <p class="govuk-body-m">{{ mssgs.payment_failed_not_taken }}</p>
 
+            {% endcall %}
+
                 {{ govukButton({
                     attributes: { id: 'continue' },
                     preventDoubleClick: true,
@@ -40,7 +42,6 @@
                     text: mssgs.try_payment_again,
                     classes: "govuk-!-margin-top-5"
                 }) }}
-            {% endcall %}
 
             {{ csrf() }}
         </form>

--- a/packages/gafl-webapp-service/src/pages/recurring-payments/set-up-payment/set-up-payment.njk
+++ b/packages/gafl-webapp-service/src/pages/recurring-payments/set-up-payment/set-up-payment.njk
@@ -48,6 +48,8 @@
                   ]
                 }) }}
 
+            {% endcall %}
+
                 {{ govukButton({
                     attributes: { id: 'continue' },
                     preventDoubleClick: true,
@@ -57,8 +59,7 @@
                 }) }}
             
             <p class="govuk-body no-print"><a class="govuk-link" href="{{ data.uri.single }}">{{ mssgs.recurring_payment_set_up_back }}</a></p>
-
-            {% endcall %}
+            
             {{ csrf() }}
         </form>
     </div>

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -134,6 +134,8 @@
                   errorMessage: { text: mssgs.enter_postcode } if error['postcode']
                 }) }}
 
+            {% endcall %}
+
                 {{ govukButton({
                     attributes: { id: 'continue' },
                     preventDoubleClick: true,
@@ -142,7 +144,6 @@
                     classes: "govuk-!-margin-top-1"
                 }) }}
 
-            {% endcall %}
             {{ csrf() }}
         </form>
         <div>

--- a/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/terms-and-conditions/terms-and-conditions.njk
@@ -66,6 +66,8 @@
                     }) }}
                 {% endif %}
 
+            {% endcall %}
+
                 {{ govukButton({
                     attributes: { id: 'continue' },
                     preventDoubleClick: true,
@@ -77,7 +79,7 @@
                 {% if data.paymentRequired %}
                     <span class="govuk-caption-m">{{ mssgs.terms_conds_pay_on_gov_uk }}</span>
                 {% endif %}
-            {% endcall %}
+
             {{ csrf() }}
         </form>
     </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3833

This ticket is to reposition Continue button outside the field set. The issue and suggested solution is detailed on page 110-111 of the DAC assessment.

On the ‘Find your address’ page, the ‘Continue’ submit button for the form has been included inside the fieldset.

This affects screen reader users as screen readers announce the start and end of fieldsets, in order to assist the user in understanding the structure of the page. Including the ‘Continue’ button within the group could lead to the implication that the button is part of the question, not a means of submitting the form.