### PR TITLE
Clarify RP agreement status when first payment does not go through

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -600,6 +600,7 @@
   "payment_cancelled_title": "Mae eich taliad wedi cael ei ganslo",
   "payment_failed_expired": "Ni chafodd y taliad ei gwblhau o fewn 90 munud o greu’r cais",
   "payment_failed_not_taken": "Nid oes unrhyw arian wedi cael ei dynnu o’ch cyfrif.",
+  "payment_failed_not_taken_recurring": "Nid oes unrhyw arian wedi cael ei dynnu o’ch cyfrif ac nid yw eich manylion talu wedi cael eu harbed ar gyfer y taliad cerdyn sy’n ailadrodd.",
   "payment_failed_rejected": "Mae’r taliad wedi cael ei wrthod gan ddarparwr y taliad. Sicrhewch eich bod wedi mewnbynnu manylion eich cerdyn yn gywir a bod digon o arian ar gael yn eich cyfrif",
   "payment_failed_title_1": "Mae eich cais i dalu wedi dod i ben",
   "payment_failed_title_2": "Mae eich taliad wedi cael ei wrthod",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -603,6 +603,7 @@
   "payment_cancelled_title": "Your payment has been cancelled",
   "payment_failed_expired": "The payment was not completed within 90 minutes of being created",
   "payment_failed_not_taken": "No money has been taken from your account.",
+  "payment_failed_not_taken_recurring": "No money has been taken from your account and your payment details have not been saved for the recurring card payment.",
   "payment_failed_rejected": "The payment was rejected by the payment provider. Please ensure that you entered your card details correctly and that you have sufficient funds in your account",
   "payment_failed_title_1": "Your payment has expired",
   "payment_failed_title_2": "Your payment was rejected",

--- a/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
+++ b/packages/gafl-webapp-service/src/pages/order-complete/order-complete/route.js
@@ -8,6 +8,7 @@ import { nextPage } from '../../../routes/next-page.js'
 import { addLanguageCodeToUri } from '../../../processors/uri-helper.js'
 import { displayPrice } from '../../../processors/price-display.js'
 import { HOW_CONTACTED } from '../../../processors/mapping-constants.js'
+import { isRecurringPayment } from '../../../processors/recurring-pay-helper.js'
 
 export const getData = async request => {
   const status = await request.cache().helpers.status.get()
@@ -57,8 +58,6 @@ const postalFulfilment = permission => {
     return 'non_postal'
   }
 }
-
-const isRecurringPayment = transaction => process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' && !!transaction.agreementId
 
 const digitalConfirmation = permission =>
   permission.licensee.preferredMethodOfConfirmation === HOW_CONTACTED.email ||

--- a/packages/gafl-webapp-service/src/pages/payment/cancelled/payment-cancelled.njk
+++ b/packages/gafl-webapp-service/src/pages/payment/cancelled/payment-cancelled.njk
@@ -18,7 +18,11 @@
               }
             }) %}
 
-                <p class="govuk-body-m">{{ mssgs.payment_failed_not_taken }}</p>
+                {% if data.recurringPayment %}
+                    <p class="govuk-body-m">{{ mssgs.payment_failed_not_taken_recurring }}</p>
+                {% else %}
+                    <p class="govuk-body-m">{{ mssgs.payment_failed_not_taken }}</p>
+                {% endif %}
 
             {% endcall %}
 

--- a/packages/gafl-webapp-service/src/pages/payment/cancelled/route.js
+++ b/packages/gafl-webapp-service/src/pages/payment/cancelled/route.js
@@ -3,11 +3,13 @@ import pageRoute from '../../../routes/page-route.js'
 import { PAYMENT_CANCELLED, NEW_TRANSACTION } from '../../../uri.js'
 import { nextPage } from '../../../routes/next-page.js'
 import { addLanguageCodeToUri } from '../../../processors/uri-helper.js'
+import { isRecurringPayment } from '../../../processors/recurring-pay-helper.js'
 
 import { COMPLETION_STATUS } from '../../../constants.js'
 
 export const getData = async request => {
   const status = await request.cache().helpers.status.get()
+  const transaction = await request.cache().helpers.transaction.get()
 
   // If the payment created flag is not set to true then throw an exception
   if (!status[COMPLETION_STATUS.paymentCreated]) {
@@ -15,6 +17,7 @@ export const getData = async request => {
   }
 
   return {
+    recurringPayment: isRecurringPayment(transaction),
     uri: {
       new: addLanguageCodeToUri(request, NEW_TRANSACTION.uri)
     }

--- a/packages/gafl-webapp-service/src/pages/payment/failed/payment-failed.njk
+++ b/packages/gafl-webapp-service/src/pages/payment/failed/payment-failed.njk
@@ -31,7 +31,12 @@
                 {% elseif data['failure-code'] === data.codes.REJECTED %}
                     <p class="govuk-body-m">{{ mssgs.payment_failed_rejected }}</p>
                 {% endif %}
-                <p class="govuk-body-m">{{ mssgs.payment_failed_not_taken }}</p>
+
+                {% if data.recurringPayment %}
+                    <p class="govuk-body-m">{{ mssgs.payment_failed_not_taken_recurring }}</p>
+                {% else %}
+                    <p class="govuk-body-m">{{ mssgs.payment_failed_not_taken }}</p>
+                {% endif %}
 
             {% endcall %}
 

--- a/packages/gafl-webapp-service/src/pages/payment/failed/route.js
+++ b/packages/gafl-webapp-service/src/pages/payment/failed/route.js
@@ -5,9 +5,11 @@ import { COMPLETION_STATUS } from '../../../constants.js'
 import { PAYMENT_FAILED, NEW_TRANSACTION } from '../../../uri.js'
 import { nextPage } from '../../../routes/next-page.js'
 import { addLanguageCodeToUri } from '../../../processors/uri-helper.js'
+import { isRecurringPayment } from '../../../processors/recurring-pay-helper.js'
 
 export const getData = async request => {
   const status = await request.cache().helpers.status.get()
+  const transaction = await request.cache().helpers.transaction.get()
 
   // If the cancelled flag is not set to true then throw an exception
   if (!status[COMPLETION_STATUS.paymentFailed]) {
@@ -17,6 +19,7 @@ export const getData = async request => {
   return {
     codes: GOVUK_PAY_ERROR_STATUS_CODES,
     'failure-code': status.payment.code,
+    recurringPayment: isRecurringPayment(transaction),
     uri: {
       new: addLanguageCodeToUri(request, NEW_TRANSACTION.uri)
     }

--- a/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
+++ b/packages/gafl-webapp-service/src/processors/recurring-pay-helper.js
@@ -21,3 +21,5 @@ export const validForRecurringPayment = permission => {
     process.env.CHANNEL?.toLowerCase() !== 'telesales'
   )
 }
+
+export const isRecurringPayment = transaction => process.env.SHOW_RECURRING_PAYMENTS?.toLowerCase() === 'true' && !!transaction.agreementId


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4514

When a user decides to set up a recurring payment agreement but then cancels the first payment, or the first payment fails, we want to include additional text on the cancel or failure page to confirm that they have not finished setting up the agreement for future payments.

This includes a bit of refactoring to use some existing logic from the order complete page.