### PR TITLE
RP job sends payment requests to GOVUK Pay

### DIFF
--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -37,7 +37,7 @@ describe('validForRecurringPayment', () => {
     [false, '12M', true, true, 'not telesales', 16],
     [false, '12M', true, true, 'not telesales', 17]
   ])(
-    'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s and age is %s',
+    'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',
     (expected, length, licenceFor, recurring, telesales, age) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -8,11 +8,11 @@ const getCatalog = () => ({
 
 const getPermission = ({ reminder, licenceFor, length, age }) => ({
   licensee: {
-    preferredMethodOfReminder: reminder
+    preferredMethodOfReminder: reminder,
+    age: age
   },
   isLicenceForYou: licenceFor,
-  licenceLength: length,
-  age: age
+  licenceLength: length
 })
 
 describe('recurringPayReminderDisplay', () => {
@@ -33,7 +33,8 @@ describe('validForRecurringPayment', () => {
     [false, '8D', true, true, 'not telesales', 18],
     [false, '12M', false, true, 'not telesales', 18],
     [false, '12M', true, false, 'not telesales', 18],
-    [false, '12M', true, true, 'telesales'], 18,
+    [false, '12M', true, true, 'telesales'],
+    18,
     [false, '12M', true, true, 'not telesales', 16],
     [false, '12M', true, true, 'not telesales', 17]
   ])(
@@ -41,7 +42,7 @@ describe('validForRecurringPayment', () => {
     (expected, length, licenceFor, recurring, telesales, age) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring
-      const permission = getPermission({ licenceFor, length, age })
+      const permission = getPermission({ reminder: 'Email', licenceFor, length, age })
       const result = validForRecurringPayment(permission)
       expect(result).toEqual(expected)
     }

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -34,7 +34,6 @@ describe('validForRecurringPayment', () => {
     [false, '12M', false, true, 'not telesales', 18],
     [false, '12M', true, false, 'not telesales', 18],
     [false, '12M', true, true, 'telesales', 18],
-    [false, '12M', true, true, 'not telesales', 16],
     [false, '12M', true, true, 'not telesales', 17]
   ])(
     'should return %s as licence length is %s, licence for you is %s, SHOW_RECURRING_PAYMENTS is %s, journey is %s, and age is %s',

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -6,12 +6,13 @@ const getCatalog = () => ({
   recurring_payment_set_up_bulletpoint_5_text: 'we will send you a text message showing the cost before the next payment is taken'
 })
 
-const getPermission = ({ reminder, licenceFor, length }) => ({
+const getPermission = ({ reminder, licenceFor, length, age }) => ({
   licensee: {
     preferredMethodOfReminder: reminder
   },
   isLicenceForYou: licenceFor,
-  licenceLength: length
+  licenceLength: length,
+  age: age
 })
 
 describe('recurringPayReminderDisplay', () => {
@@ -28,17 +29,19 @@ describe('recurringPayReminderDisplay', () => {
 
 describe('validForRecurringPayment', () => {
   it.each([
-    [true, '12M', true, true, 'not telesales'],
-    [false, '8D', true, true, 'not telesales'],
-    [false, '12M', false, true, 'not telesales'],
-    [false, '12M', true, false, 'not telesales'],
-    [false, '12M', true, true, 'telesales']
+    [true, '12M', true, true, 'not telesales', 18],
+    [false, '8D', true, true, 'not telesales', 18],
+    [false, '12M', false, true, 'not telesales', 18],
+    [false, '12M', true, false, 'not telesales', 18],
+    [false, '12M', true, true, 'telesales'], 18,
+    [false, '12M', true, true, 'not telesales', 16],
+    [false, '12M', true, true, 'not telesales', 17]
   ])(
-    'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s',
-    (expected, length, licenceFor, recurring, telesales) => {
+    'should return %s as licence length is %s, licence for you is %s and SHOW_RECURRING_PAYMENTS is %s and journey is %s and age is %s',
+    (expected, length, licenceFor, recurring, telesales, age) => {
       process.env.CHANNEL = telesales
       process.env.SHOW_RECURRING_PAYMENTS = recurring
-      const permission = getPermission({ licenceFor, length })
+      const permission = getPermission({ licenceFor, length, age })
       const result = validForRecurringPayment(permission)
       expect(result).toEqual(expected)
     }

--- a/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
+++ b/packages/gafl-webapp-service/src/processors/__tests__/recurring-pay-helper.spec.js
@@ -33,8 +33,7 @@ describe('validForRecurringPayment', () => {
     [false, '8D', true, true, 'not telesales', 18],
     [false, '12M', false, true, 'not telesales', 18],
     [false, '12M', true, false, 'not telesales', 18],
-    [false, '12M', true, true, 'telesales'],
-    18,
+    [false, '12M', true, true, 'telesales', 18],
     [false, '12M', true, true, 'not telesales', 16],
     [false, '12M', true, true, 'not telesales', 17]
   ])(

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -13,5 +13,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
-  permission.licensee.age >= 17 &&
+  permission.licensee.age > 17 &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -1,6 +1,6 @@
 import { HOW_CONTACTED } from './mapping-constants.js'
 
-const min_age_for_recurring_payment = 18;
+const MIN_AGE_FOR_RECURRING_PAYMENT = 18
 
 export const recurringPayReminderDisplay = (permission, mssgs) => {
   if (permission.licensee.preferredMethodOfReminder === HOW_CONTACTED.email) {
@@ -15,5 +15,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
-  permission.licensee.age >= min_age_for_recurring_payment &&
+  permission.licensee.age >= MIN_AGE_FOR_RECURRING_PAYMENT &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -13,4 +13,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
+  permission.licensee.age >= 17 &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -1,5 +1,7 @@
 import { HOW_CONTACTED } from './mapping-constants.js'
 
+const min_age_for_recurring_payment = 18;
+
 export const recurringPayReminderDisplay = (permission, mssgs) => {
   if (permission.licensee.preferredMethodOfReminder === HOW_CONTACTED.email) {
     return mssgs.recurring_payment_set_up_bulletpoint_5_email
@@ -13,5 +15,5 @@ export const validForRecurringPayment = permission =>
   process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' &&
   permission.licenceLength === '12M' &&
   permission.isLicenceForYou &&
-  permission.licensee.age > 17 &&
+  permission.licensee.age >= min_age_for_recurring_payment &&
   process.env.CHANNEL?.toLowerCase() !== 'telesales'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3657

Once the recurring payment has been provisioned in DynamoDB (see IWTF-4017) and the correct concessions have been applied (see IWTF-3916) then we are ready to begin processing payment.

For each permission created by the RP job, we should send a request for payment to GOV.UK Pay.

