### PR TITLE
Amend test:watch to automatically enable verbose and non-silent running

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "husky install",
     "test": "jest",
     "test:only-changed": "jest --changedSince develop",
-    "test:watch": "jest --watch",
+    "test:watch": "jest --watch --verbose --silent false",
     "format": "prettier-standard",
     "lerna:clean": "lerna clean --yes",
     "lerna:bootstrap": "lerna bootstrap",


### PR DESCRIPTION
The `test:watch` command runs in silent, non-verbose mode by default which isn't what we want; we want console logs and errors displayed in full without always having to amend our local package.json and then having to constantly `git stash` to get changes, etc.