### PR TITLE
Set name of RecurringPayment record

### DIFF
--- a/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
+++ b/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
@@ -6,7 +6,7 @@ Object {
   "cancelledDate": null,
   "cancelledReason": null,
   "endDate": 2023-11-12T00:00:00.000Z,
-  "name": "Firstname Lastname 2023",
+  "name": "Fester Tester 2023",
   "nextDueDate": 2023-11-02T00:00:00.000Z,
   "publicId": "abcdef99987",
   "status": 0,

--- a/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
+++ b/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
@@ -5,9 +5,9 @@ Object {
   "agreementId": "435678",
   "cancelledDate": null,
   "cancelledReason": null,
-  "endDate": 2023-11-12T00:00:00.000Z,
+  "endDate": "2023-11-12T00:00:00.000Z",
   "name": "Fester Tester 2023",
-  "nextDueDate": 2023-11-02T00:00:00.000Z,
+  "nextDueDate": "2023-11-02T00:00:00.000Z",
   "publicId": "abcdef99987",
   "status": 0,
 }

--- a/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
+++ b/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
@@ -6,7 +6,7 @@ Object {
   "cancelledDate": null,
   "cancelledReason": null,
   "endDate": 2023-11-12T00:00:00.000Z,
-  "name": "Firstname Lastname Duedate",
+  "name": "Firstname Lastname 2023",
   "nextDueDate": 2023-11-02T00:00:00.000Z,
   "publicId": "abcdef99987",
   "status": 0,

--- a/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
+++ b/packages/sales-api-service/src/services/__tests__/__snapshots__/recurring-payments.service.spec.js.snap
@@ -6,7 +6,7 @@ Object {
   "cancelledDate": null,
   "cancelledReason": null,
   "endDate": 2023-11-12T00:00:00.000Z,
-  "name": "Test Name",
+  "name": "Firstname Lastname Duedate",
   "nextDueDate": 2023-11-02T00:00:00.000Z,
   "publicId": "abcdef99987",
   "status": 0,

--- a/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
@@ -284,7 +284,6 @@ describe('recurring payments service', () => {
       const transactionRecord = {
         payment: {
           recurring: {
-            name: 'Test Name',
             nextDueDate: new Date('2023-11-02'),
             cancelledDate: null,
             cancelledReason: null,
@@ -298,6 +297,11 @@ describe('recurring payments service', () => {
       const contact = getMockContact()
       const result = await processRecurringPayment(transactionRecord, contact)
       expect(result.recurringPayment).toMatchSnapshot()
+    })
+
+    it('should set a valid name on the recurringPayment', async () => {
+      const result = await processRecurringPayment(createSimpleSampleTransactionRecord(), getMockContact())
+      expect(result.recurringPayment.name).toBe('Firstname Lastname Duedate')
     })
 
     it.each(['abc-123', 'def-987'])('generates a publicId %s for the recurring payment', async samplePublicId => {

--- a/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
@@ -227,7 +227,14 @@ const getMockResponse = () => ({
 })
 
 describe('recurring payments service', () => {
-  const createSimpleSampleTransactionRecord = () => ({ payment: { recurring: true }, permissions: [{}] })
+  const createSimpleSampleTransactionRecord = () => ({
+    payment: {
+      recurring: {
+        nextDueDate: new Date('2025-01-01')
+      }
+    },
+    permissions: [{}]
+  })
   const createSamplePermission = overrides => {
     const p = new Permission()
     p.referenceNumber = 'ABC123'
@@ -300,8 +307,16 @@ describe('recurring payments service', () => {
     })
 
     it('should set a valid name on the recurringPayment', async () => {
-      const result = await processRecurringPayment(createSimpleSampleTransactionRecord(), getMockContact())
-      expect(result.recurringPayment.name).toBe('Firstname Lastname Duedate')
+      const transactionRecord = {
+        payment: {
+          recurring: {
+            nextDueDate: new Date('2023-11-02')
+          }
+        },
+        permissions: [getMockPermission()]
+      }
+      const result = await processRecurringPayment(transactionRecord, getMockContact())
+      expect(result.recurringPayment.name).toBe('Firstname Lastname 2023')
     })
 
     it.each(['abc-123', 'def-987'])('generates a publicId %s for the recurring payment', async samplePublicId => {

--- a/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
@@ -316,7 +316,7 @@ describe('recurring payments service', () => {
         permissions: [getMockPermission()]
       }
       const result = await processRecurringPayment(transactionRecord, getMockContact())
-      expect(result.recurringPayment.name).toBe('Firstname Lastname 2023')
+      expect(result.recurringPayment.name).toBe('Fester Tester 2023')
     })
 
     it.each(['abc-123', 'def-987'])('generates a publicId %s for the recurring payment', async samplePublicId => {

--- a/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
@@ -230,7 +230,7 @@ describe('recurring payments service', () => {
   const createSimpleSampleTransactionRecord = () => ({
     payment: {
       recurring: {
-        nextDueDate: new Date('2025-01-01')
+        nextDueDate: '2025-01-01T00:00:00.000Z'
       }
     },
     permissions: [{}]
@@ -291,10 +291,10 @@ describe('recurring payments service', () => {
       const transactionRecord = {
         payment: {
           recurring: {
-            nextDueDate: new Date('2023-11-02'),
+            nextDueDate: '2023-11-02T00:00:00.000Z',
             cancelledDate: null,
             cancelledReason: null,
-            endDate: new Date('2023-11-12'),
+            endDate: '2023-11-12T00:00:00.000Z',
             agreementId: '435678',
             status: 0
           }
@@ -310,7 +310,7 @@ describe('recurring payments service', () => {
       const transactionRecord = {
         payment: {
           recurring: {
-            nextDueDate: new Date('2023-11-02')
+            nextDueDate: '2023-07-07T00:00:00.000Z'
           }
         },
         permissions: [getMockPermission()]

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -150,8 +150,6 @@ export const cancelRecurringPayment = async id => {
 }
 
 const determineRecurringPaymentName = (transactionRecord, contact) => {
-  console.log(transactionRecord)
-  console.log(contact)
   const dueYear = transactionRecord.payment.recurring.nextDueDate.split('-')[0]
   return [contact.firstName, contact.lastName, dueYear].join(' ')
 }

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -65,7 +65,7 @@ export const processRecurringPayment = async (transactionRecord, contact) => {
   if (transactionRecord.payment?.recurring) {
     const recurringPayment = new RecurringPayment()
     hash.update(recurringPayment.uniqueContentId)
-    recurringPayment.name = transactionRecord.payment.recurring.name
+    recurringPayment.name = determineRecurringPaymentName()
     recurringPayment.nextDueDate = transactionRecord.payment.recurring.nextDueDate
     recurringPayment.cancelledDate = transactionRecord.payment.recurring.cancelledDate
     recurringPayment.cancelledReason = transactionRecord.payment.recurring.cancelledReason
@@ -147,4 +147,8 @@ export const cancelRecurringPayment = async id => {
   } else {
     console.log('No matches found for cancellation')
   }
+}
+
+const determineRecurringPaymentName = () => {
+  return 'Firstname Lastname Duedate'
 }

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -150,6 +150,6 @@ export const cancelRecurringPayment = async id => {
 }
 
 const determineRecurringPaymentName = (transactionRecord, contact) => {
-  const dueYear = transactionRecord.payment.recurring.nextDueDate.split('-')[0]
+  const [dueYear] = transactionRecord.payment.recurring.nextDueDate.split('-')
   return [contact.firstName, contact.lastName, dueYear].join(' ')
 }

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -65,7 +65,7 @@ export const processRecurringPayment = async (transactionRecord, contact) => {
   if (transactionRecord.payment?.recurring) {
     const recurringPayment = new RecurringPayment()
     hash.update(recurringPayment.uniqueContentId)
-    recurringPayment.name = determineRecurringPaymentName()
+    recurringPayment.name = determineRecurringPaymentName(transactionRecord)
     recurringPayment.nextDueDate = transactionRecord.payment.recurring.nextDueDate
     recurringPayment.cancelledDate = transactionRecord.payment.recurring.cancelledDate
     recurringPayment.cancelledReason = transactionRecord.payment.recurring.cancelledReason
@@ -149,6 +149,7 @@ export const cancelRecurringPayment = async id => {
   }
 }
 
-const determineRecurringPaymentName = () => {
-  return 'Firstname Lastname Duedate'
+const determineRecurringPaymentName = transactionRecord => {
+  const dueYear = transactionRecord.payment.recurring.nextDueDate.getFullYear()
+  return 'Firstname Lastname ' + dueYear
 }

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -150,6 +150,8 @@ export const cancelRecurringPayment = async id => {
 }
 
 const determineRecurringPaymentName = (transactionRecord, contact) => {
-  const dueYear = transactionRecord.payment.recurring.nextDueDate.getFullYear()
+  console.log(transactionRecord)
+  console.log(contact)
+  const dueYear = transactionRecord.payment.recurring.nextDueDate.split('-')[0]
   return [contact.firstName, contact.lastName, dueYear].join(' ')
 }

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -65,7 +65,7 @@ export const processRecurringPayment = async (transactionRecord, contact) => {
   if (transactionRecord.payment?.recurring) {
     const recurringPayment = new RecurringPayment()
     hash.update(recurringPayment.uniqueContentId)
-    recurringPayment.name = determineRecurringPaymentName(transactionRecord)
+    recurringPayment.name = determineRecurringPaymentName(transactionRecord, contact)
     recurringPayment.nextDueDate = transactionRecord.payment.recurring.nextDueDate
     recurringPayment.cancelledDate = transactionRecord.payment.recurring.cancelledDate
     recurringPayment.cancelledReason = transactionRecord.payment.recurring.cancelledReason
@@ -149,7 +149,7 @@ export const cancelRecurringPayment = async id => {
   }
 }
 
-const determineRecurringPaymentName = transactionRecord => {
+const determineRecurringPaymentName = (transactionRecord, contact) => {
   const dueYear = transactionRecord.payment.recurring.nextDueDate.getFullYear()
-  return 'Firstname Lastname ' + dueYear
+  return [contact.firstName, contact.lastName, dueYear].join(' ')
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4701

Currently the name field of RecurringPayments in the CRM is not set to anything useful. We want it to include the contact name and the year the next payment is due to make it easier to find records in the interface.