### PR TITLE
Create RP Record in CRM

### DIFF
--- a/packages/dynamics-lib/src/entities/__tests__/recurring-payment.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/recurring-payment.entity.spec.js
@@ -17,8 +17,6 @@ describe('recurring payment entity', () => {
     recurringPayment.agreementId = 'c9267c6e-573d-488b-99ab-ea18431fc472'
     recurringPayment.publicId = '649-213'
     recurringPayment.status = 1
-    recurringPayment.contactId = 'b3d33cln-2e83-ea11-a811-000d3a649213'
-    recurringPayment.activePermission = 'a5b24adf-2e83-ea11-a811-000d3a649213'
 
     recurringPayment.bindToEntity(RecurringPayment.definition.relationships.contact, contact)
     recurringPayment.bindToEntity(RecurringPayment.definition.relationships.activePermission, permission)
@@ -66,9 +64,7 @@ describe('recurring payment entity', () => {
           endDate: '2019-12-15T00:00:00Z',
           agreementId: 'c9267c6e-573d-488b-99ab-ea18431fc472',
           publicId: '649-213',
-          status: 1,
-          activePermission: 'a5b24adf-2e83-ea11-a811-000d3a649213',
-          contactId: 'b3d33cln-2e83-ea11-a811-000d3a649213'
+          status: 1
         })
       )
     })
@@ -93,8 +89,6 @@ describe('recurring payment entity', () => {
           defra_agreementid: 'c9267c6e-573d-488b-99ab-ea18431fc472',
           defra_publicid: '649-213',
           statecode: 1,
-          _defra_activepermission_value: 'a5b24adf-2e83-ea11-a811-000d3a649213',
-          _defra_contact_value: 'b3d33cln-2e83-ea11-a811-000d3a649213',
           'defra_Contact@odata.bind': `$${contact.uniqueContentId}`,
           'defra_ActivePermission@odata.bind': `$${permission.uniqueContentId}`
         })
@@ -121,9 +115,7 @@ describe('recurring payment entity', () => {
           endDate: '2019-12-15T00:00:00Z',
           agreementId: 'c9267c6e-573d-488b-99ab-ea18431fc472',
           publicId: '649-213',
-          status: 1,
-          activePermission: 'a5b24adf-2e83-ea11-a811-000d3a649213',
-          contactId: 'b3d33cln-2e83-ea11-a811-000d3a649213'
+          status: 1
         })
       )
     })
@@ -143,8 +135,6 @@ describe('recurring payment entity', () => {
           defra_agreementid: 'c9267c6e-573d-488b-99ab-ea18431fc472',
           defra_publicid: '649-213',
           statecode: 1,
-          _defra_activepermission_value: 'a5b24adf-2e83-ea11-a811-000d3a649213',
-          _defra_contact_value: 'b3d33cln-2e83-ea11-a811-000d3a649213',
           'defra_Contact@odata.bind': `$${contact.uniqueContentId}`,
           'defra_ActivePermission@odata.bind': `$${permission.uniqueContentId}`
         })

--- a/packages/dynamics-lib/src/entities/recurring-payment.entity.js
+++ b/packages/dynamics-lib/src/entities/recurring-payment.entity.js
@@ -134,28 +134,4 @@ export class RecurringPayment extends BaseEntity {
   set status (status) {
     super._setState('status', status)
   }
-
-  /**
-   * The ID of the associated contact
-   * @type {string}
-   */
-  get contactId () {
-    return super._getState('contactId')
-  }
-
-  set contactId (contactId) {
-    super._setState('contactId', contactId)
-  }
-
-  /**
-   * The ID of the associated active permission
-   * @type {string}
-   */
-  get activePermission () {
-    return super._getState('activePermission')
-  }
-
-  set activePermission (activePermission) {
-    super._setState('activePermission', activePermission)
-  }
 }

