### PR TITLE
Incorrect capitalistion of address in contact summary

### DIFF
--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
@@ -122,13 +122,13 @@ export class RowGenerator {
     }
 
     const formattedParts = [
-      licensee.premises && titleCase(licensee.premises),
-      licensee.street && titleCase(licensee.street),
-      licensee.locality && titleCase(licensee.locality),
-      licensee.town && titleCase(licensee.town),
-      licensee.postcode && licensee.postcode.toUpperCase(),
-      countryName && countryName.toUpperCase()
-    ].filter(Boolean)
+      titleCase(licensee.premises),
+      titleCase(licensee.street),
+      titleCase(licensee.locality),
+      titleCase(licensee.town),
+      licensee.postcode.toUpperCase(),
+      countryName.toUpperCase()
+    ]
 
     const text = formattedParts.join(', ')
 

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
@@ -122,10 +122,10 @@ export class RowGenerator {
     }
 
     const formattedParts = [
-      licensee.premises && toProperCase(licensee.premises),
-      licensee.street && toProperCase(licensee.street),
-      licensee.locality && toProperCase(licensee.locality),
-      licensee.town && toProperCase(licensee.town),
+      licensee.premises && titleCase(licensee.premises),
+      licensee.street && titleCase(licensee.street),
+      licensee.locality && titleCase(licensee.locality),
+      licensee.town && titleCase(licensee.town),
       licensee.postcode && licensee.postcode.toUpperCase(),
       countryName && countryName.toUpperCase()
     ].filter(Boolean)

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
@@ -112,9 +112,25 @@ export class RowGenerator {
 
   generateAddressRow (countryName) {
     const { licensee } = this.permission
-    const text = [licensee.premises, licensee.street, licensee.locality, licensee.town, licensee.postcode, countryName?.toUpperCase()]
-      .filter(Boolean)
-      .join(', ')
+
+    const titleCase = str => {
+      return str
+        .toLowerCase()
+        .split(' ')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
+    }
+
+    const formattedParts = [
+      licensee.premises && toProperCase(licensee.premises),
+      licensee.street && toProperCase(licensee.street),
+      licensee.locality && toProperCase(licensee.locality),
+      licensee.town && toProperCase(licensee.town),
+      licensee.postcode && licensee.postcode.toUpperCase(),
+      countryName && countryName.toUpperCase()
+    ].filter(Boolean)
+
+    const text = formattedParts.join(', ')
 
     return this._generateRow({
       label: this.labels.contact_summary_row_address,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4719

On the licence summary page, the address all appears in capital letters, while it should only have the first letter capitalised. (Postcode and
Country)