### PR TITLE
Add Missing Welsh to Newsletter Page

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -530,7 +530,7 @@
   "new_prices_row_12_month": "12 mis",
   "new_prices_row_concession": "12 mis - pobl hŷn neu anabl",
   "new_prices_row_junior": "12 mis - ieuenctid (13 i 16)",
-  "newsletter_error_choose": "Choose if you would like to receive our email newsletter",
+  "newsletter_error_choose": "Dewiswch os hoffech dderbyn ein cylchlythyr dros e-bost",
   "newsletter_error_set_email": "Nodwch gyfeiriad e-bost yn y fformat cywir, fel enw@enghraifft.com",
   "newsletter_subscribe": "Mynnwch yr wybodaeth ddiweddaraf am genweirio, pysgodfeydd a sut rydym yn gwario eich arian trwydded. Gallwch ddatdanysgrifio ar unrhyw adeg.",
   "newsletter_title": "A hoffech chi dderbyn ein cylchlythyr dros e-bost?",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4364

Error message when no radio is selected was appearing in English when lang=cy. This ticket just adds in the Welsh.

It should be noted that the radios on the Newsletter page come preselected, so facing this error is unlikely.