### PR TITLE
Hide RCP option for Junior licence purchases

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -27,23 +27,66 @@ describe('recurringPayReminderDisplay', () => {
   })
 })
 
+// describe('validForRecurringPayment', () => {
+//   it.each([
+//     [true, '12M', true, true, 'not telesales', 18],
+//     [false, '8D', true, true, 'not telesales', 18],
+//     [false, '12M', false, true, 'not telesales', 18],
+//     [false, '12M', true, false, 'not telesales', 18],
+//     [false, '12M', true, true, 'telesales', 18],
+//     [false, '12M', true, true, 'telesales', 16],
+//   ])(
+//     'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s and age is %s',
+//     (expected, length, licenceFor, recurring, telesales, age) => {
+//       process.env.CHANNEL = telesales
+//       process.env.SHOW_RECURRING_PAYMENTS = recurring
+//       const permission = getPermission({ licenceFor, length, age })
+//       const result = validForRecurringPayment(permission)
+//       expect(result).toEqual(expected)
+//     }
+//   )
+// })
+
 describe('validForRecurringPayment', () => {
-  it.each`
-    expected  | length | licenceFor | recurring | telesales        | age
-    ${true}   |'12M'   | ${true}    | ${true}   | 'not telesales'  | 18
-    ${false}  |'8D'    | ${true}    | ${true}   | 'not telesales'  | 18
-    ${false}  |'12M'   | ${false}   | ${true}   | 'not telesales'  | 18
-    ${false}  |'12M'   | ${true}    | ${false}  | 'not telesales'  | 18
-    ${false}  |'12M'   | ${true}    | ${true}   | 'telesales'      | 18
-    ${false}  |'12M'   | ${true}    | ${true}   | 'not telesales'  | 17
-  `(
-    'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',
+  it.each([
+    [true, '12M', true, true, 'not telesales', 18],
+    [false, '8D', true, true, 'not telesales', 18],
+    [false, '12M', false, true, 'not telesales', 18],
+    [false, '12M', true, false, 'not telesales', 18],
+    [false, '12M', true, true, 'telesales', 18],
+    [false, '12M', true, true, 'not telesales', 17],
+  ])(
+    'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s and age is %s',
     (expected, length, licenceFor, recurring, telesales, age) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring
-      const permission = getPermission({ reminder: 'Email', licenceFor, length, age })
+      const permission = getPermission({ licenceFor, length, age })
       const result = validForRecurringPayment(permission)
       expect(result).toEqual(expected)
     }
   )
 })
