### PR TITLE
RP job sends payment requests to GOVUK Pay

### DIFF
--- a/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
+++ b/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
@@ -9,6 +9,9 @@ jest.mock('@defra-fish/connectors-lib', () => ({
       licensee: { countryCode: 'GB-ENG' }
     })),
     createTransaction: jest.fn()
+  },
+  govUkPayApi: {
+    finaliseTransaction: jest.fn()
   }
 }))
 
@@ -47,6 +50,7 @@ describe('recurring-payments-processor', () => {
   it('console log displays "Recurring Payments found: " when env is true', async () => {
     process.env.RUN_RECURRING_PAYMENTS = 'true'
     const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn())
+    // salesApi.getDueRecurringPayments.mockReturnValueOnce([{ expanded: { activePermission: { entity: { referenceNumber: '1' } } } }])
 
     await processRecurringPayments()
 

--- a/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
+++ b/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
@@ -43,7 +43,7 @@ describe('recurring-payments-processor', () => {
     const date = new Date().toISOString().split('T')[0]
 
     await processRecurringPayments()
-
+ 
     expect(salesApi.getDueRecurringPayments).toHaveBeenCalledWith(date)
   })
 

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -31,14 +31,18 @@ const processRecurringPayment = async record => {
   console.log('Creating new transaction based on', referenceNumber)
   try {
     const response = await salesApi.createTransaction(transactionData)
+    if (!response || !response.id || !response.payment || !response.payment.amount) {
+      throw new Error('Invalid response structure from createTransaction')
+    }
     console.log('New transaction created:', response)
 
     await finaliseTransactionWithGovUkPay(response.id, response.payment.amount)
   } catch (e) {
-    console.log('Error creating transaction', JSON.stringify(transactionData))
+    console.error('Error creating or finalising transaction', e)
     throw e
   }
 }
+
 
 const processPermissionData = async referenceNumber => {
   console.log('Preparing data based on', referenceNumber)

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -1,6 +1,12 @@
 import moment from 'moment-timezone'
 import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
 import { salesApi, govUkPayApi } from '@defra-fish/connectors-lib'
+// import {
+//   GOVUK_PAY_ERROR_STATUS_CODES,
+//   PAYMENT_JOURNAL_STATUS_CODES,
+//   TRANSACTION_SOURCE,
+//   PAYMENT_TYPE
+// } from '@defra-fish/business-rules-lib'
 
 const finaliseTransactionWithGovUkPay = async (transactionId, amount) => {
   try {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3657

Once the recurring payment has been provisioned in DynamoDB (see IWTF-4017) and the correct concessions have been applied (see IWTF-3916) then we are ready to begin processing payment.

For each permission created by the RP job, we should send a request for payment to GOV.UK Pay.