### PR TITLE
Add new query based on full reference number

### DIFF
--- a/packages/dynamics-lib/src/queries/__tests__/permission.queries.spec.js
+++ b/packages/dynamics-lib/src/queries/__tests__/permission.queries.spec.js
@@ -1,4 +1,4 @@
-import { permissionForLicensee } from '../permission.queries.js'
+import { permissionForLicensee, permissionForFullReferenceNumber } from '../permission.queries.js'
 
 describe('Permission Queries', () => {
   describe('permissionForLicensee', () => {
@@ -13,6 +13,22 @@ describe('Permission Queries', () => {
         ]),
         filter:
           "endswith(defra_name, 'ABC123') and defra_ContactId/defra_postcode eq 'AB12 3CD' and defra_ContactId/birthdate eq 2000-01-01 and statecode eq 0",
+        select: expect.any(Array)
+      })
+    })
+  })
+
+  describe('permissionForFullReferenceNumber', () => {
+    it('builds a filter to run a query for a permission with a full reference number', async () => {
+      const query = permissionForFullReferenceNumber('ABC123')
+      expect(query.toRetrieveRequest()).toEqual({
+        collection: 'defra_permissions',
+        expand: expect.arrayContaining([
+          expect.objectContaining({ property: 'defra_ContactId' }),
+          expect.objectContaining({ property: 'defra_PermitId' }),
+          expect.objectContaining({ property: 'defra_defra_permission_defra_concessionproof_PermissionId' })
+        ]),
+        filter: "defra_name eq 'ABC123' and statecode eq 0",
         select: expect.any(Array)
       })
     })

--- a/packages/dynamics-lib/src/queries/permission.queries.js
+++ b/packages/dynamics-lib/src/queries/permission.queries.js
@@ -24,3 +24,14 @@ export const permissionForLicensee = (permissionReferenceNumber, licenseeBirthDa
     expand: [licensee, permit, concessionProofs]
   })
 }
+
+export const permissionForFullReferenceNumber = permissionReferenceNumber => {
+  const { licensee, permit, concessionProofs } = Permission.definition.relationships
+  let filter = `${Permission.definition.mappings.referenceNumber.field} eq '${escapeODataStringValue(permissionReferenceNumber)}'`
+  filter += ` and ${Permission.definition.defaultFilter}`
+  return new PredefinedQuery({
+    root: Permission,
+    filter: filter,
+    expand: [licensee, permit, concessionProofs]
+  })
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4017

This is required for IWTF-4017 as we will need a new function within the Sales API to retrieve data about a permission based on its full reference number. See https://github.com/DEFRA/rod-licensing/pull/1957 for further implementation.