### PR TITLE
RCP T&C - Shrink Subheadings

### DIFF
--- a/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
@@ -26,11 +26,11 @@
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_3 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_4 }}</p>
 
-        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading }}</h2>
+        <h3 class="govuk-heading-s">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_1 }}<a href="https://www.gov.uk/call-charges" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_call_charges_link }}</a>{{ mssgs.full_stop }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_1 }}<a href="mailto:enquiries@environment-agency.gov.uk" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_enquiries_link }}</a>{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_2 }}</p>
 
-        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_bank_subheading }}</h2>
+        <h3 class="govuk-heading-s">{{ mssgs.recurring_terms_conditions_cancel_bank_subheading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_bank_body }}</p>
 
         <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_security_heading }}</h1>

--- a/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
@@ -20,20 +20,20 @@
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_reminders_body_1 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_reminders_body_2_1 }}<a href="mailto:enquiries@environment-agency.gov.uk" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_enquiries_link }}</a>{{ mssgs.recurring_terms_conditions_payment_reminders_body_2_2 }}<a href="https://www.gov.uk/call-charges" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_call_charges_link }}</a>{{ mssgs.full_stop }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_heading }}</h1>
+        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_heading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_1 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_2_1 }}<a href="{{ uri.refund }}" class="govuk-link">{{ mssgs.recurring_terms_conditions_refund_link }}</a>{{ mssgs.recurring_terms_conditions_cancel_body_2_2 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_3 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_4 }}</p>
 
-        <h3 class="govuk-heading-s">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading }}</h2>
+        <h3 class="govuk-heading-s">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading }}</h3>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_1 }}<a href="https://www.gov.uk/call-charges" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_call_charges_link }}</a>{{ mssgs.full_stop }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_1 }}<a href="mailto:enquiries@environment-agency.gov.uk" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_enquiries_link }}</a>{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_2 }}</p>
 
-        <h3 class="govuk-heading-s">{{ mssgs.recurring_terms_conditions_cancel_bank_subheading }}</h2>
+        <h3 class="govuk-heading-s">{{ mssgs.recurring_terms_conditions_cancel_bank_subheading }}</h3>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_bank_body }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_security_heading }}</h1>
+        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_security_heading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_security_body }}<a href="{{ uri.privacy }}" class="govuk-link">{{ mssgs.recurring_terms_conditions_privacy_link }}</a>{{ mssgs.full_stop }}</p>
     </div>
 </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4244

The sub-headings `Cancel by phone or email` and `Cancel through your bank` are supposed to be visually smaller than the headings, but are appearing the same size.

This ticket is just to adjust them a slightly with a shrinking potion 🧪 

Also took the time to ensure all closing tags matched the opener tags.