### PR TITLE
Add missing reminder content to contact page on junior journey

### DIFF
--- a/packages/gafl-webapp-service/src/locales/cy.json
+++ b/packages/gafl-webapp-service/src/locales/cy.json
@@ -350,6 +350,7 @@
   "identify_title": "Adnewyddu eich trwydded bysgota?",
   "important_info_contact_content_salmon": "Byddwn yn defnyddio’r cyfeiriad e-bost neu’r rhif symudol hwn i anfon nodyn atgoffa i anfon adroddiad daliad. Mae’n bosibl y byddwn hefyd yn anfon gwybodaeth bwysig arall, megis newidiadau sy’n effeithio ar y drwydded neu is-ddeddfau pysgota.",
   "important_info_contact_content_not_salmon": "Mae’n bosibl y byddwn hefyd yn defnyddio’r cyfeiriad e-bost neu’r rhif symudol hwn i anfon gwybodaeth bwysig, megis newidiadau sy’n effeithio ar y drwydded neu’r is-ddeddfau pysgota.",
+  "important_info_contact_content_12_months": "Byddwn hefyd yn defnyddio’r cyfeiriad e-bost neu’r rhif symudol hwn i anfon nodyn atgoffa am adnewyddu neu ddiweddariadau pwysig eraill, fel newidiadau i is-ddeddfau pysgota.",
   "important_info_contact_error_choose_short": "Dewiswch i ble y dylem anfon y drwydded bysgota",
   "important_info_contact_error_choose": "Dewiswch sut y dylem gysylltu â deiliad y drwydded",
   "important_info_contact_error_email": "Rhowch gyfeiriad e-bost yn y fformat cywir",

--- a/packages/gafl-webapp-service/src/locales/en.json
+++ b/packages/gafl-webapp-service/src/locales/en.json
@@ -350,6 +350,7 @@
   "identify_title": "Renew your rod fishing licence?",
   "important_info_contact_content_salmon": "We will use this email or mobile number to send a reminder to report a catch return. We may also send other important information, such as changes affecting the licence or the fishing byelaws.",
   "important_info_contact_content_not_salmon": "We may also use this email or mobile number to send important information, such as changes affecting the licence or the fishing byelaws.",
+  "important_info_contact_content_12_months": "We will also use this email or mobile number to send renewal reminders and other important updates, like changes to rod fishing byelaws.",
   "important_info_contact_error_choose_short": "Choose where we should send the fishing licence",
   "important_info_contact_error_choose": "Choose how we should contact the licence holder",
   "important_info_contact_error_email": "Enter an email address in the correct format",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4812

In the adult journey, we specifically say that we will send a reminder for 12-month licences. We don’t do that for Junior licences, for some reason. We should amend the content so that the content is consistent across both journeys.