### PR TITLE
RP job handles GOV.UK Pay error responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     ],
     "testEnvironment": "node",
     "testRunner": "jest-circus/runner",
-    "silent": true
+    "silent": false,
+    "verbose": true
   }
 }

--- a/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
+++ b/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
@@ -205,7 +205,7 @@ describe('recurring-payments-processor', () => {
     )
   })
 
-  it('logs an error if createTransaction fails', async () => {
+  it('raises and logs an error if createTransaction fails', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
     salesApi.getDueRecurringPayments.mockReturnValueOnce([getMockDueRecurringPayment()])
     const error = new Error('Wuh-oh!')

--- a/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
+++ b/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
@@ -205,14 +205,18 @@ describe('recurring-payments-processor', () => {
     )
   })
 
-  it('raises an error if createTransaction fails', async () => {
+  it('logs an error if createTransaction fails', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
     salesApi.getDueRecurringPayments.mockReturnValueOnce([getMockDueRecurringPayment()])
-    const error = 'Wuh-oh!'
+    const error = new Error('Wuh-oh!')
     salesApi.createTransaction.mockImplementationOnce(() => {
-      throw new Error(error)
+      throw error
     })
+    await processRecurringPayments()
 
-    await expect(processRecurringPayments()).rejects.toThrowError(error)
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching due recurring payments:', error)
+
+    consoleErrorSpy.mockRestore()
   })
 
   it('prepares and sends the payment request', async () => {
@@ -327,6 +331,60 @@ describe('recurring-payments-processor', () => {
     await processRecurringPayments()
 
     expect(setTimeoutSpy).not.toHaveBeenCalled()
+  })
+
+  it('logs error response when payment API returns error AC1', async () => {
+    const record = getMockDueRecurringPayment()
+    salesApi.getDueRecurringPayments.mockResolvedValueOnce([record])
+    salesApi.preparePermissionDataForRenewal.mockResolvedValueOnce({ licensee: { countryCode: 'GB-ENG' } })
+    salesApi.createTransaction.mockResolvedValueOnce({ cost: 30, id: 'trans1' })
+
+    const paymentError = new TypeError("Cannot read properties of undefined (reading 'payment_id')")
+    sendPayment.mockRejectedValueOnce(paymentError)
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await processRecurringPayments()
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error sending payment for agreement:', record.entity.agreementId, 'Error:', paymentError)
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('aborts run if systems are down at the start AC2', async () => {
+    const error = new Error('Systems down')
+    salesApi.getDueRecurringPayments.mockRejectedValueOnce(error)
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await processRecurringPayments()
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching due recurring payments:', error)
+    expect(salesApi.preparePermissionDataForRenewal).not.toHaveBeenCalled()
+  })
+
+  it('continues run if systems are down mid-run and retries AC3', async () => {
+    const record = getMockDueRecurringPayment()
+    salesApi.getDueRecurringPayments.mockResolvedValueOnce([record])
+    salesApi.preparePermissionDataForRenewal.mockResolvedValueOnce({ licensee: { countryCode: 'GB-ENG' } })
+    salesApi.createTransaction.mockResolvedValueOnce({ cost: 30, id: 'trans1' })
+
+    sendPayment
+      .mockRejectedValueOnce(new Error('Temporary error'))
+      .mockResolvedValueOnce({ payment_id: 'test-payment-id', agreementId: record.entity.agreementId })
+
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    await processRecurringPayments()
+
+    expect({
+      sendPaymentCalls: sendPayment.mock.calls.length,
+      logMessages: consoleLogSpy.mock.calls.map(call => call[0])
+    }).toMatchObject({
+      sendPaymentCalls: 2,
+      logMessages: expect.arrayContaining(['Recurring Payments job enabled', 'Recurring Payments found: ', 'Preparing data based on'])
+    })
+
+    consoleLogSpy.mockRestore()
   })
 
   describe.each([2, 3, 10])('if there are %d recurring payments', count => {

--- a/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
+++ b/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
@@ -394,7 +394,7 @@ describe('recurring-payments-processor', () => {
       jest.clearAllMocks()
     })
 
-    it('should retry the specified number of times (3x) on failure', async () => {
+    it('should retry the job three times on failure', async () => {
       const retries = 3
       const delay = 1000
 

--- a/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
+++ b/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
@@ -74,6 +74,18 @@ describe('recurring-payments-processor', () => {
     expect(salesApi.preparePermissionDataForRenewal).toHaveBeenCalledWith(referenceNumber)
   })
 
+  it('aborts the run if there is the systems are down at the start of the run', async () => {
+    const error = new Error('Systems down')
+    salesApi.getDueRecurringPayments.mockRejectedValueOnce(error)
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(processRecurringPayments()).rejects.toThrow(error)
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Run aborted. Error fetching due recurring payments:', error)
+
+    consoleErrorSpy.mockRestore()
+  })
+
   it('creates a transaction with the correct data', async () => {
     salesApi.getDueRecurringPayments.mockReturnValueOnce([getMockDueRecurringPayment()])
 

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -6,7 +6,7 @@ import { getPaymentStatus, sendPayment } from './services/govuk-pay-service.js'
 const PAYMENT_STATUS_DELAY = 60000
 const payments = []
 
-const retry = async (fn, retries = 3, delay = 1000) => {
+export const retry = async (fn, retries = 3, delay = 5000) => {
   try {
     return await fn()
   } catch (error) {
@@ -31,8 +31,6 @@ export const processRecurringPayments = async () => {
       }
     } catch (error) {
       console.error('Error fetching due recurring payments:', error)
-      // abort the run if systems are down at the start of a run
-      // return
     }
   } else {
     console.log('Recurring Payments job disabled')
@@ -70,7 +68,6 @@ const takeRecurringPayment = async (agreementId, transaction) => {
     })
   } catch (error) {
     console.error('Error sending payment for agreement:', agreementId, 'Error:', error)
-    // continue with run if systems are down mid-run
   }
 }
 
@@ -126,7 +123,6 @@ const processRecurringPaymentStatus = async record => {
     console.log(`Payment status for ${paymentId}: ${JSON.stringify(status)}`)
   } catch (error) {
     console.error('Error fetching payment status for payment:', paymentId, 'Error:', error)
-    // continue with run if systems are down mid-run
   }
 }
 

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -10,7 +10,9 @@ export const retry = async (fn, retries = 3, delay = 5000) => {
   try {
     return await fn()
   } catch (error) {
-    if (retries === 0) throw error
+    if (retries === 0) {
+      throw error
+    }
     console.log(`Retrying... Attempts left: ${retries}`)
     await new Promise(resolve => setTimeout(resolve, delay))
     return retry(fn, retries - 1, delay * 2)

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -19,7 +19,8 @@ export const processRecurringPayments = async () => {
         await Promise.all(response.map(record => processRecurringPaymentStatus(record)))
       }
     } catch (error) {
-      console.error('Error fetching due recurring payments:', error)
+      console.error('Run aborted. Error fetching due recurring payments:', error)
+      throw error
     }
   } else {
     console.log('Recurring Payments job disabled')

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -13,7 +13,7 @@ export const retry = async (fn, retries = 3, delay = 5000) => {
     if (retries === 0) {
       throw error
     }
-    console.log(`Retrying... Attempts left: ${retries}`)
+    console.log(`Error: ${error}. Retrying... Attempts left: ${retries}`)
     await new Promise(resolve => setTimeout(resolve, delay))
     return retry(fn, retries - 1, delay * 2)
   }

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -32,7 +32,7 @@ export const processRecurringPayments = async () => {
     } catch (error) {
       console.error('Error fetching due recurring payments:', error)
       // abort the run if systems are down at the start of a run
-      return
+      // return
     }
   } else {
     console.log('Recurring Payments job disabled')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4021

If our request to the payment API returns an error response code (for example, if the API is down or if our authorisation is invalid) then the recurring payment job needs to handle this gracefully. This ticket implements and error catching and logging.

If we receive an error response, this response is outputted to our logs; we abort the run if systems are down at the start of a run and try again; we continue with run if systems are down mid-run and try again; If, after both runs, a payment has still not been taken,  the run on the following day will detect that the window for processing these payments has passed and automatically cancel them.