### PR TITLE
Sanitise payment details in logging

### DIFF
--- a/packages/gafl-webapp-service/src/services/payment/__test__/govuk-pay-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/payment/__test__/govuk-pay-service.spec.js
@@ -449,7 +449,7 @@ describe('The govuk-pay-service', () => {
     it('should log debug message when response.ok is true', async () => {
       const resBody = { card_details: { foo: Symbol('foo') }, bar: Symbol('bar'), baz: Symbol('baz') }
       // eslint-disable-next-line camelcase
-      const { card_details, ...expectedLoggedOutput } = resBody
+      const { _card_details, ...expectedLoggedOutput } = resBody
       govUkPayApi.fetchPaymentStatus.mockResolvedValue(getMockFetchPaymentStatus(resBody))
 
       await getPaymentStatus(paymentId)

--- a/packages/gafl-webapp-service/src/services/payment/__test__/govuk-pay-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/payment/__test__/govuk-pay-service.spec.js
@@ -447,9 +447,8 @@ describe('The govuk-pay-service', () => {
     })
 
     it('should log debug message when response.ok is true', async () => {
-      const resBody = { card_details: { foo: Symbol('foo') }, bar: Symbol('bar'), baz: Symbol('baz') }
-      // eslint-disable-next-line camelcase
-      const { _card_details, ...expectedLoggedOutput } = resBody
+      const expectedLoggedOutput = { bar: Symbol('bar'), baz: Symbol('baz') }
+      const resBody = { card_details: { foo: Symbol('foo') }, ...expectedLoggedOutput }
       govUkPayApi.fetchPaymentStatus.mockResolvedValue(getMockFetchPaymentStatus(resBody))
 
       await getPaymentStatus(paymentId)

--- a/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
+++ b/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
@@ -94,7 +94,7 @@ export const getPaymentStatus = async (paymentId, recurring = false) => {
   if (response.ok) {
     const resBody = await response.json()
     // eslint-disable-next-line camelcase
-    const { _card_details, ...loggableBody } = resBody
+    const { card_details: _card_details, ...loggableBody } = resBody
     debug('Payment status response: %o', loggableBody)
     return resBody
   } else {

--- a/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
+++ b/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
@@ -94,7 +94,7 @@ export const getPaymentStatus = async (paymentId, recurring = false) => {
   if (response.ok) {
     const resBody = await response.json()
     // eslint-disable-next-line camelcase
-    const { card_details, ...loggableBody } = resBody
+    const { _card_details, ...loggableBody } = resBody
     debug('Payment status response: %o', loggableBody)
     return resBody
   } else {

--- a/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
+++ b/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
@@ -93,7 +93,9 @@ export const getPaymentStatus = async (paymentId, recurring = false) => {
 
   if (response.ok) {
     const resBody = await response.json()
-    debug('Payment status response: %o', resBody)
+    // eslint-disable-next-line camelcase
+    const { card_details, ...loggableBody } = resBody
+    debug('Payment status response: %o', loggableBody)
     return resBody
   } else {
     const mes = {

--- a/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
+++ b/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
@@ -93,7 +93,8 @@ export const getPaymentStatus = async (paymentId, recurring = false) => {
 
   if (response.ok) {
     const resBody = await response.json()
-    const { card_details: _cardDetails, ...loggableBody } = resBody
+    // eslint-disable-next-line camelcase
+    const { card_details, ...loggableBody } = resBody
     debug('Payment status response: %o', loggableBody)
     return resBody
   } else {

--- a/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
+++ b/packages/gafl-webapp-service/src/services/payment/govuk-pay-service.js
@@ -93,8 +93,7 @@ export const getPaymentStatus = async (paymentId, recurring = false) => {
 
   if (response.ok) {
     const resBody = await response.json()
-    // eslint-disable-next-line camelcase
-    const { card_details: _card_details, ...loggableBody } = resBody
+    const { card_details: _cardDetails, ...loggableBody } = resBody
     debug('Payment status response: %o', loggableBody)
     return resBody
   } else {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4351

This removes the card_details from the logs when we are checking the payment status from GOV.UK Pay.