### PR TITLE
Amend refund policy page

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -651,6 +651,8 @@
   "refund_bulletpoint_1_3": "Ffôn: 03708 506 506",
   "refund_bulletpoint_1_4": "Dydd Llun i ddydd Gwener, 8am hyd 6pm (ac eithrio gwyliau cyhoeddus)",
   "refund_bulletpoint_1_5": "Rhagor o wybodaeth am gostau galwadau (yn agor ar dudalen newydd)",
+  "refund_bulletpoint_1_6": "Ebost: ",
+  "refund_bulletpoint_link": "enquiries@environment-agency.gov.uk",
   "refund_bulletpoint_2_1": "Ni fydd Asiantaeth yr Amgylchedd yn codi ffi pan fyddwch yn prynu trwydded drwy ein ",
   "refund_bulletpoint_2_2": ". Nid ydym yn argymell prynu eich trwydded drwy safleoedd trydydd parti, a allai godi ffi ar ben cost y drwydded. Os ydych chi wedi prynu eich trwydded drwy drydydd parti, cysylltwch â nhw’n uniongyrchol i ofyn am ad-daliad o gost y drwydded a/neu’r ffi. Ni fydd Asiantaeth yr Amgylchedd yn rhoi ad-daliad i ddeiliaid trwydded am drwyddedau a brynwyd drwy drydydd parti.",
   "refund_bulletpoint_2_link": "gwefan",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -650,6 +650,8 @@
   "refund_bulletpoint_1_3": "Telephone: 03708 506 506",
   "refund_bulletpoint_1_4": "Monday to Friday, 8am to 6pm (except public holidays)",
   "refund_bulletpoint_1_5": "Find out more about call charges (opens in new tab)",
+  "refund_bulletpoint_1_6": "Email: ",
+  "refund_bulletpoint_link": "enquiries@environment-agency.gov.uk",
   "refund_bulletpoint_2_1": "The Environment Agency will not charge a fee when you purchase a licence through our ",
   "refund_bulletpoint_2_2": ". We do not recommend purchasing your licence through third-party sites, which may charge a fee on top of the licence cost. If you purchased your licence through a third party, please contact them directly to request a refund of the licence cost and/or fee. The Environment Agency will not refund licence holders for licences purchased through third parties.",
   "refund_bulletpoint_2_link": "website",

--- a/packages/gafl-webapp-service/src/pages/guidance/refund-policy.njk
+++ b/packages/gafl-webapp-service/src/pages/guidance/refund-policy.njk
@@ -10,6 +10,7 @@
         <ol class="govuk-list govuk-list--number">
             <li class="govuk-body">{{ mssgs.refund_bulletpoint_1_1 }}</li>
                 <p class="govuk-!-margin-top-5 govuk-!-margin-bottom-0">{{ mssgs.refund_bulletpoint_1_2 }}</p>
+                <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0">{{ mssgs.refund_bulletpoint_1_6 }}<a class="govuk-link" href="mailto:enquiries@environment-agency.gov.uk" >{{ mssgs.refund_bulletpoint_link }}</a></p>
                 <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0">{{ mssgs.refund_bulletpoint_1_3 }}</p>
                 <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0">{{ mssgs.refund_bulletpoint_1_4 }}</p>
                 <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-5"><a class="govuk-link" href="https://www.gov.uk/call-charges" rel="noreferrer noopener" target="_blank" >{{ mssgs.refund_bulletpoint_1_5 }}</a></p>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3662

This ticket's purpose is to add an email to the refund policy page, to allow users to request a refund by email. There is no risk of refund being refused for the user because the email sent date is taken as the being within the 14 day refund period - not the ‘read by staff’ date.