### PR TITLE
Incorrect details in Welsh version of payment screen

### DIFF
--- a/packages/gafl-webapp-service/src/processors/licence-type-display.js
+++ b/packages/gafl-webapp-service/src/processors/licence-type-display.js
@@ -28,9 +28,9 @@ export const licenceTypeDisplay = (permission, mssgs) => {
 export const licenceTypeAndLengthDisplay = (permission, mssgs) => {
   switch (permission.licenceLength) {
     case '12M':
-      return `${licenceTypeDisplay(permission, mssgs)}, ${mssgs.licence_type_12m}`
+      return `${licenceTypeDisplay(permission, mssgs)}, 12 months`
     case '8D':
-      return `${licenceTypeDisplay(permission, mssgs)}, ${mssgs.licence_type_8d}`
+      return `${licenceTypeDisplay(permission, mssgs)}, 8 days`
     default:
       return `${licenceTypeDisplay(permission, mssgs)}, ${mssgs.licence_type_1d}`
   }

--- a/packages/gafl-webapp-service/src/processors/licence-type-display.js
+++ b/packages/gafl-webapp-service/src/processors/licence-type-display.js
@@ -28,11 +28,11 @@ export const licenceTypeDisplay = (permission, mssgs) => {
 export const licenceTypeAndLengthDisplay = (permission, mssgs) => {
   switch (permission.licenceLength) {
     case '12M':
-      return `${licenceTypeDisplay(permission, mssgs)}, 12 months`
+      return `${licenceTypeDisplay(permission, mssgs)}, ${mssgs.licence_type_12m}`
     case '8D':
-      return `${licenceTypeDisplay(permission, mssgs)}, 8 days`
+      return `${licenceTypeDisplay(permission, mssgs)}, ${mssgs.licence_type_8d}`
     default:
-      return `${licenceTypeDisplay(permission, mssgs)}, 1 day`
+      return `${licenceTypeDisplay(permission, mssgs)}, ${mssgs.licence_type_1d}`
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3981

In the Welsh user journey, GOV.UK PAY defaults correctly to Welsh, pulling through the details of purchase from the main service. However, in at least one instance, we are supplying the licence length in English – see attached image. In the grey box, it says "Brithyllod a physgod bras, hyd at 2 wialen, 1 day" instead of "1 diwrnod".

This ticket is to ensure that details are correctly supplied in Welsh for all licence types. 