### PR TITLE
Upgrade rod-licencing to use AWS SDK v3 for DynamoDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## v1.50.0-rc.8 (2024-09-25)
+
+#### :bug: Bug Fix
+* `gafl-webapp-service`
+  * [#2054](https://github.com/DEFRA/rod-licensing/pull/2054) Correcting styling for RCP T&C headers ([@lailien3](https://github.com/lailien3))
+
+#### Committers: 2
+- Scott Dormand ([@ScottDormand96](https://github.com/ScottDormand96))
+- laila aleissa ([@lailien3](https://github.com/lailien3))
+
 ## v1.50.0-rc.7 (2024-09-18)
 
 #### :rocket: Enhancement

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "npmClient": "npm",
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.656.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.17.2",
         "@babel/eslint-parser": "^7.17.0",
@@ -66,6 +69,709 @@
       },
       "engines": {
         "node": "^12.14.1 || >=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.656.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.656.0.tgz",
+      "integrity": "sha512-a7nzK4tGZHlg1IY63aGmdSlVLYpdYFwjIDFx3vQwNAzStwh8pbb7Fv8jLFTAi33ZNHM7H4mASwvgFbu8ZfbMVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.654.0",
+        "@aws-sdk/client-sts": "3.654.0",
+        "@aws-sdk/core": "3.654.0",
+        "@aws-sdk/credential-provider-node": "3.654.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.654.0",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.3",
+        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.18",
+        "@smithy/util-defaults-mode-node": "^3.0.18",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.5",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.654.0.tgz",
+      "integrity": "sha512-4kBxs2IzCDtj6a6lRXa/lXK5wWpMGzwKtb+HMXf/rJYVM6x7wYRzc1hYrOd3DYkFQ/sR3dUFj+0mTP0os3aAbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.654.0",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.3",
+        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.18",
+        "@smithy/util-defaults-mode-node": "^3.0.18",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.654.0.tgz",
+      "integrity": "sha512-gbHrKsEnaAtmkNCVQzLyiqMzpDaThV/bWl/ODEklI+t6stW3Pe3oDMstEHLfJ6JU5g8sYnx4VLuxlnJMtUkvPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.654.0",
+        "@aws-sdk/credential-provider-node": "3.654.0",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.3",
+        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.18",
+        "@smithy/util-defaults-mode-node": "^3.0.18",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.654.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.654.0.tgz",
+      "integrity": "sha512-tyHa8jsBy+/NQZFHm6Q2Q09Vi9p3EH4yPy6PU8yPewpi2klreObtrUd0anJa6nzjS9SSuqnlZWsRic3cQ4QwCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.654.0",
+        "@aws-sdk/core": "3.654.0",
+        "@aws-sdk/credential-provider-node": "3.654.0",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.3",
+        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.18",
+        "@smithy/util-defaults-mode-node": "^3.0.18",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.654.0.tgz",
+      "integrity": "sha512-4Rwx7BVaNaFqmXBDmnOkMbyuIFFbpZ+ru4lr660p45zY1QoNNSalechfoRffcokLFOZO+VWEJkdcorPUUU993w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.4.3",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/signature-v4": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.654.0.tgz",
+      "integrity": "sha512-kogsx3Ql81JouHS7DkheCDU9MYAvK0AokxjcshDveGmf7BbgbWCA8Fnb9wjQyNDaOXNvkZu8Z8rgkX91z324/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.654.0.tgz",
+      "integrity": "sha512-tgmAH4MBi/aDR882lfw48+tDV95ZH3GWc1Eoe6DpNLiM3GN2VfU/cZwuHmi6aq+vAbdIlswBHJ/+va0fOvlyjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-stream": "^3.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.654.0.tgz",
+      "integrity": "sha512-DKSdaNu2hwdmuvnm9KnA0NLqMWxxmxSOLWjSUSoFIm++wGXUjPrRMFYKvMktaXnPuyf5my8gF/yGbwzPZ8wlTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.654.0",
+        "@aws-sdk/credential-provider-http": "3.654.0",
+        "@aws-sdk/credential-provider-process": "3.654.0",
+        "@aws-sdk/credential-provider-sso": "3.654.0",
+        "@aws-sdk/credential-provider-web-identity": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.654.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.654.0.tgz",
+      "integrity": "sha512-wPV7CNYaXDEc+SS+3R0v8SZwkHRUE1z2k2j1d49tH5QBDT4tb/k2V/biXWkwSk3hbR+IMWXmuhJDv/5lybhIvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.654.0",
+        "@aws-sdk/credential-provider-http": "3.654.0",
+        "@aws-sdk/credential-provider-ini": "3.654.0",
+        "@aws-sdk/credential-provider-process": "3.654.0",
+        "@aws-sdk/credential-provider-sso": "3.654.0",
+        "@aws-sdk/credential-provider-web-identity": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.654.0.tgz",
+      "integrity": "sha512-PmQoo8sZ9Q2Ow8OMzK++Z9lI7MsRUG7sNq3E72DVA215dhtTICTDQwGlXH2AAmIp7n+G9LLRds+4wo2ehG4mkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.654.0.tgz",
+      "integrity": "sha512-7GFme6fWEdA/XYKzZPOAdj/jS6fMBy1NdSIZsDXikS0v9jU+ZzHrAaWt13YLzHyjgxB9Sg9id9ncdY1IiubQXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.654.0",
+        "@aws-sdk/token-providers": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.654.0.tgz",
+      "integrity": "sha512-6a2g9gMtZToqSu+CusjNK5zvbLJahQ9di7buO3iXgbizXpLXU1rnawCpWxwslMpT5fLgMSKDnKDrr6wdEk7jSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.654.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.572.0.tgz",
+      "integrity": "sha512-CzuRWMj/xtN9p9eP915nlPmlyniTzke732Ow/M60++gGgB3W+RtZyFftw3TEx+NzNhd1tH54dEcGiWdiNaBz3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.654.0.tgz",
+      "integrity": "sha512-oHmSZYWsoGSYTjrohu/EFbtthGZOr9qIU8ewDzzhI2ceCEvCy6w7Vd/Ov1pG6C3faNEGAGNZynOmYJBeF2XIOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "3.572.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.654.0.tgz",
+      "integrity": "sha512-rxGgVHWKp8U2ubMv+t+vlIk7QYUaRCHaVpmUlJv0Wv6Q0KeO9a42T9FxHphjOTlCGQOLcjCreL9CF8Qhtb4mdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.654.0.tgz",
+      "integrity": "sha512-OQYb+nWlmASyXfRb989pwkJ9EVUMP1CrKn2eyTk3usl20JZmKo2Vjis6I0tLUkMSxMhnBJJlQKyWkRpD/u1FVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.654.0.tgz",
+      "integrity": "sha512-gKSomgltKVmsT8sC6W7CrADZ4GHwX9epk3GcH6QhebVO3LA9LRbkL3TwOPUXakxxOLLUTYdOZLIOtFf7iH00lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.654.0.tgz",
+      "integrity": "sha512-liCcqPAyRsr53cy2tYu4qeH4MMN0eh9g6k56XzI5xd4SghXH5YWh4qOYAlQ8T66ZV4nPMtD8GLtLXGzsH8moFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.654.0.tgz",
+      "integrity": "sha512-ydGOrXJxj3x0sJhsXyTmvJVLAE0xxuTWFJihTl67RtaO7VRNtd82I3P3bwoMMaDn5WpmV5mPo8fEUDRlBm3fPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.654.0.tgz",
+      "integrity": "sha512-D8GeJYmvbfWkQDtTB4owmIobSMexZel0fOoetwvgCQ/7L8VPph3Q2bn1TRRIXvH7wdt6DcDxA3tKMHPBkT3GlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.654.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.654.0.tgz",
+      "integrity": "sha512-i902fcBknHs0Irgdpi62+QMvzxE+bczvILXigYrlHL4+PiEnlMVpni5L5W1qCkNZXf8AaMrSBuR1NZAGp6UOUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-endpoints": "^2.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.654.0.tgz",
+      "integrity": "sha512-ykYAJqvnxLt7wfrqya28wuH3/7NdrwzfiFd7NqEVQf7dXVxL5RPEpD7DxjcyQo3DsHvvdUvGZVaQhozycn1pzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.654.0.tgz",
+      "integrity": "sha512-a0ojjdBN6pqv6gB4H/QPPSfhs7mFtlVwnmKCM/QrTaFzN0U810PJ1BST3lBx5sa23I5jWHGaoFY+5q65C3clLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6453,6 +7159,586 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.4.tgz",
+      "integrity": "sha512-VupaALAQlXViW3/enTf/f5l5JZYSAxoJL7f0nanhNNKnww6DGCg1oYIuNP78KDugnkwthBO6iEcym16HhWV8RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.8.tgz",
+      "integrity": "sha512-Tv1obAC18XOd2OnDAjSWmmthzx6Pdeh63FbLin8MlPiuJ2ATpKkq0NcNOJFr0dO+JmZXnwu8FQxKJ3TKJ3Hulw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.5.tgz",
+      "integrity": "sha512-Z0qlPXgZ0pouYgnu/cZTEYeRAvniiKZmVl4wIbZHX/nEMHkMDV9ao6KFArsU9KndE0TuhL149xcRx45wfw1YCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.20",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.4",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.3.tgz",
+      "integrity": "sha512-VoxMzSzdvkkjMJNE38yQgx4CfnmT+Z+5EUXkg4x7yag93eQkVQgZvN3XBSHC/ylfBbLbAtdu7flTCChX9I+mVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.8.tgz",
+      "integrity": "sha512-Lqe0B8F5RM7zkw//6avq1SJ8AfaRd3ubFUS1eVp5WszV7p6Ne5hQ4dSuMHDpNRPhgTvj4va9Kd/pcVigHEHRow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.6.tgz",
+      "integrity": "sha512-c/FHEdKK/7DU2z6ZE91L36ahyXWayR3B+FzELjnYq7wH5YqIseM24V+pWCS9kFn1Ln8OFGTf+pyYPiHZuX0s/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.6.tgz",
+      "integrity": "sha512-czM7Ioq3s8pIXht7oD+vmgy4Wfb4XavU/k/irO8NdXFFOx7YAlsCCcKOh/lJD1mJSYQqiR7NmpZ9JviryD/7AQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.8.tgz",
+      "integrity": "sha512-VuyszlSO49WKh3H9/kIO2kf07VUwGV80QRiaDxUfP8P8UKlokz381ETJvwLhwuypBYhLymCYyNhB3fLAGBX2og==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.3.tgz",
+      "integrity": "sha512-KeM/OrK8MVFUsoJsmCN0MZMVPjKKLudn13xpgwIMpGTYpA8QZB2Xq5tJ+RE6iu3A6NhOI4VajDTwBsm8pwwrhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.20.tgz",
+      "integrity": "sha512-HELCOVwYw5hFDBm69d+LmmGjBCjWnwp/t7SJiHmp+c4u9vgfIaCjdSeIdnlOsLrr5ic5jGTJXvJFUQnd987b/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/smithy-client": "^3.3.4",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.6.tgz",
+      "integrity": "sha512-KKTUSl1MzOM0MAjGbudeaVNtIDo+PpekTBkCNwvfZlKndodrnvRo+00USatiyLOc0ujjO9UydMRu3O9dYML7ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.6.tgz",
+      "integrity": "sha512-2c0eSYhTQ8xQqHMcRxLMpadFbTXg6Zla5l0mwNftFCZMQmuhI7EbAJMx6R5eqfuV3YbJ3QGyS3d5uSmrHV8Khg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.7.tgz",
+      "integrity": "sha512-g3mfnC3Oo8pOI0dYuPXLtdW1WGVb3bR2tkV21GNkm0ZvQjLTtamXAwCWt/FCb0HGvKt3gHHmF1XerG0ICfalOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.3.tgz",
+      "integrity": "sha512-/gcm5DJ3k1b1zEInzBGAZC8ntJ+jwrz1NcSIu+9dSXd1FfG0G6QgkDI40tt8/WYUbHtLyo8fEqtm2v29koWo/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.6.tgz",
+      "integrity": "sha512-NK3y/T7Q/Bw+Z8vsVs9MYIQ5v7gOX7clyrXcwhhIBQhbPgRl6JDrZbusO9qWDhcEus75Tg+VCxtIRfo3H76fpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.3.tgz",
+      "integrity": "sha512-GcbMmOYpH9iRqtC05RbRnc/0FssxSTHlmaNhYBTgSgNCYpdR3Kt88u5GAZTBmouzv+Zlj/VRv92J9ruuDeJuEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.6.tgz",
+      "integrity": "sha512-sQe08RunoObe+Usujn9+R2zrLuQERi3CWvRO3BvnoWSYUaIrLKuAIeY7cMeDax6xGyfIP3x/yFWbEKSXvOnvVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.6.tgz",
+      "integrity": "sha512-UJKw4LlEkytzz2Wq+uIdHf6qOtFfee/o7ruH0jF5I6UAuU+19r9QV7nU3P/uI0l6+oElRHmG/5cBBcGJrD7Ozg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.6.tgz",
+      "integrity": "sha512-53SpchU3+DUZrN7J6sBx9tBiCVGzsib2e4sc512Q7K9fpC5zkJKs6Z9s+qbMxSYrkEkle6hnMtrts7XNkMJJMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.7.tgz",
+      "integrity": "sha512-IA4K2qTJYXkF5OfVN4vsY1hfnUZjaslEE8Fsr/gGFza4TAC2A9NfnZuSY2srQIbt9bwtjHiAayrRVgKse4Q7fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.4.tgz",
+      "integrity": "sha512-72MiK7xYukNsnLJI9NqvUHqTu0ziEsfMsYNlWpiJfuGQnCTFKpckThlEatirvcA/LmT1h7rRO+pJD06PYsPu9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.4.tgz",
+      "integrity": "sha512-NKw/2XxOW/Rg3rzB90HxsmGok5oS6vRzJgMh/JN4BHaOQQ4q5OuX999GmOGxEp730wbpIXIowfKZmIMXkG4v0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-stream": "^3.1.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
+      "integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.6.tgz",
+      "integrity": "sha512-47Op/NU8Opt49KyGpHtVdnmmJMsp2hEwBdyjuFB9M2V5QVOwA7pBhhxKN5z6ztKGrMw76gd8MlbPuzzvaAncuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.20.tgz",
+      "integrity": "sha512-HpYmCpEThQJpCKzwzrGrklhdegRfuXI9keHRrHidbyEMliCdgic6t38MikJeZEkdIcEMhO1g95HIYMzjUzB+xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.4",
+        "@smithy/types": "^3.4.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.20.tgz",
+      "integrity": "sha512-atdsHNtAX0rwTvRRGsrONU0C0XzapH6tI8T1y/OReOvWN7uBwXqqWRft6m8egU2DgeReU0xqT3PHdGCe5VRaaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.4",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.2.tgz",
+      "integrity": "sha512-FEISzffb4H8DLzGq1g4MuDpcv6CIG15fXoQzDH9SjpRJv6h7J++1STFWWinilG0tQh9H1v2UKWG19Jjr2B16zQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.6.tgz",
+      "integrity": "sha512-BxbX4aBhI1O9p87/xM+zWy0GzT3CEVcXFPBRDoHAM+pV0eSW156pR+PSYEz0DQHDMYDsYAflC2bQNz2uaDBUZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.6.tgz",
+      "integrity": "sha512-BRZiuF7IwDntAbevqMco67an0Sr9oLQJqqRCsSPZZHYRnehS0LHDAkJk/pSmI7Z8c/1Vet294H7fY2fWUgB+Rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.8.tgz",
+      "integrity": "sha512-hoKOqSmb8FD3WLObuB5hwbM7bNIWgcnvkThokTvVq7J5PKjlLUK5qQQcB9zWLHIoSaIlf3VIv2OxZY2wtQjcRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.5.tgz",
+      "integrity": "sha512-jYOSvM3H6sZe3CHjzD2VQNCjWBJs+4DbtwBMvUp9y5EnnwNa7NQxTeYeQw0CKCAdGGZ3QvVkyJmvbvs5M/B10A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.4",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -7557,6 +8843,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -9954,6 +11246,28 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -16068,6 +17382,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -17618,6 +18941,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -20996,6 +22325,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "license": "MIT"
+    },
     "node_modules/strong-log-transformer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
@@ -21465,8 +22800,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.656.0"
+        "@aws-sdk/client-dynamodb": "^3.658.1",
+        "@aws-sdk/lib-dynamodb": "^3.658.1"
       },
       "devDependencies": {
         "@babel/core": "^7.17.2",
@@ -197,17 +198,17 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.656.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.656.0.tgz",
-      "integrity": "sha512-a7nzK4tGZHlg1IY63aGmdSlVLYpdYFwjIDFx3vQwNAzStwh8pbb7Fv8jLFTAi33ZNHM7H4mASwvgFbu8ZfbMVA==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.658.1.tgz",
+      "integrity": "sha512-RUMMadGecgIZ8J8IU1+SE5OC7MNyToq929hIqWNmlCwPdmveG4TsUmm+dJ2k+G7AwyzumB252Kkb8kdbLJ6H3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.654.0",
-        "@aws-sdk/client-sts": "3.654.0",
-        "@aws-sdk/core": "3.654.0",
-        "@aws-sdk/credential-provider-node": "3.654.0",
+        "@aws-sdk/client-sso-oidc": "3.658.1",
+        "@aws-sdk/client-sts": "3.658.1",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
         "@aws-sdk/middleware-endpoint-discovery": "3.654.0",
         "@aws-sdk/middleware-host-header": "3.654.0",
         "@aws-sdk/middleware-logger": "3.654.0",
@@ -219,26 +220,26 @@
         "@aws-sdk/util-user-agent-browser": "3.654.0",
         "@aws-sdk/util-user-agent-node": "3.654.0",
         "@smithy/config-resolver": "^3.0.8",
-        "@smithy/core": "^2.4.3",
-        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
         "@smithy/hash-node": "^3.0.6",
         "@smithy/invalid-dependency": "^3.0.6",
         "@smithy/middleware-content-length": "^3.0.8",
         "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-retry": "^3.0.21",
         "@smithy/middleware-serde": "^3.0.6",
         "@smithy/middleware-stack": "^3.0.6",
         "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.2.3",
         "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
         "@smithy/url-parser": "^3.0.6",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.18",
-        "@smithy/util-defaults-mode-node": "^3.0.18",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
         "@smithy/util-endpoints": "^2.1.2",
         "@smithy/util-middleware": "^3.0.6",
         "@smithy/util-retry": "^3.0.6",
@@ -265,14 +266,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.654.0.tgz",
-      "integrity": "sha512-4kBxs2IzCDtj6a6lRXa/lXK5wWpMGzwKtb+HMXf/rJYVM6x7wYRzc1hYrOd3DYkFQ/sR3dUFj+0mTP0os3aAbA==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.658.1.tgz",
+      "integrity": "sha512-lOuaBtqPTYGn6xpXlQF4LsNDsQ8Ij2kOdnk+i69Kp6yS76TYvtUuukyLL5kx8zE1c8WbYtxj9y8VNw9/6uKl7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.654.0",
+        "@aws-sdk/core": "3.658.1",
         "@aws-sdk/middleware-host-header": "3.654.0",
         "@aws-sdk/middleware-logger": "3.654.0",
         "@aws-sdk/middleware-recursion-detection": "3.654.0",
@@ -283,26 +284,26 @@
         "@aws-sdk/util-user-agent-browser": "3.654.0",
         "@aws-sdk/util-user-agent-node": "3.654.0",
         "@smithy/config-resolver": "^3.0.8",
-        "@smithy/core": "^2.4.3",
-        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
         "@smithy/hash-node": "^3.0.6",
         "@smithy/invalid-dependency": "^3.0.6",
         "@smithy/middleware-content-length": "^3.0.8",
         "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-retry": "^3.0.21",
         "@smithy/middleware-serde": "^3.0.6",
         "@smithy/middleware-stack": "^3.0.6",
         "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.2.3",
         "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
         "@smithy/url-parser": "^3.0.6",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.18",
-        "@smithy/util-defaults-mode-node": "^3.0.18",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
         "@smithy/util-endpoints": "^2.1.2",
         "@smithy/util-middleware": "^3.0.6",
         "@smithy/util-retry": "^3.0.6",
@@ -314,15 +315,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.654.0.tgz",
-      "integrity": "sha512-gbHrKsEnaAtmkNCVQzLyiqMzpDaThV/bWl/ODEklI+t6stW3Pe3oDMstEHLfJ6JU5g8sYnx4VLuxlnJMtUkvPw==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.658.1.tgz",
+      "integrity": "sha512-RGcZAI3qEA05JszPKwa0cAyp8rnS1nUvs0Sqw4hqLNQ1kD7b7V6CPjRXe7EFQqCOMvM4kGqx0+cEEVTOmBsFLw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.654.0",
-        "@aws-sdk/credential-provider-node": "3.654.0",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
         "@aws-sdk/middleware-host-header": "3.654.0",
         "@aws-sdk/middleware-logger": "3.654.0",
         "@aws-sdk/middleware-recursion-detection": "3.654.0",
@@ -333,26 +334,26 @@
         "@aws-sdk/util-user-agent-browser": "3.654.0",
         "@aws-sdk/util-user-agent-node": "3.654.0",
         "@smithy/config-resolver": "^3.0.8",
-        "@smithy/core": "^2.4.3",
-        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
         "@smithy/hash-node": "^3.0.6",
         "@smithy/invalid-dependency": "^3.0.6",
         "@smithy/middleware-content-length": "^3.0.8",
         "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-retry": "^3.0.21",
         "@smithy/middleware-serde": "^3.0.6",
         "@smithy/middleware-stack": "^3.0.6",
         "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.2.3",
         "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
         "@smithy/url-parser": "^3.0.6",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.18",
-        "@smithy/util-defaults-mode-node": "^3.0.18",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
         "@smithy/util-endpoints": "^2.1.2",
         "@smithy/util-middleware": "^3.0.6",
         "@smithy/util-retry": "^3.0.6",
@@ -363,20 +364,20 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.654.0"
+        "@aws-sdk/client-sts": "^3.658.1"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.654.0.tgz",
-      "integrity": "sha512-tyHa8jsBy+/NQZFHm6Q2Q09Vi9p3EH4yPy6PU8yPewpi2klreObtrUd0anJa6nzjS9SSuqnlZWsRic3cQ4QwCg==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.658.1.tgz",
+      "integrity": "sha512-yw9hc5blTnbT1V6mR7Cx9HGc9KQpcLQ1QXj8rntiJi6tIYu3aFNVEyy81JHL7NsuBSeQulJTvHO3y6r3O0sfRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.654.0",
-        "@aws-sdk/core": "3.654.0",
-        "@aws-sdk/credential-provider-node": "3.654.0",
+        "@aws-sdk/client-sso-oidc": "3.658.1",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
         "@aws-sdk/middleware-host-header": "3.654.0",
         "@aws-sdk/middleware-logger": "3.654.0",
         "@aws-sdk/middleware-recursion-detection": "3.654.0",
@@ -387,26 +388,26 @@
         "@aws-sdk/util-user-agent-browser": "3.654.0",
         "@aws-sdk/util-user-agent-node": "3.654.0",
         "@smithy/config-resolver": "^3.0.8",
-        "@smithy/core": "^2.4.3",
-        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
         "@smithy/hash-node": "^3.0.6",
         "@smithy/invalid-dependency": "^3.0.6",
         "@smithy/middleware-content-length": "^3.0.8",
         "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-retry": "^3.0.21",
         "@smithy/middleware-serde": "^3.0.6",
         "@smithy/middleware-stack": "^3.0.6",
         "@smithy/node-config-provider": "^3.1.7",
-        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.2.3",
         "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
         "@smithy/url-parser": "^3.0.6",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.18",
-        "@smithy/util-defaults-mode-node": "^3.0.18",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
         "@smithy/util-endpoints": "^2.1.2",
         "@smithy/util-middleware": "^3.0.6",
         "@smithy/util-retry": "^3.0.6",
@@ -418,17 +419,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.654.0.tgz",
-      "integrity": "sha512-4Rwx7BVaNaFqmXBDmnOkMbyuIFFbpZ+ru4lr660p45zY1QoNNSalechfoRffcokLFOZO+VWEJkdcorPUUU993w==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.658.1.tgz",
+      "integrity": "sha512-vJVMoMcSKXK2gBRSu9Ywwv6wQ7tXH8VL1fqB1uVxgCqBZ3IHfqNn4zvpMPWrwgO2/3wv7XFyikGQ5ypPTCw4jA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.4.3",
+        "@smithy/core": "^2.4.6",
         "@smithy/node-config-provider": "^3.1.7",
         "@smithy/property-provider": "^3.1.6",
         "@smithy/protocol-http": "^4.1.3",
-        "@smithy/signature-v4": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/signature-v4": "^4.1.4",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
         "@smithy/util-middleware": "^3.0.6",
         "fast-xml-parser": "4.4.1",
@@ -454,19 +455,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.654.0.tgz",
-      "integrity": "sha512-tgmAH4MBi/aDR882lfw48+tDV95ZH3GWc1Eoe6DpNLiM3GN2VfU/cZwuHmi6aq+vAbdIlswBHJ/+va0fOvlyjw==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.658.1.tgz",
+      "integrity": "sha512-4ubkJjEVCZflxkZnV1JDQv8P2pburxk1LrEp55telfJRzXrnowzBKwuV2ED0QMNC448g2B3VCaffS+Ct7c4IWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.654.0",
-        "@smithy/fetch-http-handler": "^3.2.7",
-        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/node-http-handler": "^3.2.3",
         "@smithy/property-provider": "^3.1.6",
         "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
-        "@smithy/util-stream": "^3.1.6",
+        "@smithy/util-stream": "^3.1.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -474,15 +475,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.654.0.tgz",
-      "integrity": "sha512-DKSdaNu2hwdmuvnm9KnA0NLqMWxxmxSOLWjSUSoFIm++wGXUjPrRMFYKvMktaXnPuyf5my8gF/yGbwzPZ8wlTg==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.658.1.tgz",
+      "integrity": "sha512-2uwOamQg5ppwfegwen1ddPu5HM3/IBSnaGlaKLFhltkdtZ0jiqTZWUtX2V+4Q+buLnT0hQvLS/frQ+7QUam+0Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.654.0",
-        "@aws-sdk/credential-provider-http": "3.654.0",
+        "@aws-sdk/credential-provider-http": "3.658.1",
         "@aws-sdk/credential-provider-process": "3.654.0",
-        "@aws-sdk/credential-provider-sso": "3.654.0",
+        "@aws-sdk/credential-provider-sso": "3.658.1",
         "@aws-sdk/credential-provider-web-identity": "3.654.0",
         "@aws-sdk/types": "3.654.0",
         "@smithy/credential-provider-imds": "^3.2.3",
@@ -495,20 +496,20 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.654.0"
+        "@aws-sdk/client-sts": "^3.658.1"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.654.0.tgz",
-      "integrity": "sha512-wPV7CNYaXDEc+SS+3R0v8SZwkHRUE1z2k2j1d49tH5QBDT4tb/k2V/biXWkwSk3hbR+IMWXmuhJDv/5lybhIvg==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.658.1.tgz",
+      "integrity": "sha512-XwxW6N+uPXPYAuyq+GfOEdfL/MZGAlCSfB5gEWtLBFmFbikhmEuqfWtI6CD60OwudCUOh6argd21BsJf8o1SJA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.654.0",
-        "@aws-sdk/credential-provider-http": "3.654.0",
-        "@aws-sdk/credential-provider-ini": "3.654.0",
+        "@aws-sdk/credential-provider-http": "3.658.1",
+        "@aws-sdk/credential-provider-ini": "3.658.1",
         "@aws-sdk/credential-provider-process": "3.654.0",
-        "@aws-sdk/credential-provider-sso": "3.654.0",
+        "@aws-sdk/credential-provider-sso": "3.658.1",
         "@aws-sdk/credential-provider-web-identity": "3.654.0",
         "@aws-sdk/types": "3.654.0",
         "@smithy/credential-provider-imds": "^3.2.3",
@@ -538,12 +539,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.654.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.654.0.tgz",
-      "integrity": "sha512-7GFme6fWEdA/XYKzZPOAdj/jS6fMBy1NdSIZsDXikS0v9jU+ZzHrAaWt13YLzHyjgxB9Sg9id9ncdY1IiubQXQ==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.658.1.tgz",
+      "integrity": "sha512-YOagVEsZEk9DmgJEBg+4MBXrPcw/tYas0VQ5OVBqC5XHNbi2OBGJqgmjVPesuu393E7W0VQxtJFDS00O1ewQgA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.654.0",
+        "@aws-sdk/client-sso": "3.658.1",
         "@aws-sdk/token-providers": "3.654.0",
         "@aws-sdk/types": "3.654.0",
         "@smithy/property-provider": "^3.1.6",
@@ -584,6 +585,25 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.658.1.tgz",
+      "integrity": "sha512-IU/PTANYfmTCt/gB5tM6XYvHXtBGTgNDW5kE5iNte5+VLN3OPXAzlg8Tk00b3sgERyOufiJ5nyerSCSsjyM5WQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/util-dynamodb": "3.658.1",
+        "@smithy/core": "^2.4.6",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.658.1"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
@@ -710,6 +730,21 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.658.1.tgz",
+      "integrity": "sha512-lzlnis+35a2OhGZlVJvM3/30iIVoP2cIv5Bkw1F2nkM6Pr+1NOd3XvYhCY1Ud5zWtV6HUSptzessvUPqJTMfjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.658.1"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
@@ -7189,16 +7224,16 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.5.tgz",
-      "integrity": "sha512-Z0qlPXgZ0pouYgnu/cZTEYeRAvniiKZmVl4wIbZHX/nEMHkMDV9ao6KFArsU9KndE0TuhL149xcRx45wfw1YCA==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.6.tgz",
+      "integrity": "sha512-6lQQp99hnyuNNIzeTYSzCUXJHwvvFLY7hfdFGSJM95tjRDJGfzWYFRBXPaM9766LiiTsQ561KErtbufzUFSYUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-endpoint": "^3.1.3",
-        "@smithy/middleware-retry": "^3.0.20",
+        "@smithy/middleware-retry": "^3.0.21",
         "@smithy/middleware-serde": "^3.0.6",
         "@smithy/protocol-http": "^4.1.3",
-        "@smithy/smithy-client": "^3.3.4",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-middleware": "^3.0.6",
@@ -7308,15 +7343,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.20.tgz",
-      "integrity": "sha512-HELCOVwYw5hFDBm69d+LmmGjBCjWnwp/t7SJiHmp+c4u9vgfIaCjdSeIdnlOsLrr5ic5jGTJXvJFUQnd987b/g==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.21.tgz",
+      "integrity": "sha512-/h0fElV95LekVVEJuSw+aI11S1Y3zIUwBc6h9ZbUv43Gl2weXsbQwjLoet6j/Qtb0phfrSxS6pNg6FqgJOWZkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.7",
         "@smithy/protocol-http": "^4.1.3",
         "@smithy/service-error-classification": "^3.0.6",
-        "@smithy/smithy-client": "^3.3.4",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
         "@smithy/util-middleware": "^3.0.6",
         "@smithy/util-retry": "^3.0.6",
@@ -7495,9 +7530,9 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.4.tgz",
-      "integrity": "sha512-NKw/2XxOW/Rg3rzB90HxsmGok5oS6vRzJgMh/JN4BHaOQQ4q5OuX999GmOGxEp730wbpIXIowfKZmIMXkG4v0Q==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.5.tgz",
+      "integrity": "sha512-7IZi8J3Dr9n3tX+lcpmJ/5tCYIqoXdblFBaPuv0SEKZFRpCxE+TqIWL6I3t7jLlk9TWu3JSvEZAhtjB9yvB+zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-endpoint": "^3.1.3",
@@ -7595,13 +7630,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.20.tgz",
-      "integrity": "sha512-HpYmCpEThQJpCKzwzrGrklhdegRfuXI9keHRrHidbyEMliCdgic6t38MikJeZEkdIcEMhO1g95HIYMzjUzB+xg==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.21.tgz",
+      "integrity": "sha512-M/FhTBk4c/SsB91dD/M4gMGfJO7z/qJaM9+XQQIqBOf4qzZYMExnP7R4VdGwxxH8IKMGW+8F0I4rNtVRrcfPoA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^3.1.6",
-        "@smithy/smithy-client": "^3.3.4",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -7611,16 +7646,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.20.tgz",
-      "integrity": "sha512-atdsHNtAX0rwTvRRGsrONU0C0XzapH6tI8T1y/OReOvWN7uBwXqqWRft6m8egU2DgeReU0xqT3PHdGCe5VRaaQ==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.21.tgz",
+      "integrity": "sha512-NiLinPvF86U3S2Pdx/ycqd4bnY5dmFSPNL5KYRwbNjqQFS09M5Wzqk8BNk61/47xCYz1X/6KeiSk9qgYPTtuDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^3.0.8",
         "@smithy/credential-provider-imds": "^3.2.3",
         "@smithy/node-config-provider": "^3.1.7",
         "@smithy/property-provider": "^3.1.6",
-        "@smithy/smithy-client": "^3.3.4",
+        "@smithy/smithy-client": "^3.3.5",
         "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "silent": true
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.656.0"
+    "@aws-sdk/client-dynamodb": "^3.658.1",
+    "@aws-sdk/lib-dynamodb": "^3.658.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,5 +105,8 @@
     "testEnvironment": "node",
     "testRunner": "jest-circus/runner",
     "silent": true
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.656.0"
   }
 }

--- a/packages/business-rules-lib/package-lock.json
+++ b/packages/business-rules-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@defra-fish/business-rules-lib",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/business-rules-lib",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "joi": "^17.6.0",

--- a/packages/business-rules-lib/package.json
+++ b/packages/business-rules-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/business-rules-lib",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "Shared business rules for the rod licensing digital services",
   "type": "module",
   "engines": {

--- a/packages/connectors-lib/package-lock.json
+++ b/packages/connectors-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@defra-fish/connectors-lib",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/connectors-lib",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@airbrake/node": "^2.1.7",

--- a/packages/connectors-lib/package.json
+++ b/packages/connectors-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/connectors-lib",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "Shared connectors",
   "type": "module",
   "engines": {

--- a/packages/connectors-lib/src/documentclient-decorator.js
+++ b/packages/connectors-lib/src/documentclient-decorator.js
@@ -1,14 +1,15 @@
 import db from 'debug'
-import AWS from 'aws-sdk'
-const { DynamoDB } = AWS
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb'
 const debug = db('connectors:aws')
 
-export const createDocumentClient = options => {
-  const docClient = new DynamoDB.DocumentClient(options)
+export const createDocumentClient = (options) => {
+  const client = new DynamoDBClient(options)
+  const docClient = DynamoDBDocument.from(client)
 
   // Support for large query/scan operations which return results in pages
-  const wrapPagedDocumentClientOperation = operationName => {
-    return async params => {
+  const wrapPagedDocumentClientOperation = (operationName) => {
+    return async (params) => {
       const items = []
       let lastEvaluatedKey = null
       do {
@@ -31,7 +32,7 @@ export const createDocumentClient = options => {
    * @param {DocumentClient.BatchWriteItemInput} params as per DynamoDB.DocumentClient.batchWrite
    * @returns {Promise<void>}
    */
-  docClient.batchWriteAllPromise = async params => {
+  docClient.batchWriteAllPromise = async (params) => {
     let request = { ...params }
     let hasUnprocessedItems = !!Object.keys(request.RequestItems).length
     let unprocessedItemsDelay = 500
@@ -46,14 +47,14 @@ export const createDocumentClient = options => {
             'Failed to write items to DynamoDB using batch write.  UnprocessedItems were returned and maxRetries has been reached.'
           )
         }
-        await new Promise(resolve => setTimeout(resolve, unprocessedItemsDelay))
+        await new Promise((resolve) => setTimeout(resolve, unprocessedItemsDelay))
         unprocessedItemsDelay = Math.min(2500, unprocessedItemsDelay * 1.5)
         debug('Replaying DynamoDB batchWrite operation due to UnprocessedItems: %o', params.RequestItems)
       }
     }
   }
 
-  docClient.createUpdateExpression = payload =>
+  docClient.createUpdateExpression = (payload) =>
     Object.entries(payload).reduce(
       (acc, [k, v], idx) => {
         acc.UpdateExpression += `${idx > 0 ? ',' : ''}#${k} = :${k}`
@@ -61,7 +62,7 @@ export const createDocumentClient = options => {
         acc.ExpressionAttributeValues[`:${k}`] = v
         return acc
       },
-      { UpdateExpression: 'SET ', ExpressionAttributeNames: {}, ExpressionAttributeValues: {} }
+       { UpdateExpression: 'SET ', ExpressionAttributeNames: {}, ExpressionAttributeValues: {} }
     )
 
   return docClient

--- a/packages/dynamics-lib/package-lock.json
+++ b/packages/dynamics-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@defra-fish/dynamics-lib",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/dynamics-lib",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "cache-manager": "^3.6.0",

--- a/packages/dynamics-lib/package.json
+++ b/packages/dynamics-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/dynamics-lib",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "Framework to support integration with dynamics",
   "type": "module",
   "engines": {

--- a/packages/fulfilment-job/package-lock.json
+++ b/packages/fulfilment-job/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@defra-fish/fulfilment-job",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/fulfilment-job",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/connectors-lib": "1.49.0-rc.10",
-        "@defra-fish/dynamics-lib": "1.49.0-rc.10",
+        "@defra-fish/connectors-lib": "1.50.0-rc.8",
+        "@defra-fish/dynamics-lib": "1.50.0-rc.8",
         "commander": "^7.2.0",
         "debug": "^4.3.3",
         "merge2": "^1.4.1",

--- a/packages/fulfilment-job/package.json
+++ b/packages/fulfilment-job/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/fulfilment-job",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "Rod Licensing Sales Fulfilment Job",
   "type": "module",
   "engines": {
@@ -35,8 +35,8 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@defra-fish/connectors-lib": "1.50.0-rc.7",
-    "@defra-fish/dynamics-lib": "1.50.0-rc.7",
+    "@defra-fish/connectors-lib": "1.50.0-rc.8",
+    "@defra-fish/dynamics-lib": "1.50.0-rc.8",
     "commander": "^7.2.0",
     "debug": "^4.3.3",
     "merge2": "^1.4.1",

--- a/packages/gafl-webapp-service/package-lock.json
+++ b/packages/gafl-webapp-service/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@defra-fish/gafl-webapp-service",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/gafl-webapp-service",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/business-rules-lib": "1.49.0-rc.10",
-        "@defra-fish/connectors-lib": "1.49.0-rc.10",
+        "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+        "@defra-fish/connectors-lib": "1.50.0-rc.8",
         "@defra/hapi-gapi": "^2.0.0",
         "@hapi/boom": "^9.1.2",
         "@hapi/catbox-redis": "^6.0.2",

--- a/packages/gafl-webapp-service/package.json
+++ b/packages/gafl-webapp-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/gafl-webapp-service",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "The websales frontend for the GAFL service",
   "type": "module",
   "engines": {
@@ -36,8 +36,8 @@
     "prepare": "gulp --gulpfile build/gulpfile.cjs"
   },
   "dependencies": {
-    "@defra-fish/business-rules-lib": "1.50.0-rc.7",
-    "@defra-fish/connectors-lib": "1.50.0-rc.7",
+    "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+    "@defra-fish/connectors-lib": "1.50.0-rc.8",
     "@defra/hapi-gapi": "^2.0.0",
     "@hapi/boom": "^9.1.2",
     "@hapi/catbox-redis": "^6.0.2",

--- a/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
+++ b/packages/gafl-webapp-service/src/pages/guidance/recurring-payment-terms-conditions.njk
@@ -6,21 +6,21 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-l">{{ mssgs.recurring_terms_conditions_title }}</h1>
+        <h1 class="govuk-heading-xl">{{ mssgs.recurring_terms_conditions_title }}</h1>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_body }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_payment_subheading }}</h2>
+        <h2 class="govuk-heading-l">{{ mssgs.recurring_terms_conditions_payment_subheading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_body_1 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_body_2 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_body_3 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_body_4 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_body_5 }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_payment_reminders_subheading }}</h2>
+        <h2 class="govuk-heading-l">{{ mssgs.recurring_terms_conditions_payment_reminders_subheading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_reminders_body_1 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_payment_reminders_body_2_1 }}<a href="mailto:enquiries@environment-agency.gov.uk" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_enquiries_link }}</a>{{ mssgs.recurring_terms_conditions_payment_reminders_body_2_2 }}<a href="https://www.gov.uk/call-charges" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_call_charges_link }}</a>{{ mssgs.full_stop }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_heading }}</h2>
+        <h2 class="govuk-heading-l">{{ mssgs.recurring_terms_conditions_cancel_heading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_1 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_2_1 }}<a href="{{ uri.refund }}" class="govuk-link">{{ mssgs.recurring_terms_conditions_refund_link }}</a>{{ mssgs.recurring_terms_conditions_cancel_body_2_2 }}</p>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_body_3 }}</p>
@@ -31,10 +31,9 @@
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_1 }}<a href="mailto:enquiries@environment-agency.gov.uk" class="govuk-link" target="_blank">{{ mssgs.recurring_terms_conditions_enquiries_link }}</a>{{ mssgs.recurring_terms_conditions_cancel_phone_email_subheading_body_2_2 }}</p>
 
         <h3 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_cancel_bank_subheading }}</h3>
