### PR TITLE
Amend recurring payment transaction to contain reference to recurring payment

### DIFF
--- a/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
+++ b/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
@@ -100,6 +100,7 @@ describe('recurring-payments-processor', () => {
 
     const expectedData = {
       dataSource: 'Recurring Payment',
+      agreementId: 'test-agreement-id',
       permissions: [
         {
           isLicenceForYou,
@@ -380,6 +381,7 @@ describe('recurring-payments-processor', () => {
         expectedData.push([
           {
             dataSource: 'Recurring Payment',
+            agreementId: 'test-agreement-id',
             permissions: [expect.objectContaining({ permitId: permit })]
           }
         ])

--- a/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
+++ b/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
@@ -270,7 +270,7 @@ describe('recurring-payments-processor', () => {
     sendPayment.mockResolvedValueOnce(mockPaymentResponse)
 
     await processRecurringPayments()
-    jest.advanceTimersByTime(60000)
+    jest.useFakeTimers(60000)
 
     expect(getPaymentStatus).toHaveBeenCalledWith('test-payment-id')
   })

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -30,7 +30,7 @@ const processRecurringPayment = async record => {
 }
 
 const createNewTransaction = async (referenceNumber, agreementId) => {
-  const transactionData = await processPermissionData(agreementId, referenceNumber)
+  const transactionData = await processPermissionData(referenceNumber, agreementId)
   console.log('Creating new transaction based on', referenceNumber, 'with agreementId', agreementId)
   try {
     const response = await salesApi.createTransaction(transactionData)
@@ -52,8 +52,8 @@ const takeRecurringPayment = async (agreementId, transaction) => {
   })
 }
 
-const processPermissionData = async (agreementId, referenceNumber) => {
-  console.log('Preparing data based on', referenceNumber, ', Agreement ID:', agreementId)
+const processPermissionData = async (referenceNumber, agreementId) => {
+  console.log('Preparing data based on', referenceNumber, 'with agreementId', agreementId)
   const data = await salesApi.preparePermissionDataForRenewal(referenceNumber)
   const licenseeWithoutCountryCode = Object.assign((({ countryCode: _countryCode, ...l }) => l)(data.licensee))
   return {

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -25,13 +25,13 @@ export const processRecurringPayments = async () => {
 const processRecurringPayment = async record => {
   const referenceNumber = record.expanded.activePermission.entity.referenceNumber
   const agreementId = record.entity.agreementId
-  const transaction = await createNewTransaction(referenceNumber)
+  const transaction = await createNewTransaction(referenceNumber, agreementId)
   await takeRecurringPayment(agreementId, transaction)
 }
 
-const createNewTransaction = async referenceNumber => {
-  const transactionData = await processPermissionData(referenceNumber)
-  console.log('Creating new transaction based on', referenceNumber)
+const createNewTransaction = async (referenceNumber, agreementId) => {
+  const transactionData = await processPermissionData(agreementId, referenceNumber)
+  console.log('Creating new transaction based on', referenceNumber, 'with agreementId', agreementId)
   try {
     const response = await salesApi.createTransaction(transactionData)
     console.log('New transaction created:', response)
@@ -52,12 +52,13 @@ const takeRecurringPayment = async (agreementId, transaction) => {
   })
 }
 
-const processPermissionData = async referenceNumber => {
-  console.log('Preparing data based on', referenceNumber)
+const processPermissionData = async (agreementId, referenceNumber) => {
+  console.log('Preparing data based on', referenceNumber, ', Agreement ID:', agreementId)
   const data = await salesApi.preparePermissionDataForRenewal(referenceNumber)
   const licenseeWithoutCountryCode = Object.assign((({ countryCode: _countryCode, ...l }) => l)(data.licensee))
   return {
     dataSource: 'Recurring Payment',
+    agreementId,
     permissions: [
       {
         isLicenceForYou: data.isLicenceForYou,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4516

We want the transaction created for a recurring payment to contain a reference to the recurring payment

So that we are able to update the existing recurring payment and create a follow-on payment once a new Permission is provisioned

The createNewTransaction function in recurring-payments-processor adds the agreement id to the transaction.