### PR TITLE
Add new route to Sales API connector

### DIFF
--- a/packages/connectors-lib/src/__tests__/sales-api-connector.spec.js
+++ b/packages/connectors-lib/src/__tests__/sales-api-connector.spec.js
@@ -643,4 +643,17 @@ describe('sales-api-connector', () => {
       })
     })
   })
+
+  describe('preparePermissionDataForRenewal', () => {
+    it('retrieves all items using .getAll()', async () => {
+      const expectedResponse = { foo: 'bar' }
+      fetch.mockReturnValue({ ok: true, status: 200, statusText: 'OK', text: async () => JSON.stringify(expectedResponse) })
+      await expect(salesApi.preparePermissionDataForRenewal('AAAAAA')).resolves.toEqual(expectedResponse)
+      expect(fetch).toHaveBeenCalledWith('http://0.0.0.0:4000/permissionRenewalData/AAAAAA', {
+        method: 'get',
+        headers: expect.any(Object),
+        timeout: 20000
+      })
+    })
+  })
 })

--- a/packages/connectors-lib/src/sales-api-connector.js
+++ b/packages/connectors-lib/src/sales-api-connector.js
@@ -285,3 +285,13 @@ export const isSystemError = statusCode => Math.floor(statusCode / 100) === 5
  * @throws on a non-2xx response
  */
 export const getDueRecurringPayments = async date => exec2xxOrThrow(call(new URL(`/dueRecurringPayments/${date}`, urlBase), 'get'))
+
+/**
+ * Prepare permission data for renewal
+ *
+ * @param referenceNumber
+ * @returns {Promise<*>}
+ * @throws on a non-2xx response
+ */
+export const preparePermissionDataForRenewal = async referenceNumber =>
+  exec2xxOrThrow(call(new URL(`/permissionRenewalData/${referenceNumber}`, urlBase), 'get'))


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4017

This is required for IWTF-4017 as we will need a new function within the Sales API to prepare data for a recurring payment. The recurring payment job needs to be able to conenct to this new feature so this PR updates the connector. See https://github.com/DEFRA/rod-licensing/pull/1957/ for further implementation.