### PR TITLE
Correcting Cookie Banner Service Name

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -130,7 +130,7 @@
   "analytics_banner_reject": "Gwrthod cwcis dadansoddol",
   "analytics_banner_rejection_1": "Rydych wedi gwrthod cwcis ychwanegol. Gallwch ",
   "analytics_banner_rejection_2": "  ar unrhyw adeg.",
-  "analytics_banner_title": "Cwcis gwasanaeth Trwydded bysgota â gwialen",
+  "analytics_banner_title": "Cwcis gwasanaeth 'Cael trwydded bysgota â gwialen'",
   "analytics_banner_view_cookies_link": "Gweld pob cwci",
   "and": " a ",
   "back": "Yn ôl",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -130,7 +130,7 @@
   "analytics_banner_reject": "Reject analytics cookies",
   "analytics_banner_rejection_1": "You have rejected additional cookies. You can ",
   "analytics_banner_rejection_2": " at any time",
-  "analytics_banner_title": "Cookies on 'Get a fishing rod licence'",
+  "analytics_banner_title": "Cookies on 'Get a rod fishing licence'",
   "analytics_banner_view_cookies_link": "View cookies",
   "and": " and ",
   "back": "Back",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4208

Service name in English was incorrect.

Furthermore, despite not being part of this ticket, but being in the same scope, the Welsh translation was also corrected to match the English better.