-
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_cancel_bank_body }}</p>
 
-        <h2 class="govuk-heading-m">{{ mssgs.recurring_terms_conditions_security_heading }}</h2>
+        <h2 class="govuk-heading-l">{{ mssgs.recurring_terms_conditions_security_heading }}</h2>
         <p class="govuk-body">{{ mssgs.recurring_terms_conditions_security_body }}<a href="{{ uri.privacy }}" class="govuk-link">{{ mssgs.recurring_terms_conditions_privacy_link }}</a>{{ mssgs.full_stop }}</p>
     </div>
 </div>

--- a/packages/payment-mop-up-job/package-lock.json
+++ b/packages/payment-mop-up-job/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@defra-fish/payment-mop-up-job",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/payment-mop-up-job",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/business-rules-lib": "1.49.0-rc.10",
-        "@defra-fish/connectors-lib": "1.49.0-rc.10",
+        "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+        "@defra-fish/connectors-lib": "1.50.0-rc.8",
         "bottleneck": "^2.19.5",
         "debug": "^4.3.3",
         "moment": "^2.29.1"

--- a/packages/payment-mop-up-job/package.json
+++ b/packages/payment-mop-up-job/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/payment-mop-up-job",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "Process incomplete web-sales",
   "type": "module",
   "engines": {
@@ -36,8 +36,8 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@defra-fish/business-rules-lib": "1.50.0-rc.7",
-    "@defra-fish/connectors-lib": "1.50.0-rc.7",
+    "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+    "@defra-fish/connectors-lib": "1.50.0-rc.8",
     "bottleneck": "^2.19.5",
     "debug": "^4.3.3",
     "moment": "^2.29.1"

--- a/packages/pocl-job/package-lock.json
+++ b/packages/pocl-job/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@defra-fish/pocl-job",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/pocl-job",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/business-rules-lib": "1.49.0-rc.10",
-        "@defra-fish/connectors-lib": "1.49.0-rc.10",
+        "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+        "@defra-fish/connectors-lib": "1.50.0-rc.8",
         "commander": "^7.2.0",
         "debug": "^4.3.3",
         "filesize": "^6.4.0",

--- a/packages/pocl-job/package.json
+++ b/packages/pocl-job/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/pocl-job",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "Post Office Counter Licence sales processor",
   "type": "module",
   "engines": {
@@ -35,8 +35,8 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@defra-fish/business-rules-lib": "1.50.0-rc.7",
-    "@defra-fish/connectors-lib": "1.50.0-rc.7",
+    "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+    "@defra-fish/connectors-lib": "1.50.0-rc.8",
     "commander": "^7.2.0",
     "debug": "^4.3.3",
     "filesize": "^6.4.0",

--- a/packages/recurring-payments-job/package-lock.json
+++ b/packages/recurring-payments-job/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@defra-fish/recurring-payments-job",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/recurring-payments-job",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/business-rules-lib": "1.50.0-rc.7",
-        "@defra-fish/connectors-lib": "1.50.0-rc.7",
+        "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+        "@defra-fish/connectors-lib": "1.50.0-rc.8",
         "commander": "^7.2.0",
         "moment-timezone": "^0.5.34"
       },

--- a/packages/recurring-payments-job/package.json
+++ b/packages/recurring-payments-job/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/recurring-payments-job",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "Rod Licensing Recurring Payments Job",
   "type": "module",
   "engines": {
@@ -36,8 +36,8 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@defra-fish/business-rules-lib": "1.50.0-rc.7",
-    "@defra-fish/connectors-lib": "1.50.0-rc.7",
+    "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+    "@defra-fish/connectors-lib": "1.50.0-rc.8",
     "commander": "^7.2.0",
     "moment-timezone": "^0.5.34"
   }

--- a/packages/sales-api-service/package-lock.json
+++ b/packages/sales-api-service/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@defra-fish/sales-api-service",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/sales-api-service",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/business-rules-lib": "1.49.0-rc.10",
-        "@defra-fish/connectors-lib": "1.49.0-rc.10",
-        "@defra-fish/dynamics-lib": "1.49.0-rc.10",
+        "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+        "@defra-fish/connectors-lib": "1.50.0-rc.8",
+        "@defra-fish/dynamics-lib": "1.50.0-rc.8",
         "@hapi/boom": "^9.1.2",
         "@hapi/hapi": "^20.1.3",
         "@hapi/inert": "^6.0.3",

--- a/packages/sales-api-service/package.json
+++ b/packages/sales-api-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/sales-api-service",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "Rod Licensing Sales API",
   "type": "module",
   "engines": {
@@ -35,9 +35,9 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@defra-fish/business-rules-lib": "1.50.0-rc.7",
-    "@defra-fish/connectors-lib": "1.50.0-rc.7",
-    "@defra-fish/dynamics-lib": "1.50.0-rc.7",
+    "@defra-fish/business-rules-lib": "1.50.0-rc.8",
+    "@defra-fish/connectors-lib": "1.50.0-rc.8",
+    "@defra-fish/dynamics-lib": "1.50.0-rc.8",
     "@hapi/boom": "^9.1.2",
     "@hapi/hapi": "^20.1.3",
     "@hapi/inert": "^6.0.3",

--- a/packages/sqs-receiver-service/package-lock.json
+++ b/packages/sqs-receiver-service/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@defra-fish/sqs-receiver-service",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@defra-fish/sqs-receiver-service",
-      "version": "1.50.0-rc.7",
+      "version": "1.50.0-rc.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra-fish/connectors-lib": "1.49.0-rc.10",
+        "@defra-fish/connectors-lib": "1.50.0-rc.8",
         "debug": "^4.3.1",
         "joi": "^17.3.0",
         "node-fetch": "^2.6.1",

--- a/packages/sqs-receiver-service/package.json
+++ b/packages/sqs-receiver-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defra-fish/sqs-receiver-service",
-  "version": "1.50.0-rc.7",
+  "version": "1.50.0-rc.8",
   "description": "SQS Receiver service",
   "type": "module",
   "engines": {
@@ -35,7 +35,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
-    "@defra-fish/connectors-lib": "1.50.0-rc.7",
+    "@defra-fish/connectors-lib": "1.50.0-rc.8",
     "debug": "^4.3.1",
     "joi": "^17.3.0",
     "node-fetch": "^2.6.1",

--- a/scripts/github/deploy.sh
+++ b/scripts/github/deploy.sh
@@ -67,9 +67,6 @@ echo "Updating version from ${PREVIOUS_VERSION} to ${NEW_VERSION}"
 # Update package files versions, project inter-dependencies and lerna.json with new version number
 lerna version "${NEW_VERSION}" --yes --no-push --force-publish --exact
 
-# Update package lock with new version number
-lerna exec -- npm install --package-lock-only
-
 # Generate changelog information for changes since the last tag
 echo "Generating changelog updates for all changes between ${PREVIOUS_VERSION} and ${NEW_VERSION}"
 lerna-changelog --from "${PREVIOUS_VERSION}" --to "${NEW_VERSION}" | cat - CHANGELOG.md > CHANGELOG.new && mv CHANGELOG.new CHANGELOG.md


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3449

This ticket is part of upgrading rod-licencing from using the AWS SDK v2 to v3.This ticket specifically covers upgrading the parts of our codebase that use the AWS SDK to use DynamoDB.