### PR TITLE
Fix field names in test

### DIFF
--- a/packages/dynamics-lib/src/queries/__tests__/recurring-payments-queries.spec.js
+++ b/packages/dynamics-lib/src/queries/__tests__/recurring-payments-queries.spec.js
@@ -51,7 +51,8 @@ describe('Recurring Payment Queries', () => {
           '_defra_activepermission_value',
           '_defra_contact_value',
           'defra_publicid',
-          '_defra_nextrecurringpayment_value'
+          '_defra_nextrecurringpayment_value',
+          'defra_lastdigitscardnumbers'
         ]
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4513

This test was written on one branch while the defra_lastdigitscardnumbers field was being added on another, so once they were merged it failed.