+
+// describe('validForRecurringPayment', () => {
+//   test.each`
+//     expected  | length   | licenceFor | recurring | telesales           | age
+//     ${true}   | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${18}
+//     ${false}  | ${'8D'}  | ${true}    | ${true}   | ${'not telesales'}  | ${18}
+//     ${false}  | ${'12M'} | ${false}   | ${true}   | ${'not telesales'}  | ${18}
+//     ${false}  | ${'12M'} | ${true}    | ${false}  | ${'not telesales'}  | ${18}
+//     ${false}  | ${'12M'} | ${true}    | ${true}   | ${'telesales'}      | ${18}
+//     ${false}  | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${17}
+//   `(
+//     // 'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',
+//     // '"age": age, "expected": expected, "length": length, "licenceFor": licenceFor, "recurring": recurring, "telesales": telesales',
+//     // 'should return $expected as licence length is $length, licence for you is $licenceFor, SHOW_RECURRING_PAYMENTS is $recurring, journey is $telesales, and age is $age',
+
+//     (expected, length, licenceFor, recurring, telesales, age) => {
+//       process.env.CHANNEL = telesales
+//       process.env.SHOW_RECURRING_PAYMENTS = recurring
+//       const permission = getPermission({ reminder: 'Email', licenceFor, length, age })
+//       const result = validForRecurringPayment(permission)
+//       expect(result).toEqual(expected)
+//     }
+//   )
+// })

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -37,7 +37,7 @@ describe('validForRecurringPayment', () => {
     [false, '12M', true, true, 'not telesales', 16],
     [false, '12M', true, true, 'not telesales', 17]
   ])(
-    'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s and age is %s',
+    'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',
     (expected, length, licenceFor, recurring, telesales, age) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -9,7 +9,7 @@ const getCatalog = () => ({
 const getPermission = ({ reminder, licenceFor, length, age }) => ({
   licensee: {
     preferredMethodOfReminder: reminder,
-    age: age
+    age
   },
   isLicenceForYou: licenceFor,
   licenceLength: length
@@ -28,14 +28,15 @@ describe('recurringPayReminderDisplay', () => {
 })
 
 describe('validForRecurringPayment', () => {
-  it.each([
-    [true, '12M', true, true, 'not telesales', 18],
-    [false, '8D', true, true, 'not telesales', 18],
-    [false, '12M', false, true, 'not telesales', 18],
-    [false, '12M', true, false, 'not telesales', 18],
-    [false, '12M', true, true, 'telesales', 18],
-    [false, '12M', true, true, 'not telesales', 17]
-  ])(
+  it.each`
+    expected  | length | licenceFor | recurring | telesales        | age
+    ${true}   |'12M'   | ${true}    | ${true}   | 'not telesales'  | 18
+    ${false}  |'8D'    | ${true}    | ${true}   | 'not telesales'  | 18
+    ${false}  |'12M'   | ${false}   | ${true}   | 'not telesales'  | 18
+    ${false}  |'12M'   | ${true}    | ${false}  | 'not telesales'  | 18
+    ${false}  |'12M'   | ${true}    | ${true}   | 'telesales'      | 18
+    ${false}  |'12M'   | ${true}    | ${true}   | 'not telesales'  | 17
+  `(
     'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',
     (expected, length, licenceFor, recurring, telesales, age) => {
       process.env.CHANNEL = telesales

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -8,11 +8,11 @@ const getCatalog = () => ({
 
 const getPermission = ({ reminder, licenceFor, length, age }) => ({
   licensee: {
-    preferredMethodOfReminder: reminder
+    preferredMethodOfReminder: reminder,
+    age: age
   },
   isLicenceForYou: licenceFor,
-  licenceLength: length,
-  age: age
+  licenceLength: length
 })
 
 describe('recurringPayReminderDisplay', () => {
@@ -33,7 +33,8 @@ describe('validForRecurringPayment', () => {
     [false, '8D', true, true, 'not telesales', 18],
     [false, '12M', false, true, 'not telesales', 18],
     [false, '12M', true, false, 'not telesales', 18],
-    [false, '12M', true, true, 'telesales'], 18,
+    [false, '12M', true, true, 'telesales'],
+    18,
     [false, '12M', true, true, 'not telesales', 16],
     [false, '12M', true, true, 'not telesales', 17]
   ])(
@@ -41,7 +42,7 @@ describe('validForRecurringPayment', () => {
     (expected, length, licenceFor, recurring, telesales, age) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring
-      const permission = getPermission({ licenceFor, length, age })
+      const permission = getPermission({ reminder: 'Email', licenceFor, length, age })
       const result = validForRecurringPayment(permission)
       expect(result).toEqual(expected)
     }

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -34,7 +34,6 @@ describe('validForRecurringPayment', () => {
     [false, '12M', false, true, 'not telesales', 18],
     [false, '12M', true, false, 'not telesales', 18],
     [false, '12M', true, true, 'telesales', 18],
-    [false, '12M', true, true, 'not telesales', 16],
     [false, '12M', true, true, 'not telesales', 17]
   ])(
     'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -6,12 +6,13 @@ const getCatalog = () => ({
   recurring_payment_set_up_bulletpoint_5_text: 'we will send you a text message showing the cost before the next payment is taken'
 })
 
-const getPermission = ({ reminder, licenceFor, length }) => ({
+const getPermission = ({ reminder, licenceFor, length, age }) => ({
   licensee: {
     preferredMethodOfReminder: reminder
   },
   isLicenceForYou: licenceFor,
-  licenceLength: length
+  licenceLength: length,
+  age: age
 })
 
 describe('recurringPayReminderDisplay', () => {
@@ -28,17 +29,19 @@ describe('recurringPayReminderDisplay', () => {
 
 describe('validForRecurringPayment', () => {
   it.each([
-    [true, '12M', true, true, 'not telesales'],
-    [false, '8D', true, true, 'not telesales'],
-    [false, '12M', false, true, 'not telesales'],
-    [false, '12M', true, false, 'not telesales'],
-    [false, '12M', true, true, 'telesales']
+    [true, '12M', true, true, 'not telesales', 18],
+    [false, '8D', true, true, 'not telesales', 18],
+    [false, '12M', false, true, 'not telesales', 18],
+    [false, '12M', true, false, 'not telesales', 18],
+    [false, '12M', true, true, 'telesales'], 18,
+    [false, '12M', true, true, 'not telesales', 16],
+    [false, '12M', true, true, 'not telesales', 17]
   ])(
-    'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s',
-    (expected, length, licenceFor, recurring, telesales) => {
+    'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s and age is %s',
+    (expected, length, licenceFor, recurring, telesales, age) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring
-      const permission = getPermission({ licenceFor, length })
+      const permission = getPermission({ licenceFor, length, age })
       const result = validForRecurringPayment(permission)
       expect(result).toEqual(expected)
     }

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -27,37 +27,18 @@ describe('recurringPayReminderDisplay', () => {
   })
 })
 
-// describe('validForRecurringPayment', () => {
-//   it.each([
-//     [true, '12M', true, true, 'not telesales', 18],
-//     [false, '8D', true, true, 'not telesales', 18],
-//     [false, '12M', false, true, 'not telesales', 18],
-//     [false, '12M', true, false, 'not telesales', 18],
-//     [false, '12M', true, true, 'telesales', 18],
-//     [false, '12M', true, true, 'telesales', 16],
-//   ])(
-//     'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s and age is %s',
-//     (expected, length, licenceFor, recurring, telesales, age) => {
-//       process.env.CHANNEL = telesales
-//       process.env.SHOW_RECURRING_PAYMENTS = recurring
-//       const permission = getPermission({ licenceFor, length, age })
-//       const result = validForRecurringPayment(permission)
-//       expect(result).toEqual(expected)
-//     }
-//   )
-// })
-
 describe('validForRecurringPayment', () => {
-  it.each([
-    [true, '12M', true, true, 'not telesales', 18],
-    [false, '8D', true, true, 'not telesales', 18],
-    [false, '12M', false, true, 'not telesales', 18],
-    [false, '12M', true, false, 'not telesales', 18],
-    [false, '12M', true, true, 'telesales', 18],
-    [false, '12M', true, true, 'not telesales', 17],
-  ])(
+  test.each`
+    expected  | length   | licenceFor | recurring | telesales           | age
+    ${true}   | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${18}
+    ${false}  | ${'8D'}  | ${true}    | ${true}   | ${'not telesales'}  | ${18}
+    ${false}  | ${'12M'} | ${false}   | ${true}   | ${'not telesales'}  | ${18}
+    ${false}  | ${'12M'} | ${true}    | ${false}  | ${'not telesales'}  | ${18}
+    ${false}  | ${'12M'} | ${true}    | ${true}   | ${'telesales'}      | ${18}
+    ${false}  | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${17}
+  `(
     'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s and age is %s',
-    (expected, length, licenceFor, recurring, telesales, age) => {
+    ({ expected, length, licenceFor, recurring, telesales, age }) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring
       const permission = getPermission({ licenceFor, length, age })
@@ -66,27 +47,3 @@ describe('validForRecurringPayment', () => {
     }
   )
 })
-
-// describe('validForRecurringPayment', () => {
-//   test.each`
-//     expected  | length   | licenceFor | recurring | telesales           | age
-//     ${true}   | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${18}
-//     ${false}  | ${'8D'}  | ${true}    | ${true}   | ${'not telesales'}  | ${18}
-//     ${false}  | ${'12M'} | ${false}   | ${true}   | ${'not telesales'}  | ${18}
-//     ${false}  | ${'12M'} | ${true}    | ${false}  | ${'not telesales'}  | ${18}
-//     ${false}  | ${'12M'} | ${true}    | ${true}   | ${'telesales'}      | ${18}
-//     ${false}  | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${17}
-//   `(
-//     // 'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',
-//     // '"age": age, "expected": expected, "length": length, "licenceFor": licenceFor, "recurring": recurring, "telesales": telesales',
-//     // 'should return $expected as licence length is $length, licence for you is $licenceFor, SHOW_RECURRING_PAYMENTS is $recurring, journey is $telesales, and age is $age',
-
-//     (expected, length, licenceFor, recurring, telesales, age) => {
-//       process.env.CHANNEL = telesales
-//       process.env.SHOW_RECURRING_PAYMENTS = recurring
-//       const permission = getPermission({ reminder: 'Email', licenceFor, length, age })
-//       const result = validForRecurringPayment(permission)
-//       expect(result).toEqual(expected)
-//     }
-//   )
-// })

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -30,14 +30,14 @@ describe('recurringPayReminderDisplay', () => {
 describe('validForRecurringPayment', () => {
   test.each`
     expected  | length   | licenceFor | recurring | telesales           | birthDate
-    ${true}   | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${18}
-    ${false}  | ${'8D'}  | ${true}    | ${true}   | ${'not telesales'}  | ${18}
-    ${false}  | ${'12M'} | ${false}   | ${true}   | ${'not telesales'}  | ${18}
-    ${false}  | ${'12M'} | ${true}    | ${false}  | ${'not telesales'}  | ${18}
-    ${false}  | ${'12M'} | ${true}    | ${true}   | ${'telesales'}      | ${18}
-    ${false}  | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${16}
+    ${true}   | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${'1946-01-01'}
+    ${false}  | ${'8D'}  | ${true}    | ${true}   | ${'not telesales'}  | ${'1946-01-01'}
+    ${false}  | ${'12M'} | ${false}   | ${true}   | ${'not telesales'}  | ${'1946-01-01'}
+    ${false}  | ${'12M'} | ${true}    | ${false}  | ${'not telesales'}  | ${'1946-01-01'}
+    ${false}  | ${'12M'} | ${true}    | ${true}   | ${'telesales'}      | ${'1946-01-01'}
+    ${false}  | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${'2010-01-01'}
   `(
-    'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',
+    'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and birthDate is %s',
     ({ expected, length, licenceFor, recurring, telesales, birthDate }) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -6,10 +6,10 @@ const getCatalog = () => ({
   recurring_payment_set_up_bulletpoint_5_text: 'we will send you a text message showing the cost before the next payment is taken'
 })
 
-const getPermission = ({ reminder, licenceFor, length, age }) => ({
+const getPermission = ({ reminder, licenceFor, length, birthDate }) => ({
   licensee: {
     preferredMethodOfReminder: reminder,
-    age
+    birthDate
   },
   isLicenceForYou: licenceFor,
   licenceLength: length
@@ -29,19 +29,19 @@ describe('recurringPayReminderDisplay', () => {
 
 describe('validForRecurringPayment', () => {
   test.each`
-    expected  | length   | licenceFor | recurring | telesales           | age
+    expected  | length   | licenceFor | recurring | telesales           | birthDate
     ${true}   | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${18}
     ${false}  | ${'8D'}  | ${true}    | ${true}   | ${'not telesales'}  | ${18}
     ${false}  | ${'12M'} | ${false}   | ${true}   | ${'not telesales'}  | ${18}
     ${false}  | ${'12M'} | ${true}    | ${false}  | ${'not telesales'}  | ${18}
     ${false}  | ${'12M'} | ${true}    | ${true}   | ${'telesales'}      | ${18}
-    ${false}  | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${17}
+    ${false}  | ${'12M'} | ${true}    | ${true}   | ${'not telesales'}  | ${16}
   `(
-    'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s and age is %s',
-    ({ expected, length, licenceFor, recurring, telesales, age }) => {
+    'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',
+    ({ expected, length, licenceFor, recurring, telesales, birthDate }) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring
-      const permission = getPermission({ licenceFor, length, age })
+      const permission = getPermission({ licenceFor, length, birthDate })
       const result = validForRecurringPayment(permission)
       expect(result).toEqual(expected)
     }

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -33,8 +33,7 @@ describe('validForRecurringPayment', () => {
     [false, '8D', true, true, 'not telesales', 18],
     [false, '12M', false, true, 'not telesales', 18],
     [false, '12M', true, false, 'not telesales', 18],
-    [false, '12M', true, true, 'telesales'],
-    18,
+    [false, '12M', true, true, 'telesales', 18],
     [false, '12M', true, true, 'not telesales', 16],
     [false, '12M', true, true, 'not telesales', 17]
   ])(

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -13,10 +13,10 @@ export const recurringPayReminderDisplay = (permission, mssgs) => {
 }
 
 export const validForRecurringPayment = permission => {
-  const licenseeAge = moment().tz(SERVICE_LOCAL_TIME).diff(moment(permission.licensee.birthDate), 'years');
+  const licenseeAge = moment().tz(SERVICE_LOCAL_TIME).diff(moment(permission.licensee.birthDate), 'years')
   return process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
     permission.licenceLength === '12M' &&
     permission.isLicenceForYou &&
     licenseeAge > JUNIOR_MAX_AGE &&
-    process.env.CHANNEL?.toLowerCase() !== 'telesales';
+    process.env.CHANNEL?.toLowerCase() !== 'telesales'
 }

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -14,5 +14,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
-  permission.licensee.age > JUNIOR_MAX_AGE + 1 &&
+  permission.licensee.birthDate > JUNIOR_MAX_AGE &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -13,5 +13,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
-  permission.licensee.age >= 17 &&
+  permission.licensee.age > 17 &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -1,6 +1,6 @@
 import { HOW_CONTACTED } from './mapping-constants.js'
 
-const min_age_for_recurring_payment = 18;
+const MIN_AGE_FOR_RECURRING_PAYMENT = 18
 
 export const recurringPayReminderDisplay = (permission, mssgs) => {
   if (permission.licensee.preferredMethodOfReminder === HOW_CONTACTED.email) {
@@ -15,5 +15,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
-  permission.licensee.age >= min_age_for_recurring_payment &&
+  permission.licensee.age >= MIN_AGE_FOR_RECURRING_PAYMENT &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -13,4 +13,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
+  permission.licensee.age >= 17 &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -1,6 +1,5 @@
 import { HOW_CONTACTED } from './mapping-constants.js'
-
-const MIN_AGE_FOR_RECURRING_PAYMENT = 18
+import { isJunior } from '../ages.js'
 
 export const recurringPayReminderDisplay = (permission, mssgs) => {
   if (permission.licensee.preferredMethodOfReminder === HOW_CONTACTED.email) {
@@ -15,5 +14,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
-  permission.licensee.age >= MIN_AGE_FOR_RECURRING_PAYMENT &&
+  permission.licensee.age > isJunior &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -1,5 +1,5 @@
 import { HOW_CONTACTED } from './mapping-constants.js'
-import { isJunior } from '../ages.js'
+import { JUNIOR_MAX_AGE } from '../../../business-rules-lib/src/util/ages.js'
 
 export const recurringPayReminderDisplay = (permission, mssgs) => {
   if (permission.licensee.preferredMethodOfReminder === HOW_CONTACTED.email) {
@@ -14,5 +14,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
-  permission.licensee.age > isJunior &&
+  permission.licensee.age > JUNIOR_MAX_AGE + 1 &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -1,5 +1,7 @@
 import { HOW_CONTACTED } from './mapping-constants.js'
 import { JUNIOR_MAX_AGE } from '../../../business-rules-lib/src/util/ages.js'
+import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib';
+import moment from 'moment-timezone';
 
 export const recurringPayReminderDisplay = (permission, mssgs) => {
   if (permission.licensee.preferredMethodOfReminder === HOW_CONTACTED.email) {
@@ -10,9 +12,11 @@ export const recurringPayReminderDisplay = (permission, mssgs) => {
   return mssgs.recurring_payment_set_up_bulletpoint_5_text
 }
 
-export const validForRecurringPayment = permission =>
-  process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
-  permission.licenceLength === '12M' &&
-  permission.isLicenceForYou &&
-  permission.licensee.birthDate > JUNIOR_MAX_AGE &&
-  process.env.CHANNEL?.toLowerCase() !== 'telesales'
+export const validForRecurringPayment = permission => {
+  const licenseeAge = moment().tz(SERVICE_LOCAL_TIME).diff(moment(permission.licensee.birthDate), 'years');
+  return process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
+    permission.licenceLength === '12M' &&
+    permission.isLicenceForYou &&
+    licenseeAge > JUNIOR_MAX_AGE &&
+    process.env.CHANNEL?.toLowerCase() !== 'telesales';
+}

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -1,5 +1,7 @@
 import { HOW_CONTACTED } from './mapping-constants.js'
 
+const min_age_for_recurring_payment = 18;
+
 export const recurringPayReminderDisplay = (permission, mssgs) => {
   if (permission.licensee.preferredMethodOfReminder === HOW_CONTACTED.email) {
     return mssgs.recurring_payment_set_up_bulletpoint_5_email
@@ -13,5 +15,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
-  permission.licensee.age > 17 &&
+  permission.licensee.age >= min_age_for_recurring_payment &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4066

Anglers under 17 y/o should not be offered the option to set up recurring payments, so it the option has been hidden.