### PR TITLE
Recurring payment job should handle errors from await salesApi.processRPResult()

### DIFF
--- a/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
+++ b/packages/recurring-payments-job/src/__tests__/recurring-payments-processor.spec.js
@@ -607,7 +607,7 @@ describe('recurring-payments-processor', () => {
 
     await processRecurringPayments()
 
-    expect(errorSpy).toHaveBeenCalledWith('Failed to process Recurring Payment for transaction 1', expect.any(Error))
+    expect(errorSpy).toHaveBeenCalledWith('Failed to process Recurring Payment for trans-1', expect.any(Error))
 
     errorSpy.mockRestore()
   })

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -127,7 +127,7 @@ const preparePayment = (agreementId, transaction) => {
   return result
 }
 
-const processRecurringPaymentStatus = async payment => {
+export const processRecurringPaymentStatus = async payment => {
   try {
     const {
       state: { status }
@@ -136,9 +136,15 @@ const processRecurringPaymentStatus = async payment => {
     debug(`Payment status for ${payment.paymentId}: ${status}`)
 
     if (status === PAYMENT_STATUS.Success) {
-      await salesApi.processRPResult(payment.transaction.id, payment.paymentId, payment.created_date)
-      debug(`Processed Recurring Payment for ${payment.transaction.id}`)
+      try {
+        await salesApi.processRPResult(payment.transaction.id, payment.paymentId, payment.created_date)
+        debug(`Processed Recurring Payment for ${payment.transaction.id}`)
+      } catch (err) {
+        console.error(`Failed to process Recurring Payment for ${payment.transaction.id}`, err)
+        return
+      }
     }
+
     if (status === PAYMENT_STATUS.Failure || status === PAYMENT_STATUS.Error) {
       console.error(
         `Payment failed. Recurring payment agreement for: ${payment.agreementId} set to be cancelled. Updating payment journal.`

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -141,7 +141,7 @@ const processRecurringPaymentStatus = async payment => {
         debug(`Processed Recurring Payment for ${payment.transaction.id}`)
       } catch (err) {
         console.error(`Failed to process Recurring Payment for ${payment.transaction.id}`, err)
-        return
+        throw err
       }
     }
 

--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -127,7 +127,7 @@ const preparePayment = (agreementId, transaction) => {
   return result
 }
 
-export const processRecurringPaymentStatus = async payment => {
+const processRecurringPaymentStatus = async payment => {
   try {
     const {
       state: { status }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4649

Currently, when the recurring payment job calls await salesApi.processRPResult, we await the response but we don’t do anything with it. We should have some error handling in place so that if one record fails to process, we can log it to be reviewed later, but also not have the whole job fall over.