### PR TITLE
Country capital letters

### DIFF
--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/__snapshots__/route.spec.js.snap
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/__snapshots__/route.spec.js.snap
@@ -66,7 +66,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -131,7 +131,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -196,7 +196,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -261,7 +261,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -326,7 +326,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -392,7 +392,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -458,7 +458,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -563,7 +563,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -648,7 +648,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -753,7 +753,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -838,7 +838,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -944,7 +944,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1030,7 +1030,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1136,7 +1136,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1222,7 +1222,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1327,7 +1327,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1432,7 +1432,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1537,7 +1537,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1642,7 +1642,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1748,7 +1748,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1854,7 +1854,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -1960,7 +1960,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -2046,7 +2046,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -2152,7 +2152,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -2238,7 +2238,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -2345,7 +2345,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -2432,7 +2432,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -2539,7 +2539,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {
@@ -2626,7 +2626,7 @@ Array [
       "text": Symbol(contact-summary-row-address),
     },
     "value": Object {
-      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB",
+      "text": "14 Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England",
     },
   },
   Object {

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/route.spec.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/__tests__/route.spec.js
@@ -30,7 +30,7 @@ jest.mock('../../../../processors/mapping-constants', () => ({
 
 jest.mock('../../../../processors/refdata-helper.js', () => ({
   countries: {
-    nameFromCode: async () => 'GB'
+    nameFromCode: async () => 'England'
   }
 }))
 
@@ -133,9 +133,10 @@ describe('contact-summary > route', () => {
           street: 'howecroft court',
           locality: 'eastmead lane',
           town: 'bristol',
-          postcode: 'BS9 1HJ'
+          postcode: 'BS9 1HJ',
+          country: 'England'
         },
-        'Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, GB'
+        'Howecroft Court, Eastmead Lane, Bristol, BS9 1HJ, England'
       ],
       [
         'street',
@@ -144,9 +145,10 @@ describe('contact-summary > route', () => {
           street: undefined,
           locality: 'eastmead lane',
           town: 'bristol',
-          postcode: 'BS9 1HJ'
+          postcode: 'BS9 1HJ',
+          country: 'England'
         },
-        '14, Eastmead Lane, Bristol, BS9 1HJ, GB'
+        '14, Eastmead Lane, Bristol, BS9 1HJ, England'
       ],
       [
         'locality',
@@ -155,9 +157,10 @@ describe('contact-summary > route', () => {
           street: 'howecroft court',
           locality: undefined,
           town: 'bristol',
-          postcode: 'BS9 1HJ'
+          postcode: 'BS9 1HJ',
+          country: 'Northern Ireland'
         },
-        '14, Howecroft Court, Bristol, BS9 1HJ, GB'
+        '14, Howecroft Court, Bristol, BS9 1HJ, Northern Ireland'
       ],
       [
         'town',
@@ -166,16 +169,17 @@ describe('contact-summary > route', () => {
           street: 'howecroft court',
           locality: 'eastmead lane',
           town: undefined,
-          postcode: 'BS9 1HJ'
+          postcode: 'BS9 1HJ',
+          country: 'Wales'
         },
-        '14, Howecroft Court, Eastmead Lane, BS9 1HJ, GB'
+        '14, Howecroft Court, Eastmead Lane, BS9 1HJ, Wales'
       ]
     ])('omits %s when undefined', (missingField, licenseeOverrides, expectedAddress) => {
       const permission = getMockPermission(licenseeOverrides)
       const request = getRequestMock({ permission })
       const rowGenerator = new route.RowGenerator(request, permission)
 
-      const row = rowGenerator.generateAddressRow('GB')
+      const row = rowGenerator.generateAddressRow(licenseeOverrides.country)
 
       expect(row.value.text).toBe(expectedAddress)
     })

--- a/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
+++ b/packages/gafl-webapp-service/src/pages/summary/contact-summary/route.js
@@ -127,7 +127,7 @@ export class RowGenerator {
       capitalise(licensee.locality),
       capitalise(licensee.town),
       licensee.postcode?.toUpperCase(),
-      countryName?.toUpperCase()
+      countryName
     ]
       .filter(Boolean)
       .join(', ')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4719

Licence summary page address country appears in capitals when should only be first letter