### PR TITLE
Make reference number entry box on renewal journey smaller

### DIFF
--- a/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
+++ b/packages/gafl-webapp-service/src/pages/renewals/identify/identify.njk
@@ -102,7 +102,7 @@
                       id: "ref",
                       name: "referenceNumber",
                       type: "text",
-                      classes: "govuk-!-width-one-third",
+                      classes: "govuk-input--width-10",
                       errorMessage: { text: mssgs.identify_error_empty } if error['referenceNumber'],
                       label: {
                         text: mssgs.identify_label_last_six,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4720

On the renewal journey, on mobile phone view - the text box is too long compared to the other text boxes, this may encourage people to enter more than just the last 6 digits.