### PR TITLE
Update postal fulfilment information banner

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -578,7 +578,7 @@
   "payment_failed_title_3": "Your payment has failed",
   "phone_number": "rhif ffôn",
   "pound": "£",
-  "notification_heading": "Bydd llythyr wedi’i argraffu yn cymryd lle trwyddedau cerdyn wedi’u gorchuddio â phlastig o 31 Mai 2024.",
+  "notification_heading": "Mae llythyr wedi’i argraffu wedi cymryd lle trwyddedau cerdyn wedi’u gorchuddio â phlastig ers 31 Mai 2024",
   "notification_label": "Pwysig",
   "notification_text": "Mae dewis derbyn trwydded drwy e-bost neu neges destun yn helpu i leihau faint o bapur yr ydym yn ei ddefnyddio, ac yn buddsoddi mwy o incwm trwyddedau i’r sector pysgota.",
   "privacy_dp_officer_body_1": "Mae ein Swyddog Diogelu Data yn gyfrifol am gyngor annibynnol a monitro defnydd Asiantaeth yr Amgylchedd o ddata personol. Gallwch ddarllen ein  ",

--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -141,7 +141,6 @@
   "buy_different_licence": "Prynu trwydded wahanol",
   "change_licence_details_you": "Adolygu neu newid manylion eich trwydded",
   "change_licence_details_other": "Adolygu neu newid manylion y drwydded",
-  "change_licence_number": "Newid rhif y drwydded",
   "check_conf_contact_correct": "Mae’n gywir",
   "check_conf_contact_title_1": "A yw’r ",
   "check_conf_contact_title_2": " yn gywir?",

--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -141,6 +141,7 @@
   "buy_different_licence": "Prynu trwydded wahanol",
   "change_licence_details_you": "Adolygu neu newid manylion eich trwydded",
   "change_licence_details_other": "Adolygu neu newid manylion y drwydded",
+  "change_licence_number": "Newid rhif y drwydded",
   "check_conf_contact_correct": "Mae’n gywir",
   "check_conf_contact_title_1": "A yw’r ",
   "check_conf_contact_title_2": " yn gywir?",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -141,6 +141,7 @@
   "buy_different_licence": "Buy a different licence",
   "change_licence_details_you": "Review or change the licence details",
   "change_licence_details_other": "Review or change the licence details",
+  "change_licence_number": "Change licence number",
   "choose_payment_heading": "Would you like to set up a recurring card payment to renew this licence each year?",
   "choose_payment_error": "Select yes or no",
   "choose_payment_hint": "A recurring card payment is an automatic payment taken from your debit or credit card",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -141,7 +141,6 @@
   "buy_different_licence": "Buy a different licence",
   "change_licence_details_you": "Review or change the licence details",
   "change_licence_details_other": "Review or change the licence details",
-  "change_licence_number": "Change licence number",
   "choose_payment_heading": "Would you like to set up a recurring card payment to renew this licence each year?",
   "choose_payment_error": "Select yes or no",
   "choose_payment_hint": "A recurring card payment is an automatic payment taken from your debit or credit card",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -509,7 +509,7 @@
   "newsletter_error_set_email": "Enter an email address in the correct format, like name@example.com",
   "newsletter_subscribe": "Stay up to date with the latest news on angling, fisheries and how we spend your licence money. You can unsubscribe at any time.",
   "newsletter_title": "Would you like to receive our email newsletter?",
-  "notification_heading": "Plastic-coated card licences will be replaced by a printed letter from 31 May 2024.",
+  "notification_heading": "Plastic-coated card licences were replaced by printed letters on 31 May 2024.",
   "notification_label": "Important",
   "notification_text": "Choosing to get a licence by email or text message helps reduce the paper we use and invests more licence income back into fishing.",
   "no_licence_req_body": "How much will this cost?",

--- a/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
@@ -20,20 +20,20 @@
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_reminders_body_1 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_reminders_body_2_1 }}<a href="mailto:enquiries@environment-agency.gov.uk" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_enquiries_link }}</a>{{ mssgs.recurring_terms_conditions_payment_reminders_body_2_2 }}<a href="https://www.gov.uk/call-charges" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_call_charges_link }}</a>{{ mssgs.full_stop }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_heading }}</h1>
+        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_heading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_1 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_2_1 }}<a href="{{ uri.refund }}" class="govuk-link">{{ mssgs.recurring_terms_conditions_refund_link }}</a>{{ mssgs.recurring_terms_conditions_cancel_body_2_2 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_3 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_4 }}</p>
 
-        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading }}</h2>
+        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading }}</h3>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_1 }}<a href="https://www.gov.uk/call-charges" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_call_charges_link }}</a>{{ mssgs.full_stop }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_1 }}<a href="mailto:enquiries@environment-agency.gov.uk" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_enquiries_link }}</a>{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_2 }}</p>
 
-        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_bank_subheading }}</h2>
+        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_bank_subheading }}</h3>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_bank_body }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_security_heading }}</h1>
+        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_security_heading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_security_body }}<a href="{{ uri.privacy }}" class="govuk-link">{{ mssgs.recurring_terms_conditions_privacy_link }}</a>{{ mssgs.full_stop }}</p>
     </div>
 </div>

--- a/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
@@ -20,20 +20,20 @@
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_reminders_body_1 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_reminders_body_2_1 }}<a href="mailto:enquiries@environment-agency.gov.uk" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_enquiries_link }}</a>{{ mssgs.recurring_terms_conditions_payment_reminders_body_2_2 }}<a href="https://www.gov.uk/call-charges" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_call_charges_link }}</a>{{ mssgs.full_stop }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_heading }}</h2>
+        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_heading }}</h1>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_1 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_2_1 }}<a href="{{ uri.refund }}" class="govuk-link">{{ mssgs.recurring_terms_conditions_refund_link }}</a>{{ mssgs.recurring_terms_conditions_cancel_body_2_2 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_3 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_4 }}</p>
 
-        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading }}</h3>
+        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_1 }}<a href="https://www.gov.uk/call-charges" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_call_charges_link }}</a>{{ mssgs.full_stop }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_1 }}<a href="mailto:enquiries@environment-agency.gov.uk" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_enquiries_link }}</a>{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_2 }}</p>
 
-        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_bank_subheading }}</h3>
+        <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_bank_subheading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_bank_body }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_security_heading }}</h2>
+        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_security_heading }}</h1>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_security_body }}<a href="{{ uri.privacy }}" class="govuk-link">{{ mssgs.recurring_terms_conditions_privacy_link }}</a>{{ mssgs.full_stop }}</p>
     </div>
 </div>

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -100,7 +100,7 @@
                 <div id="ref-ro" class="govuk-body-m initially-hidden">
                     <span class="govuk-!-font-weight-bold">{{ mssgs.identify_label_licence_ending }}</span>
                     <span class="govuk-body-m govuk-!-font-weight-bold">{{ payload.referenceNumber if payload.referenceNumber else data.referenceNumber }}
-                        &nbsp;&nbsp;<a id="change" href="#" class="govuk-link">{{ mssgs.licence_summary_change }}</a>
+                        &nbsp;&nbsp;<a id="change" href="#" class="govuk-link">{{ mssgs.change_licence_number }}</a>
                     </span>
                 </div>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4241

Now that we have usefully migrated our postal licence from Paragon to Notify, we need to update the banner on our service on the buy/fulfilment page.