### PR TITLE
Allow RCP agreements to be created through easy renewal with later date

### DIFF
--- a/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
+++ b/packages/sales-api-service/src/services/__tests__/recurring-payments.service.spec.js
@@ -95,7 +95,6 @@ jest.mock('../../services/paymentjournals/payment-journals.service.js', () => ({
 }))
 
 jest.mock('@defra-fish/business-rules-lib', () => ({
-  ADVANCED_PURCHASE_MAX_DAYS: 30,
   PAYMENT_JOURNAL_STATUS_CODES: {
     InProgress: 'InProgressCode',
     Cancelled: 'CancelledCode',
@@ -456,6 +455,17 @@ describe('recurring payments service', () => {
         '3456'
       ],
       [
+        'starts thirty-one days after issue date - next due on issue date plus one year',
+        '9o8u7yhui89u8i9oiu8i8u7yhu',
+        {
+          startDate: '2024-12-14T00:00:00.000Z',
+          issueDate: '2024-11-12T15:00:45.922Z',
+          endDate: '2025-12-13T23:59:59.999Z'
+        },
+        '2025-11-12T00:00:00.000Z',
+        '4321'
+      ],
+      [
         "issued on 29th Feb '24, starts on 30th March '24 - next due on 28th Feb '25",
         'hy7u8ijhyu78jhyu8iu8hjiujn',
         {
@@ -511,11 +521,11 @@ describe('recurring payments service', () => {
 
     it.each([
       [
-        'start date is thirty one days after issue date',
+        'start date equals issue date',
         {
-          startDate: '2024-12-14T00:00:00.000Z',
-          issueDate: '2024-11-12T15:00:45.922Z',
-          endDate: '2025-12-13T23:59:59.999Z'
+          startDate: '2024-11-11T00:00:00.000Z',
+          issueDate: '2024-11-11T00:00:00.000Z',
+          endDate: '2025-11-10T23:59:59.999Z'
         }
       ],
       [

--- a/packages/sales-api-service/src/services/recurring-payments.service.js
+++ b/packages/sales-api-service/src/services/recurring-payments.service.js
@@ -10,7 +10,7 @@ import {
 import { calculateEndDate, generatePermissionNumber } from './permissions.service.js'
 import { getObfuscatedDob } from './contacts.service.js'
 import { createHash } from 'node:crypto'
-import { ADVANCED_PURCHASE_MAX_DAYS, PAYMENT_JOURNAL_STATUS_CODES, PAYMENT_TYPE, TRANSACTION_SOURCE } from '@defra-fish/business-rules-lib'
+import { PAYMENT_JOURNAL_STATUS_CODES, PAYMENT_TYPE, TRANSACTION_SOURCE } from '@defra-fish/business-rules-lib'
 import { TRANSACTION_STAGING_TABLE, TRANSACTION_QUEUE } from '../config.js'
 import { TRANSACTION_STATUS } from '../services/transactions/constants.js'
 import { retrieveStagedTransaction } from '../services/transactions/retrieve-transaction.js'
@@ -26,7 +26,7 @@ export const getRecurringPayments = date => executeQuery(findDueRecurringPayment
 
 const getNextDueDate = (startDate, issueDate, endDate) => {
   const mStart = moment(startDate)
-  if (mStart.isAfter(moment(issueDate)) && mStart.isSameOrBefore(moment(issueDate).add(ADVANCED_PURCHASE_MAX_DAYS, 'days'), 'day')) {
+  if (mStart.isAfter(moment(issueDate))) {
     if (mStart.isSame(moment(issueDate), 'day')) {
       return moment(startDate).add(1, 'year').subtract(10, 'days').startOf('day').toISOString()
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4806

Previously, creation of a new recurring payment agreement was limited so that the start date could not be more than 30 days after the issue date. If that were the case, creation of the new records in the CRM would fail. Earlier validation in the new licence journey should have prevented anyone from getting into that situation anyway.

However, in some edge cases, it's possible that a user going through the easy renewals journey very early (more than 30 days before expiry) could try to set up a recurring payment agreement for a licence starting more than 30 days after the issue date. This would then silently fail and not show up in the CRM.

This PR removes the 30-day limit on the start date when setting up new recurring payment agreements on completion of the journey. This should fix the issue for users going through easy renewals, while anyone going through the new licence journey should still be limited by the on-page validation.