### PR TITLE
RP Job Handles API Erros / Failed Payments

### DIFF
--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -5,6 +5,7 @@ import { getPaymentStatus, sendPayment } from './services/govuk-pay-service.js'
 
 const PAYMENT_STATUS_DELAY = 60000
 const payments = []
+const PAYMENT_STATUS_SUCCESS = 'success'
 
 export const processRecurringPayments = async () => {
   if (process.env.RUN_RECURRING_PAYMENTS?.toLowerCase() === 'true') {
@@ -30,13 +31,13 @@ export const processRecurringPayments = async () => {
 const processRecurringPayment = async record => {
   const referenceNumber = record.expanded.activePermission.entity.referenceNumber
   const agreementId = record.entity.agreementId
-  const transaction = await createNewTransaction(referenceNumber)
+  const transaction = await createNewTransaction(referenceNumber, agreementId)
   await takeRecurringPayment(agreementId, transaction)
 }
 
-const createNewTransaction = async referenceNumber => {
-  const transactionData = await processPermissionData(referenceNumber)
-  console.log('Creating new transaction based on', referenceNumber)
+const createNewTransaction = async (referenceNumber, agreementId) => {
+  const transactionData = await processPermissionData(referenceNumber, agreementId)
+  console.log('Creating new transaction based on', referenceNumber, 'with agreementId', agreementId)
   try {
     const response = await salesApi.createTransaction(transactionData)
     console.log('New transaction created:', response)
@@ -61,12 +62,13 @@ const takeRecurringPayment = async (agreementId, transaction) => {
   }
 }
 
-const processPermissionData = async referenceNumber => {
-  console.log('Preparing data based on', referenceNumber)
+const processPermissionData = async (referenceNumber, agreementId) => {
+  console.log('Preparing data based on', referenceNumber, 'with agreementId', agreementId)
   const data = await salesApi.preparePermissionDataForRenewal(referenceNumber)
   const licenseeWithoutCountryCode = Object.assign((({ countryCode: _countryCode, ...l }) => l)(data.licensee))
   return {
     dataSource: 'Recurring Payment',
+    agreementId,
     permissions: [
       {
         isLicenceForYou: data.isLicenceForYou,
@@ -106,17 +108,16 @@ const preparePayment = (agreementId, transaction) => {
 const processRecurringPaymentStatus = async record => {
   const agreementId = record.entity.agreementId
   const paymentId = getPaymentId(agreementId)
-  try {
-    const {
-      state: { status }
-    } = await getPaymentStatus(paymentId)
-    console.log(`Payment status for ${paymentId}: ${JSON.stringify(status)}`)
-  } catch (error) {
-    console.error('Error fetching payment status for payment:', paymentId, 'Error:', error)
+  const {
+    state: { status }
+  } = await getPaymentStatus(paymentId)
+  console.log(`Payment status for ${paymentId}: ${status}`)
+  if (status === PAYMENT_STATUS_SUCCESS) {
+    const payment = payments.find(p => p.paymentId === paymentId)
+    await salesApi.processRPResult(payment.transaction.id, paymentId, payment.created_date)
   }
 }
 
 const getPaymentId = agreementId => {
-  const payment = payments.find(p => p.agreementId === agreementId)
-  return payment.paymentId
+  return payments.find(p => p.agreementId === agreementId).paymentId
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4021

When the recurring payments job sends a “create payment” request to GOV.UK Pay , we expect it to return confirmation that our payment request has been received.

Similarly, when we send our second request , we expect it to return the status of our payment request.

However, if our request to the payment API returns an error response code (for example, if the API is down or if our authorisation is invalid) then the recurring payment job needs to handle this gracefully.

-error responses should be outputted to our logs; abort the run if systems are down at the start of a run and try again; continue with run if systems are down mid-run and try again

-after both runs, if a payment has still not been taken,  the run on the following day will detect that the window for processing these payments has passed and automatically cancel them.