### PR TITLE
Silence Sass deprecation warnings from dependencies

### DIFF
--- a/packages/gafl-webapp-service/build/gulpfile.cjs
+++ b/packages/gafl-webapp-service/build/gulpfile.cjs
@@ -66,7 +66,8 @@ const buildSass = () => {
     .pipe(
       sass({
         outputStyle: 'compressed',
-        includePaths: path.join('..', 'node_modules')
+        includePaths: path.join('..', 'node_modules'),
+        quietDeps: true
       }).on('error', sass.logError)
     )
     .pipe(sourcemaps.write())


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3845

This applies the suggested change in https://frontend.design-system.service.gov.uk/import-css/#silence-deprecation-warnings-from-dependencies-in-dart-sass

Deprecation warnings in our own Sass code will still be raised.