### PR TITLE
Check recurring status based on transaction

### DIFF
--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/__tests__/order-complete.spec.js
@@ -105,7 +105,8 @@ const getSampleRequest = ({
   statusSet = () => {},
   statusSetCurrentPermission = () => {},
   transactionCost = 1,
-  messages = getMessages()
+  messages = getMessages(),
+  agreementId
 } = {}) => ({
   cache: () => ({
     helpers: {
@@ -116,7 +117,8 @@ const getSampleRequest = ({
       },
       transaction: {
         get: async () => ({
-          cost: transactionCost
+          cost: transactionCost,
+          agreementId
         }),
         getCurrentPermission: () => permission
       }
@@ -205,17 +207,16 @@ describe('The order completion handler', () => {
   })
 
   it.each`
-    show     | recurring | expected
-    ${true}  | ${true}   | ${true}
-    ${true}  | ${false}  | ${false}
-    ${false} | ${false}  | ${false}
-    ${false} | ${true}   | ${false}
+    show     | agreementId  | expected
+    ${true}  | ${'foo123'}  | ${true}
+    ${true}  | ${undefined} | ${false}
+    ${false} | ${'foo123'}  | ${false}
+    ${false} | ${undefined} | ${false}
   `(
-    'recurringPayment returns $expected when SHOW_RECURRING_PAYMENTS is $show and the permission recurring payment is $recurring',
-    async ({ show, recurring, expected }) => {
+    'recurringPayment returns $expected when SHOW_RECURRING_PAYMENTS is $show and the transaction agreementId is $agreementId',
+    async ({ show, agreementId, expected }) => {
       process.env.SHOW_RECURRING_PAYMENTS = show
-      const permission = getSamplePermission({ isRecurringPayment: recurring })
-      const request = getSampleRequest({ permission })
+      const request = getSampleRequest({ agreementId })
       const { recurringPayment } = await getData(request)
 
       expect(recurringPayment).toBe(expected)

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
@@ -58,12 +58,7 @@ const postalFulfilment = permission => {
   }
 }
 
-const isRecurringPayment = transaction => {
-  if (process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' && transaction.agreementId) {
-    return true
-  }
-  return false
-}
+const isRecurringPayment = transaction => !!(process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' && transaction.agreementId)
 
 const digitalConfirmation = permission =>
   permission.licensee.preferredMethodOfConfirmation === HOW_CONTACTED.email ||

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
@@ -58,7 +58,7 @@ const postalFulfilment = permission => {
   }
 }
 
-const isRecurringPayment = transaction => !!(process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' && transaction.agreementId)
+const isRecurringPayment = transaction => process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' && !!transaction.agreementId
 
 const digitalConfirmation = permission =>
   permission.licensee.preferredMethodOfConfirmation === HOW_CONTACTED.email ||

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
@@ -41,7 +41,7 @@ export const getData = async request => {
     digitalConfirmation: digital && permission.licensee.postalFulfilment,
     digitalLicence: digital && !permission.licensee.postalFulfilment,
     postalLicence: permission.licensee.postalFulfilment,
-    recurringPayment: isRecurringPayment(permission),
+    recurringPayment: isRecurringPayment(transaction),
     uri: {
       feedback: process.env.FEEDBACK_URI || FEEDBACK_URI_DEFAULT,
       licenceDetails: addLanguageCodeToUri(request, LICENCE_DETAILS.uri),
@@ -58,7 +58,12 @@ const postalFulfilment = permission => {
   }
 }
 
-const isRecurringPayment = permission => process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' && permission.isRecurringPayment
+const isRecurringPayment = transaction => {
+  if (process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' && transaction.agreementId) {
+    return true
+  }
+  return false
+}
 
 const digitalConfirmation = permission =>
   permission.licensee.preferredMethodOfConfirmation === HOW_CONTACTED.email ||


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4265

When checking on the order complete page if the new licence has a recurring payment agreement, base this off the existence of an agreementId on the transaction rather than trying to get it from the permission.