### PR TITLE
Don't try to generate RCP record without data

### DIFF
--- a/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
@@ -530,6 +530,15 @@ describe('recurring payments service', () => {
       await expect(generateRecurringPaymentRecord(sampleTransaction)).rejects.toThrow('Invalid dates provided for permission')
     })
 
+    it('returns a false flag when recurringPayment is not present', async () => {
+      const sampleTransaction = createFinalisedSampleTransaction()
+      delete sampleTransaction.recurringPayment
+
+      const rpRecord = await generateRecurringPaymentRecord(sampleTransaction)
+
+      expect(rpRecord.payment?.recurring).toBeFalsy()
+    })
+
     it('returns a false flag when agreementId is not present', async () => {
       const sampleTransaction = createFinalisedSampleTransaction(
         null,

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -37,7 +37,7 @@ const getNextDueDate = (startDate, issueDate, endDate) => {
 }
 
 export const generateRecurringPaymentRecord = async (transactionRecord, permission) => {
-  if (transactionRecord.recurringPayment.agreementId) {
+  if (transactionRecord.recurringPayment?.agreementId) {
     const agreementResponse = await getRecurringPaymentAgreement(transactionRecord.recurringPayment.agreementId)
     const lastDigitsCardNumbers = agreementResponse.payment_instrument?.card_details?.last_digits_card_number
     const [{ startDate, issueDate, endDate }] = transactionRecord.permissions


### PR DESCRIPTION
If we send in a transaction record that doesn't have a recurringPayment attached to it, then generateRecurringPaymentRecord() should not try to create a new RecurringPayment record.