### PR TITLE
Licence to start error not in error summary

### DIFF
--- a/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
+++ b/packages/gafl-webapp-service/src/pages/licence-details/licence-to-start/licence-to-start.njk
@@ -38,6 +38,9 @@
       'date-range': {
         'date.min': { ref: '#licence-start-date-day', text: mssgs.licence_start_error_within + data.advancedPurchaseMaxDays + mssgs.licence_start_days },
         'date.max': { ref: '#licence-start-date-day', text: mssgs.licence_start_error_within + data.advancedPurchaseMaxDays + mssgs.licence_start_days }
+      },
+      'licence-to-start': {
+        'any.required': { ref: '#licence-to-start', text: mssgs.licence_start_error_choose_when }
       }
     }
 %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3913

On the licence to start page, if no option is selected, the select an option error doesn't appear in the error summary box