### PR TITLE
Missing Welsh from Licence-type selection page

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -498,7 +498,7 @@
   "licence_type_salmon_acr_note_2_BOBO": "Mae’n rhaid iddynt ",
   "licence_type_salmon_acr_note_3_BOBO": " pan fyddant wedi gorffen pysgota am y flwyddyn, hyd yn oed os nad ydynt wedi dal unrhyw eogiaid na brithyllod y môr.",
   "licence_type_salmon_acr_note_link": "gyflwyno ffurflen ddalfa flynyddol (yn agor mewn tab newydd)",
-  "licence_type_salmon_junior": "You’ll only need this licence if you are specifically fishing for salmon or sea trout.",
+  "licence_type_salmon_junior": "Dim ond os byddwch chi’n pysgota’n benodol ar gyfer eogiaid a brithyllod y môr y bydd angen y drwydded hon arnoch.",
   "licence_type_title_other": "Pa fath o drwydded sydd ei hangen arnynt?",
   "licence_type_title_you": "Pa fath o drwydded sydd ei hangen arnoch?",
   "licence_type_trout_three_rod": "Mae’n cwmpasu brithyllod anfudol a phob pysgodyn dŵr croyw, ond nid eogiaid na brithyllod y môr. Mae’r holl ddulliau pysgota gan ddefnyddio hyd at 3 gwialen wedi’u cwmpasu. Er enghraifft pysgota arbenigol ar gyfer carp gan ddefnyddio 3 gwialen ar yr un pryd.",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4518

Welsh translation for junior hint text was not included on licence type selection page.