--- a/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
+++ b/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
@@ -8,7 +8,7 @@ Object {
   "endDate": 2023-11-12T00:00:00.000Z,
   "name": "Test Name",
   "nextDueDate": 2023-11-02T00:00:00.000Z,
-  "publicId": "1234456",
+  "publicId": "abcdef99987",
   "status": 0,
 }
 `;

--- a/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
@@ -259,6 +259,26 @@ describe('recurring payments service', () => {
           endDate: '2025-01-30T23:59:59.999Z'
         },
         '2025-11-12T00:00:00.000Z'
+      ],
+      [
+        "issued on 29th Feb '24, starts on 30th March '24 - next due on 28th Feb '25",
+        'hy7u8ijhyu78jhyu8iu8hjiujn',
+        {
+          startDate: '2024-03-30T00:00:00.000Z',
+          issueDate: '2024-02-29T12:38:24.123Z',
+          endDate: '2025-03-29T23:59:59.999Z'
+        },
+        '2025-02-28T00:00:00.000Z'
+      ],
+      [
+        "issued on 30th March '25 at 1am, starts at 1:30am - next due on 20th March '26",
+        'jhy67uijhy67u87yhtgjui8u7j',
+        {
+          startDate: '2025-03-30T01:30:00.000Z',
+          issueDate: '2025-03-30T01:00:00.000Z',
+          endDate: '2026-03-29T23:59:59.999Z'
+        },
+        '2026-03-20T00:00:00.000Z'
       ]
     ])('creates record from transaction with %s', (_d, agreementId, permissionData, expectedNextDueDate) => {
       const sampleTransaction = createFinalisedSampleTransaction(agreementId, permissionData)

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -1,6 +1,38 @@
 import { executeQuery, findDueRecurringPayments, RecurringPayment } from '@defra-fish/dynamics-lib'
+import { createHash } from 'node:crypto'
+import moment from 'moment'
 
 export const getRecurringPayments = date => executeQuery(findDueRecurringPayments(date))
+
+const getNextDueDate = (startDate, issueDate, endDate) => {
+  if (moment(startDate).isSame(moment(issueDate), 'day')) {
+    return moment(startDate).add(1, 'year').subtract(10, 'days').startOf('day').toISOString()
+  }
+  if (moment(startDate).isBefore(moment(issueDate).add(10, 'days'), 'day')) {
+    return moment(endDate).subtract(10, 'days').startOf('day').toISOString()
+  }
+  if (moment(startDate).isSameOrAfter(moment(issueDate).add(10, 'days'), 'day')) {
+    return moment(issueDate).add(1, 'year').startOf('day').toISOString()
+  }
+}
+
+export const generateRecurringPaymentRecord = transactionRecord => {
+  const [{ startDate, issueDate, endDate }] = transactionRecord.permissions
+  return {
+    payment: {
+      recurring: {
+        name: '',
+        nextDueDate: getNextDueDate(startDate, issueDate, endDate),
+        cancelledDate: null,
+        cancelledReason: null,
+        endDate,
+        agreementId: transactionRecord.agreementId,
+        status: 1
+      }
+    },
+    permissions: transactionRecord.permissions
+  }
+}
 
 /**
  * Process a recurring payment instruction
@@ -8,15 +40,17 @@ export const getRecurringPayments = date => executeQuery(findDueRecurringPayment
  * @returns {Promise<{recurringPayment: RecurringPayment | null}>}
  */
 export const processRecurringPayment = async (transactionRecord, contact) => {
+  const hash = createHash('sha256')
   if (transactionRecord.payment?.recurring) {
     const recurringPayment = new RecurringPayment()
+    hash.update(recurringPayment.uniqueContentId)
     recurringPayment.name = transactionRecord.payment.recurring.name
     recurringPayment.nextDueDate = transactionRecord.payment.recurring.nextDueDate
     recurringPayment.cancelledDate = transactionRecord.payment.recurring.cancelledDate
     recurringPayment.cancelledReason = transactionRecord.payment.recurring.cancelledReason
     recurringPayment.endDate = transactionRecord.payment.recurring.endDate
     recurringPayment.agreementId = transactionRecord.payment.recurring.agreementId
-    recurringPayment.publicId = transactionRecord.payment.recurring.publicId
+    recurringPayment.publicId = hash.digest('base64')
     recurringPayment.status = transactionRecord.payment.recurring.status
     const [permission] = transactionRecord.permissions
     recurringPayment.bindToEntity(RecurringPayment.definition.relationships.activePermission, permission)

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -5,15 +5,17 @@ import moment from 'moment'
 export const getRecurringPayments = date => executeQuery(findDueRecurringPayments(date))
 
 const getNextDueDate = (startDate, issueDate, endDate) => {
-  if (moment(startDate).isSame(moment(issueDate), 'day')) {
-    return moment(startDate).add(1, 'year').subtract(10, 'days').startOf('day').toISOString()
-  }
-  if (moment(startDate).isBefore(moment(issueDate).add(10, 'days'), 'day')) {
-    return moment(endDate).subtract(10, 'days').startOf('day').toISOString()
-  }
-  if (moment(startDate).isSameOrAfter(moment(issueDate).add(10, 'days'), 'day')) {
+  const mStart = moment(startDate)
+  if (mStart.isAfter(moment(issueDate)) && mStart.isSameOrBefore(moment(issueDate).add(30, 'days'), 'day')) {
+    if (mStart.isSame(moment(issueDate), 'day')) {
+      return moment(startDate).add(1, 'year').subtract(10, 'days').startOf('day').toISOString()
+    }
+    if (mStart.isBefore(moment(issueDate).add(10, 'days'), 'day')) {
+      return moment(endDate).subtract(10, 'days').startOf('day').toISOString()
+    }
     return moment(issueDate).add(1, 'year').startOf('day').toISOString()
   }
+  throw new Error('Invalid dates provided for permission')
 }
 
 export const generateRecurringPaymentRecord = transactionRecord => {

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -18,7 +18,7 @@ const getNextDueDate = (startDate, issueDate, endDate) => {
   throw new Error('Invalid dates provided for permission')
 }
 
-export const generateRecurringPaymentRecord = transactionRecord => {
+export const generateRecurringPaymentRecord = (transactionRecord, permission) => {
   const [{ startDate, issueDate, endDate }] = transactionRecord.permissions
   return {
     payment: {
@@ -32,7 +32,7 @@ export const generateRecurringPaymentRecord = transactionRecord => {
         status: 1
       }
     },
-    permissions: transactionRecord.permissions
+    permissions: [permission]
   }
 }
 

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -1,12 +1,13 @@
 import { executeQuery, findDueRecurringPayments, RecurringPayment } from '@defra-fish/dynamics-lib'
 import { createHash } from 'node:crypto'
+import { ADVANCED_PURCHASE_MAX_DAYS } from '@defra-fish/business-rules-lib'
 import moment from 'moment'
 
 export const getRecurringPayments = date => executeQuery(findDueRecurringPayments(date))
 
 const getNextDueDate = (startDate, issueDate, endDate) => {
   const mStart = moment(startDate)
-  if (mStart.isAfter(moment(issueDate)) && mStart.isSameOrBefore(moment(issueDate).add(30, 'days'), 'day')) {
+  if (mStart.isAfter(moment(issueDate)) && mStart.isSameOrBefore(moment(issueDate).add(ADVANCED_PURCHASE_MAX_DAYS, 'days'), 'day')) {
     if (mStart.isSame(moment(issueDate), 'day')) {
       return moment(startDate).add(1, 'year').subtract(10, 'days').startOf('day').toISOString()
     }

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -65,11 +65,6 @@ export async function processQueue ({ id }) {
       isRenewal
     )
 
-    const { recurringPayment } = await processRecurringPayment(generateRecurringPaymentRecord(transactionRecord), contact)
-    if (recurringPayment) {
-      entities.push(recurringPayment)
-    }
-
     permission.bindToEntity(Permission.definition.relationships.licensee, contact)
     permission.bindToEntity(Permission.definition.relationships.permit, permit)
     permission.bindToEntity(Permission.definition.relationships.transaction, transaction)
@@ -78,7 +73,10 @@ export async function processQueue ({ id }) {
 
     entities.push(contact, permission)
 
+    const { recurringPayment } = await processRecurringPayment(generateRecurringPaymentRecord(transactionRecord, permission), contact)
+
     if (recurringPayment && permit.isRecurringPaymentSupported) {
+      entities.push(recurringPayment)
       const paymentInstruction = new RecurringPaymentInstruction()
       paymentInstruction.bindToEntity(RecurringPaymentInstruction.definition.relationships.licensee, contact)
       paymentInstruction.bindToEntity(RecurringPaymentInstruction.definition.relationships.permit, permit)

--- a/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
+++ b/packages/sales-api-service/src/services/transactions/process-transaction-queue.js
@@ -12,7 +12,7 @@ import {
 } from '@defra-fish/dynamics-lib'
 import { DDE_DATA_SOURCE, FULFILMENT_SWITCHOVER_DATE, POCL_TRANSACTION_SOURCES } from '@defra-fish/business-rules-lib'
 import { getReferenceDataForEntityAndId, getGlobalOptionSetValue, getReferenceDataForEntity } from '../reference-data.service.js'
-import { processRecurringPayment } from '../recurring-payments.service.js'
+import { generateRecurringPaymentRecord, processRecurringPayment } from '../recurring-payments.service.js'
 import { resolveContactPayload } from '../contacts.service.js'
 import { retrieveStagedTransaction } from './retrieve-transaction.js'
 import { TRANSACTION_STAGING_TABLE, TRANSACTION_STAGING_HISTORY_TABLE } from '../../config.js'
@@ -65,7 +65,7 @@ export async function processQueue ({ id }) {
       isRenewal
     )
 
-    const { recurringPayment } = await processRecurringPayment(transactionRecord, contact)
+    const { recurringPayment } = await processRecurringPayment(generateRecurringPaymentRecord(transactionRecord), contact)
     if (recurringPayment) {
       entities.push(recurringPayment)
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4262

After a successful payment, when the permission is provisioned, a RCP record should be created along with everything else. It shouldn't be created if the RCP toggle is off