### PR TITLE
implement fail screen for easy renewals journey Part 1

### DIFF
--- a/packages/gafl-webapp-service/src/pages/renewals/identify/licence-not-found.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/licence-not-found.njk
@@ -1,0 +1,23 @@
+{% extends "layout.njk" %}
+{% from "fieldset/macro.njk" import govukFieldset %}
+
+{% set title = data.title %}
+
+{% block pageTitle %}{{ title }}{{ mssgs.gov_uk }}{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            {% call govukFieldset({
+                legend: {
+                    text: title,
+                    classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-3",
+                    isPageHeading: true
+                }
+            }) %}
+
+            {% endcall %}
+        </div>
+    </div>
+{% endblock %}

--- a/packages/gafl-webapp-service/src/uri.js
+++ b/packages/gafl-webapp-service/src/uri.js
@@ -48,6 +48,7 @@ export const IDENTIFY = { uri: '/buy/renew/identify', page: 'identify' }
 export const RENEWAL_INACTIVE = { uri: '/buy/renew/inactive', page: 'renewal-inactive' }
 export const AUTHENTICATE = { uri: '/buy/renew/authenticate' }
 export const RENEWAL_START_DATE = { uri: '/buy/renew/renewal-start-date', page: 'renewal-start-date' }
+export const RENEWAL_NO_MATCH = { uri: '/buy/renew/licence-not-found', page: 'licence-not-found' }
 
 export const CONTROLLER = { uri: '/buy' }
 export const NEW_TRANSACTION = { uri: '/buy/new' }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4392

The easy renewals journey is using error validation to tell a user they are not eligible to use the service (in this case because their details do not match any in our systems). This is not a correct use of the design pattern: [Recover from validation errors](https://design-system.service.gov.uk/patterns/validation/) 

“Do not use validation to check whether the user is eligible to use the service”

Instead the user should be taken to a new screen that tells them what has happened and what they need to do next.