### PR TITLE
Add validation schemas to recurring payment routes

### DIFF
--- a/packages/sales-api-service/src/schema/recurring-payments.schema.js
+++ b/packages/sales-api-service/src/schema/recurring-payments.schema.js
@@ -19,3 +19,13 @@ export const dueRecurringPaymentsResponseSchema = Joi.object({
     activePermission: { entity: finalisedPermissionSchemaContent }
   })
 })
+
+export const dueRecurringPaymentsRequestParamsSchema = Joi.object({
+  date: Joi.string().isoDate().required()
+})
+
+export const processRPResultRequestParamsSchema = Joi.object({
+  transactionId: Joi.string().required(),
+  paymentId: Joi.string().required(),
+  createdDate: Joi.string().isoDate().required()
+})

--- a/packages/sales-api-service/src/server/routes/__tests__/recurring-payments.spec.js
+++ b/packages/sales-api-service/src/server/routes/__tests__/recurring-payments.spec.js
@@ -1,5 +1,6 @@
 import recurringPayments from '../recurring-payments.js'
 import { getRecurringPayments, processRPResult } from '../../../services/recurring-payments.service.js'
+import { dueRecurringPaymentsRequestParamsSchema, processRPResultRequestParamsSchema } from '../../../schema/recurring-payments.schema.js'
 
 const [
   {
@@ -13,6 +14,11 @@ const [
 jest.mock('../../../services/recurring-payments.service.js', () => ({
   getRecurringPayments: jest.fn(),
   processRPResult: jest.fn()
+}))
+
+jest.mock('../../../schema/recurring-payments.schema.js', () => ({
+  dueRecurringPaymentsRequestParamsSchema: jest.fn(),
+  processRPResultRequestParamsSchema: jest.fn()
 }))
 
 const getMockRequest = ({
@@ -44,6 +50,13 @@ describe('recurring payments', () => {
       await drpHandler(request, getMockResponseToolkit())
       expect(getRecurringPayments).toHaveBeenCalledWith(date)
     })
+
+    it('should validate with dueRecurringPaymentsRequestParamsSchema', async () => {
+      const date = Symbol('date')
+      const request = getMockRequest({ date })
+      await drpHandler(request, getMockResponseToolkit())
+      expect(recurringPayments[0].options.validate.params).toBe(dueRecurringPaymentsRequestParamsSchema)
+    })
   })
 
   describe('processRPResult', () => {
@@ -60,6 +73,13 @@ describe('recurring payments', () => {
       const request = getMockRequest({ transactionId, paymentId, createdDate })
       await prpHandler(request, getMockResponseToolkit())
       expect(processRPResult).toHaveBeenCalledWith(transactionId, paymentId, createdDate)
+    })
+
+    it('should validate with dueRecurringPaymentsRequestParamsSchema', async () => {
+      const date = Symbol('date')
+      const request = getMockRequest({ date })
+      await drpHandler(request, getMockResponseToolkit())
+      expect(recurringPayments[1].options.validate.params).toBe(processRPResultRequestParamsSchema)
     })
   })
 })

--- a/packages/sales-api-service/src/server/routes/recurring-payments.js
+++ b/packages/sales-api-service/src/server/routes/recurring-payments.js
@@ -1,4 +1,8 @@
-import { dueRecurringPaymentsResponseSchema } from '../../schema/recurring-payments.schema.js'
+import {
+  dueRecurringPaymentsRequestParamsSchema,
+  dueRecurringPaymentsResponseSchema,
+  processRPResultRequestParamsSchema
+} from '../../schema/recurring-payments.schema.js'
 import { getRecurringPayments, processRPResult } from '../../services/recurring-payments.service.js'
 
 export default [
@@ -13,6 +17,9 @@ export default [
       },
       description: 'Retrieve recurring payments due for the specified date',
       tags: ['api', 'recurring-payments'],
+      validate: {
+        params: dueRecurringPaymentsRequestParamsSchema
+      },
       plugins: {
         'hapi-swagger': {
           responses: {
@@ -34,6 +41,9 @@ export default [
       },
       description: 'Generate a permission from a recurring payment record',
       tags: ['api', 'recurring-payments'],
+      validate: {
+        params: processRPResultRequestParamsSchema
+      },
       plugins: {
         'hapi-swagger': {
           responses: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4640

The new routes added to the Sales API for recurring payments should have proper validation.