### PR TITLE
Fix name of cancelledreasons optionset

### DIFF
--- a/packages/dynamics-lib/src/__mocks__/option-set-data.json
+++ b/packages/dynamics-lib/src/__mocks__/option-set-data.json
@@ -6631,32 +6631,34 @@
       ]
     },
     {
-      "Name": "defra_cancelledreason",
+      "Name": "defra_cancelledreasons",
       "MetadataId": "c5bb4ec0-78b5-4413-9c95-b879793343c7",
       "Options": [
         {
-          "Value": 910400195,
+          "Value": 910400000,
           "Color": "#0000ff",
           "IsManaged": false,
-          "ExternalValue": null,
+          "ExternalValue": "",
           "ParentValues": [],
+          "Tag": null,
+          "IsHidden": false,
           "MetadataId": null,
           "HasChanged": null,
           "Label": {
             "LocalizedLabels": [
               {
-                "Label": "User cancelled",
+                "Label": "Business Cancelled",
                 "LanguageCode": 1033,
                 "IsManaged": false,
-                "MetadataId": "cd2cfff1-d4e1-e711-810c-5065f38ada61",
+                "MetadataId": "88a2a531-4322-ee11-9966-0022489d6a34",
                 "HasChanged": null
               }
             ],
             "UserLocalizedLabel": {
-              "Label": "User cancelled",
+              "Label": "Business Cancelled",
               "LanguageCode": 1033,
               "IsManaged": false,
-              "MetadataId": "cd2cfff1-d4e1-e711-810c-5065f38ada61",
+              "MetadataId": "88a2a531-4322-ee11-9966-0022489d6a34",
               "HasChanged": null
             }
           },
@@ -6666,7 +6668,7 @@
                 "Label": "",
                 "LanguageCode": 1033,
                 "IsManaged": false,
-                "MetadataId": "de2cfff1-d4e1-e711-810c-5065f38ada61",
+                "MetadataId": "8aa2a531-4322-ee11-9966-0022489d6a34",
                 "HasChanged": null
               }
             ],
@@ -6674,7 +6676,148 @@
               "Label": "",
               "LanguageCode": 1033,
               "IsManaged": false,
-              "MetadataId": "de2cfff1-d4e1-e711-810c-5065f38ada61",
+              "MetadataId": "8aa2a531-4322-ee11-9966-0022489d6a34",
+              "HasChanged": null
+            }
+          }
+        },
+        {
+          "Value": 910400001,
+          "Color": "#0000ff",
+          "IsManaged": false,
+          "ExternalValue": "",
+          "ParentValues": [],
+          "Tag": null,
+          "IsHidden": false,
+          "MetadataId": null,
+          "HasChanged": null,
+          "Label": {
+            "LocalizedLabels": [
+              {
+                "Label": "Permission Refunded",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "8ba2a531-4322-ee11-9966-0022489d6a34",
+                "HasChanged": null
+              }
+            ],
+            "UserLocalizedLabel": {
+              "Label": "Permission Refunded",
+              "LanguageCode": 1033,
+              "IsManaged": false,
+              "MetadataId": "8ba2a531-4322-ee11-9966-0022489d6a34",
+              "HasChanged": null
+            }
+          },
+          "Description": {
+            "LocalizedLabels": [
+              {
+                "Label": "",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "8da2a531-4322-ee11-9966-0022489d6a34",
+                "HasChanged": null
+              }
+            ],
+            "UserLocalizedLabel": {
+              "Label": "",
+              "LanguageCode": 1033,
+              "IsManaged": false,
+              "MetadataId": "8da2a531-4322-ee11-9966-0022489d6a34",
+              "HasChanged": null
+            }
+          }
+        },
+        {
+          "Value": 910400002,
+          "Color": "#0000ff",
+          "IsManaged": false,
+          "ExternalValue": "",
+          "ParentValues": [],
+          "Tag": null,
+          "IsHidden": false,
+          "MetadataId": null,
+          "HasChanged": null,
+          "Label": {
+            "LocalizedLabels": [
+              {
+                "Label": "Payment Failure",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "8ea2a531-4322-ee11-9966-0022489d6a34",
+                "HasChanged": null
+              }
+            ],
+            "UserLocalizedLabel": {
+              "Label": "Payment Failure",
+              "LanguageCode": 1033,
+              "IsManaged": false,
+              "MetadataId": "8ea2a531-4322-ee11-9966-0022489d6a34",
+              "HasChanged": null
+            }
+          },
+          "Description": {
+            "LocalizedLabels": [
+              {
+                "Label": "",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "90a2a531-4322-ee11-9966-0022489d6a34",
+                "HasChanged": null
+              }
+            ],
+            "UserLocalizedLabel": {
+              "Label": "",
+              "LanguageCode": 1033,
+              "IsManaged": false,
+              "MetadataId": "90a2a531-4322-ee11-9966-0022489d6a34",
+              "HasChanged": null
+            }
+          }
+        },
+        {
+          "Value": 910400003,
+          "Color": "#0000ff",
+          "IsManaged": false,
+          "ExternalValue": "",
+          "ParentValues": [],
+          "Tag": null,
+          "IsHidden": false,
+          "MetadataId": null,
+          "HasChanged": null,
+          "Label": {
+            "LocalizedLabels": [
+              {
+                "Label": "User Cancelled",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "91a2a531-4322-ee11-9966-0022489d6a34",
+                "HasChanged": null
+              }
+            ],
+            "UserLocalizedLabel": {
+              "Label": "User Cancelled",
+              "LanguageCode": 1033,
+              "IsManaged": false,
+              "MetadataId": "91a2a531-4322-ee11-9966-0022489d6a34",
+              "HasChanged": null
+            }
+          },
+          "Description": {
+            "LocalizedLabels": [
+              {
+                "Label": "",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "93a2a531-4322-ee11-9966-0022489d6a34",
+                "HasChanged": null
+              }
+            ],
+            "UserLocalizedLabel": {
+              "Label": "",
+              "LanguageCode": 1033,
+              "IsManaged": false,
+              "MetadataId": "93a2a531-4322-ee11-9966-0022489d6a34",
               "HasChanged": null
             }
           }

--- a/packages/dynamics-lib/src/entities/__tests__/recurring-payment.entity.spec.js
+++ b/packages/dynamics-lib/src/entities/__tests__/recurring-payment.entity.spec.js
@@ -35,7 +35,7 @@ describe('recurring payment entity', () => {
       defra_name: '18569ba8-094e-4e8c-9911-bfedd5ccc17a',
       defra_nextduedate: '2019-12-14T00:00:00Z',
       defra_cancelleddate: '2019-12-14T00:00:00Z',
-      defra_cancelledreason: 910400195,
+      defra_cancelledreason: 910400003,
       defra_enddate: '2019-12-15T00:00:00Z',
       defra_agreementid: 'c9267c6e-573d-488b-99ab-ea18431fc472',
       defra_publicid: '649-213',
@@ -66,7 +66,7 @@ describe('recurring payment entity', () => {
           name: '18569ba8-094e-4e8c-9911-bfedd5ccc17a',
           nextDueDate: '2019-12-14T00:00:00Z',
           cancelledDate: '2019-12-14T00:00:00Z',
-          cancelledReason: expect.objectContaining({ id: 910400195, label: 'User cancelled', description: 'User cancelled' }),
+          cancelledReason: expect.objectContaining({ id: 910400003, label: 'User Cancelled', description: 'User Cancelled' }),
           endDate: '2019-12-15T00:00:00Z',
           agreementId: 'c9267c6e-573d-488b-99ab-ea18431fc472',
           publicId: '649-213',
@@ -83,7 +83,7 @@ describe('recurring payment entity', () => {
         contact,
         permission,
         cancelledDate: '2019-10-14T00:00:00Z',
-        cancelledReason: optionSetData.defra_cancelledreason.options['910400195']
+        cancelledReason: optionSetData.defra_cancelledreasons.options['910400003']
       })
       const dynamicsEntity = recurringPayment.toRequestBody()
       expect(dynamicsEntity).toMatchObject(
@@ -91,7 +91,7 @@ describe('recurring payment entity', () => {
           defra_name: 'Test Name',
           defra_nextduedate: '2019-12-14T00:00:00Z',
           defra_cancelleddate: '2019-10-14T00:00:00Z',
-          defra_cancelledreason: 910400195,
+          defra_cancelledreason: 910400003,
           defra_enddate: '2019-12-15T00:00:00Z',
           defra_agreementid: 'c9267c6e-573d-488b-99ab-ea18431fc472',
           defra_publicid: '649-213',

--- a/packages/dynamics-lib/src/entities/recurring-payment.entity.js
+++ b/packages/dynamics-lib/src/entities/recurring-payment.entity.js
@@ -18,7 +18,7 @@ export class RecurringPayment extends BaseEntity {
       status: { field: 'statecode', type: 'decimal' },
       nextDueDate: { field: 'defra_nextduedate', type: 'datetime' },
       cancelledDate: { field: 'defra_cancelleddate', type: 'datetime' },
-      cancelledReason: { field: 'defra_cancelledreason', type: 'optionset', ref: 'defra_cancelledreason' },
+      cancelledReason: { field: 'defra_cancelledreason', type: 'optionset', ref: 'defra_cancelledreasons' },
       endDate: { field: 'defra_enddate', type: 'datetime' },
       agreementId: { field: 'defra_agreementid', type: 'string' },
       publicId: { field: 'defra_publicid', type: 'string' },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4658

The name of the field is defra_cancelledreason, but the name of the optionset is defra_cancelledreasons.