### PR TITLE
Fix error generating fulfilment file after CRM fulfilment requests

### DIFF
--- a/packages/dynamics-lib/src/queries/__tests__/fulfilment.queries.spec.js
+++ b/packages/dynamics-lib/src/queries/__tests__/fulfilment.queries.spec.js
@@ -15,7 +15,8 @@ describe('Fulfilment Queries', () => {
             ])
           })
         ]),
-        filter: 'defra_FulfilmentRequestFileId eq null and statecode eq 0',
+        filter:
+          "defra_FulfilmentRequestFileId eq null and defra_notes eq 'Initial fulfilment request created at point of sale' and statecode eq 0",
         select: expect.any(Array),
         orderBy: ['defra_requesttimestamp asc']
       })

--- a/packages/dynamics-lib/src/queries/fulfilment.queries.js
+++ b/packages/dynamics-lib/src/queries/fulfilment.queries.js
@@ -10,7 +10,7 @@ import { FulfilmentRequestFile } from '../entities/fulfilment-request-file.entit
  */
 export const findUnassociatedFulfilmentRequests = () => {
   const { permission } = FulfilmentRequest.definition.relationships
-  const filter = `${FulfilmentRequest.definition.relationships.fulfilmentRequestFile.property} eq null and defra_notes eq 'Initial fulfilment request created at point of sale' and ${FulfilmentRequest.definition.defaultFilter}`
+  const filter = `${FulfilmentRequest.definition.relationships.fulfilmentRequestFile.property} eq null and ${FulfilmentRequest.definition.mappings.notes.field} eq 'Initial fulfilment request created at point of sale' and ${FulfilmentRequest.definition.defaultFilter}`
   return new PredefinedQuery({
     root: FulfilmentRequest,
     filter: filter,

--- a/packages/dynamics-lib/src/queries/fulfilment.queries.js
+++ b/packages/dynamics-lib/src/queries/fulfilment.queries.js
@@ -10,7 +10,7 @@ import { FulfilmentRequestFile } from '../entities/fulfilment-request-file.entit
  */
 export const findUnassociatedFulfilmentRequests = () => {
   const { permission } = FulfilmentRequest.definition.relationships
-  const filter = `${FulfilmentRequest.definition.relationships.fulfilmentRequestFile.property} eq null and ${FulfilmentRequest.definition.defaultFilter}`
+  const filter = `${FulfilmentRequest.definition.relationships.fulfilmentRequestFile.property} eq null and defra_notes eq 'Initial fulfilment request created at point of sale' and ${FulfilmentRequest.definition.defaultFilter}`
   return new PredefinedQuery({
     root: FulfilmentRequest,
     filter: filter,

--- a/packages/fulfilment-job/src/staging/create-part-files.js
+++ b/packages/fulfilment-job/src/staging/create-part-files.js
@@ -63,12 +63,15 @@ const processQueryPage = async page => {
     const fulfilmentFile = await getTargetFulfilmentFile()
     const partNumber = getPartNumber(fulfilmentFile.numberOfRequests, config.file.partFileSize)
     const partFileSize = Math.min(config.file.partFileSize, config.file.size - fulfilmentFile.numberOfRequests)
-    const itemsToWrite = page.splice(0, partFileSize).map(result => ({
-      fulfilmentRequest: result.entity,
-      permission: result.expanded.permission.entity,
-      licensee: result.expanded.permission.expanded.licensee.entity,
-      permit: result.expanded.permission.expanded.permit.entity
-    }))
+    const itemsToWrite = page.splice(0, partFileSize).map((result, idx) => {
+      debug('Writing item id %s', result.id || result.defra_fulfilmentrequestid || 'not found')
+      return ({
+        fulfilmentRequest: result.entity,
+        permission: result.expanded.permission.entity,
+        licensee: result.expanded.permission.expanded.licensee.entity,
+        permit: result.expanded.permission.expanded.permit.entity
+      })
+    })
     await writeS3PartFile(fulfilmentFile, partNumber, itemsToWrite)
 
     fulfilmentFile.numberOfRequests += itemsToWrite.length

--- a/packages/fulfilment-job/src/staging/create-part-files.js
+++ b/packages/fulfilment-job/src/staging/create-part-files.js
@@ -63,15 +63,12 @@ const processQueryPage = async page => {
     const fulfilmentFile = await getTargetFulfilmentFile()
     const partNumber = getPartNumber(fulfilmentFile.numberOfRequests, config.file.partFileSize)
     const partFileSize = Math.min(config.file.partFileSize, config.file.size - fulfilmentFile.numberOfRequests)
-    const itemsToWrite = page.splice(0, partFileSize).map((result, idx) => {
-      debug('Writing item %s', JSON.stringify(result, undefined, '\t'))
-      return ({
-        fulfilmentRequest: result.entity,
-        permission: result.expanded.permission.entity,
-        licensee: result.expanded.permission.expanded.licensee.entity,
-        permit: result.expanded.permission.expanded.permit.entity
-      })
-    })
+    const itemsToWrite = page.splice(0, partFileSize).map(result => ({
+      fulfilmentRequest: result.entity,
+      permission: result.expanded.permission.entity,
+      licensee: result.expanded.permission.expanded.licensee.entity,
+      permit: result.expanded.permission.expanded.permit.entity
+    }))
     await writeS3PartFile(fulfilmentFile, partNumber, itemsToWrite)
 
     fulfilmentFile.numberOfRequests += itemsToWrite.length

--- a/packages/fulfilment-job/src/staging/create-part-files.js
+++ b/packages/fulfilment-job/src/staging/create-part-files.js
@@ -64,7 +64,7 @@ const processQueryPage = async page => {
     const partNumber = getPartNumber(fulfilmentFile.numberOfRequests, config.file.partFileSize)
     const partFileSize = Math.min(config.file.partFileSize, config.file.size - fulfilmentFile.numberOfRequests)
     const itemsToWrite = page.splice(0, partFileSize).map((result, idx) => {
-      debug('Writing item id %s', result.id || result.defra_fulfilmentrequestid || 'not found')
+      debug('Writing item %s', JSON.stringify(result, undefined, '\t'))
       return ({
         fulfilmentRequest: result.entity,
         permission: result.expanded.permission.entity,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4101

The fuilfilment job doesn't handle the new fulfilment requests generated by the CRM. We don't want it to, it should ignore these, but at the moment the job throws and error and falls over which also isn't what we want