### PR TITLE
Missing inline error on renewals id page

### DIFF
--- a/packages/gafl-webapp-service/src/pages/renewals/identify/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/__tests__/route.spec.js
@@ -66,6 +66,23 @@ describe('getData', () => {
     await getData(getMockRequest(undefined, pageGet))
     expect(pageGet).toHaveBeenCalledWith(IDENTIFY.page)
   })
+
+  it.each([
+    ['full-date', 'object.missing'],
+    ['day', 'any.required']
+  ])('should add error details ({%s: %s}) to the page data', async (errorKey, errorValue) => {
+    const pageGet = async () => ({
+      error: { [errorKey]: errorValue }
+    })
+
+    const result = await getData(getMockRequest(undefined, pageGet))
+    expect(result.error).toEqual({ errorKey, errorValue })
+  })
+
+  it('omits error if there is no error', async () => {
+    const result = await getData(getMockRequest())
+    expect(result.error).toBeUndefined()
+  })
 })
 
 describe('default', () => {

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -141,7 +141,7 @@
                             classes: "govuk-!-font-weight-bold govuk-label"
                       }
                   },
-                  errorMessage: { text: mssgs.enter_dob } if error['date-of-birth'],
+                  errorMessage: { text: errorMap[data.error.errorKey][data.error.errorValue].text } if data.error,
                   hint: {
                     text: mssgs.enter_dob_example
                   }

--- a/packages/gafl-webapp-service/src/pages/renewals/identify/route.js
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/route.js
@@ -21,13 +21,21 @@ export const getData = async request => {
     }
   }
 
-  return {
+  const pageData = {
     referenceNumber: permission.referenceNumber,
     uri: {
       new: addLanguageCodeToUri(request, NEW_TRANSACTION.uri)
     },
     ...getDateErrorFlags(page?.error)
   }
+
+  if (page?.error) {
+    const [errorKey] = Object.keys(page.error)
+    const errorValue = page.error[errorKey]
+    pageData.error = { errorKey, errorValue }
+  }
+
+  return pageData
 }
 
 export const validator = payload => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3913

The inline error for date of birth on the renewals identity page is missing, it's only presented in the error summary box