### PR TITLE
Correcting spelling error on conditions page

### DIFF
--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -731,7 +731,7 @@
   "terms_conds_agree_notify_self": "I agree to the licence conditions",
   "terms_conds_body_notify_self": "When you buy this licence you must:",
   "terms_conds_bulletpoint_1_notify_self": "not share your licence - it is only valid for the named licence holder",
-  "terms_conds_bulletpoint_2_notify_self": "carry proof of your licence when you go fishing and show it to our entitlement officers if asked",
+  "terms_conds_bulletpoint_2_notify_self": "carry proof of your licence when you go fishing and show it to our enforcement officers if asked",
   "terms_conds_bulletpoint_3_notify_self": "get permission to fish from the owner of the water's fishing rights, usually a fishery or angling club, in addition to having this licence",
   "terms_conds_bulletpoint_4_1_notify_self": "comply with the ",
   "terms_conds_bulletpoint_4_2_notify_self": " that apply to the area you want to fish",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4144

In the conditions page, enforcement officers is incorrectly referenced as "entitlement officers".