### PR TITLE
Fix bug where transaction id is not recognised

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-recurring-payments.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/agreed-handler-recurring-payments.spec.js
@@ -36,7 +36,7 @@ describe('The agreed handler', () => {
     cache: () => ({
       helpers: {
         transaction: {
-          get: async () => ({ id: 'id-111', cost: 0 }),
+          get: async () => ({ cost: 0 }),
           set: async () => {}
         },
         status: {
@@ -88,6 +88,26 @@ describe('The agreed handler', () => {
       await agreedHandler(mockRequest, getRequestToolkit())
 
       expect(transactionPayload.id).toBe(v4guid)
+    })
+
+    it("doesn't overwrite transaction id if one is already set", async () => {
+      const setTransaction = jest.fn()
+      const transactionId = 'abc-123-def-456'
+      uuidv4.mockReturnValue('def-789-ghi-012')
+      const mockRequest = getMockRequest({
+        transaction: {
+          get: async () => ({ cost: 0, id: transactionId }),
+          set: setTransaction
+        }
+      })
+
+      await agreedHandler(mockRequest, getRequestToolkit())
+
+      expect(setTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: transactionId
+        })
+      )
     })
 
     it('sends a recurring payment creation request to Gov.UK Pay', async () => {

--- a/packages/gafl-webapp-service/src/handlers/agreed-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/agreed-handler.js
@@ -241,7 +241,9 @@ const finaliseTransaction = async (request, transaction, status) => {
 export default async (request, h) => {
   const status = await request.cache().helpers.status.get()
   const transaction = await request.cache().helpers.transaction.get()
-  transaction.id = uuidv4()
+  if (!transaction.id) {
+    transaction.id = uuidv4()
+  }
 
   // If the agreed flag is not set to true then throw an exception
   if (!status[COMPLETION_STATUS.agreed]) {

--- a/packages/gafl-webapp-service/src/handlers/agreed-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/agreed-handler.js
@@ -281,6 +281,7 @@ export default async (request, h) => {
 
   // If the transaction has already been finalised then redirect to the order completed page
   if (!status[COMPLETION_STATUS.finalised]) {
+    console.log('finalising transaction', request, transaction, status)
     await finaliseTransaction(request, transaction, status)
   } else {
     debug('Transaction %s already finalised, redirect to order complete: %s', transaction.id)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4352

On return from GovPay, the transaction is not retrieved and the transaction id has changed