### PR TITLE
RP job handles GOV.UK Pay error responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "http-response-status-code": "^1.7.5"
+      },
       "devDependencies": {
         "@babel/core": "^7.17.2",
         "@babel/eslint-parser": "^7.17.0",
@@ -10866,6 +10869,33 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/http-response-status-code": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/http-response-status-code/-/http-response-status-code-1.7.5.tgz",
+      "integrity": "sha512-TniWrgb6YebncsjCxxMz0aOkJ9iw1y3kPIkzeUbdzKfR5m2BqtVOKxMe7L7NhHy3oqccayCV4FR+Y5U77GqC7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Skillnter"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/skillnter"
+        },
+        {
+          "type": "open_collective",
+          "url": "https://opencollective.com/http-response-status-code"
+        },
+        {
+          "type": "buy_me_a_coffee",
+          "url": "https://buymeacoffee.com/skillnter"
+        },
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.com/paypalme/skillnte"
+        }
+      ]
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -105,5 +105,8 @@
     "testEnvironment": "node",
     "testRunner": "jest-circus/runner",
     "silent": true
+  },
+  "dependencies": {
+    "http-response-status-code": "^1.7.5"
   }
 }

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -2,26 +2,54 @@ import moment from 'moment-timezone'
 import { SERVICE_LOCAL_TIME } from '@defra-fish/business-rules-lib'
 import { salesApi } from '@defra-fish/connectors-lib'
 import { getPaymentStatus, sendPayment } from './services/govuk-pay-service.js'
-import db from 'debug'
-const debug = db('recurring-payments:processor')
+import { isClientError, isServerError } from 'http-response-status-code'
 
 const PAYMENT_STATUS_DELAY = 60000
 const payments = []
 const PAYMENT_STATUS_SUCCESS = 'success'
 
+const fetchDueRecurringPayments = async date => {
+  try {
+    const duePayments = await salesApi.getDueRecurringPayments(date)
+    console.log('Recurring Payments found:', duePayments)
+    return duePayments
+  } catch (error) {
+    console.error('Run aborted. Error fetching due recurring payments:', error)
+    throw error
+  }
+}
+
 export const processRecurringPayments = async () => {
-  if (process.env.RUN_RECURRING_PAYMENTS?.toLowerCase() === 'true') {
-    debug('Recurring Payments job enabled')
-    const date = new Date().toISOString().split('T')[0]
-    const response = await salesApi.getDueRecurringPayments(date)
-    debug('Recurring Payments found: ', response)
-    await Promise.all(response.map(record => processRecurringPayment(record)))
-    if (response.length > 0) {
-      await new Promise(resolve => setTimeout(resolve, PAYMENT_STATUS_DELAY))
-      await Promise.all(response.map(record => processRecurringPaymentStatus(record)))
-    }
-  } else {
-    debug('Recurring Payments job disabled')
+  if (process.env.RUN_RECURRING_PAYMENTS?.toLowerCase() !== 'true') {
+    console.log('Recurring Payments job disabled')
+    return
+  }
+
+  console.log('Recurring Payments job enabled')
+  const date = new Date().toISOString().split('T')[0]
+
+  // FETCH DUE PAYMENTS
+  const dueRCPayments = await fetchDueRecurringPayments(date)
+  if (dueRCPayments.length === 0) {
+    return
+  }
+
+  // REQUEST THE PAYMENTS
+  try {
+    await Promise.all(dueRCPayments.map(processRecurringPayment))
+  } catch (error) {
+    console.error('Run aborted. Error requesting payments:', error)
+    throw error
+  }
+
+  // WAIT, THEN POLL STATUS
+  await new Promise(resolve => setTimeout(resolve, PAYMENT_STATUS_DELAY))
+
+  try {
+    await Promise.all(dueRCPayments.map(processRecurringPaymentStatus))
+  } catch (error) {
+    console.error('Run aborted. Error retrieving payment statuses:', error)
+    throw error
   }
 }
 
@@ -34,20 +62,20 @@ const processRecurringPayment = async record => {
 
 const createNewTransaction = async (referenceNumber, agreementId) => {
   const transactionData = await processPermissionData(referenceNumber, agreementId)
-  debug('Creating new transaction based on: ', referenceNumber, 'with agreementId: ', agreementId)
+  console.log('Creating new transaction based on', referenceNumber, 'with agreementId', agreementId)
   try {
     const response = await salesApi.createTransaction(transactionData)
-    debug('New transaction created:', response)
+    console.log('New transaction created:', response)
     return response
   } catch (e) {
-    console.error('Error creating transaction', JSON.stringify(transactionData))
+    console.log('Error creating transaction', JSON.stringify(transactionData))
     throw e
   }
 }
 
 const takeRecurringPayment = async (agreementId, transaction) => {
   const preparedPayment = preparePayment(agreementId, transaction)
-  debug('Requesting payment:', preparedPayment)
+  console.log('Requesting payment:', preparedPayment)
   const payment = await sendPayment(preparedPayment)
   payments.push({
     agreementId,
@@ -58,7 +86,7 @@ const takeRecurringPayment = async (agreementId, transaction) => {
 }
 
 const processPermissionData = async (referenceNumber, agreementId) => {
-  debug('Preparing data based on', referenceNumber, 'with agreementId', agreementId)
+  console.log('Preparing data based on', referenceNumber, 'with agreementId', agreementId)
   const data = await salesApi.preparePermissionDataForRenewal(referenceNumber)
   const licenseeWithoutCountryCode = Object.assign((({ countryCode: _countryCode, ...l }) => l)(data.licensee))
   return {
@@ -103,14 +131,28 @@ const preparePayment = (agreementId, transaction) => {
 const processRecurringPaymentStatus = async record => {
   const agreementId = record.entity.agreementId
   const paymentId = getPaymentId(agreementId)
-  const {
-    state: { status }
-  } = await getPaymentStatus(paymentId)
-  debug(`Payment status for ${paymentId}: ${status}`)
-  if (status === PAYMENT_STATUS_SUCCESS) {
-    const payment = payments.find(p => p.paymentId === paymentId)
-    await salesApi.processRPResult(payment.transaction.id, paymentId, payment.created_date)
-    debug(`Processed Recurring Payment for ${payment.transaction.id}`)
+
+  try {
+    const {
+      state: { status }
+    } = await getPaymentStatus(paymentId)
+
+    console.log(`Payment status for ${paymentId}: ${status}`)
+    if (status === PAYMENT_STATUS_SUCCESS) {
+      const payment = payments.find(p => p.paymentId === paymentId)
+      await salesApi.processRPResult(payment.transaction.id, paymentId, payment.created_date)
+    }
+  } catch (error) {
+    const status = error.response?.status
+
+    if (isClientError(status)) {
+      console.error(`Failed to fetch status for payment ${paymentId}, error ${status}`)
+    } else if (isServerError(status)) {
+      console.error(`Payment status API error for ${paymentId}, error ${status}`)
+    } else {
+      console.error(`Unexpected error fetching payment status for ${paymentId}.`)
+    }
+    throw error
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4021

When the recurring payments job sends a “create payment” request to GOV.UK Pay, we expect it to return confirmation that our payment request has been received. However, if our request to the payment API returns an error response code (for example, if the API is down or if our authorisation is invalid) then the recurring payment job needs to handle this gracefully.