### PR TITLE
Recurring payment job should handle errors from await salesApi.processRPResult()

### DIFF
--- a/packages/recurring-payments-job/src/recurring-payments-processor.js
+++ b/packages/recurring-payments-job/src/recurring-payments-processor.js
@@ -155,8 +155,13 @@ const processRecurringPaymentStatus = async payment => {
     debug(`Payment status for ${payment.paymentId}: ${status}`)
 
     if (status === PAYMENT_STATUS.Success) {
-      await salesApi.processRPResult(payment.transaction.id, payment.paymentId, payment.created_date)
-      debug(`Processed Recurring Payment for ${payment.transaction.id}`)
+      try {
+        await salesApi.processRPResult(payment.transaction.id, payment.paymentId, payment.created_date)
+        debug(`Processed Recurring Payment for ${payment.transaction.id}`)
+      } catch (err) {
+        console.error(`Failed to process Recurring Payment for ${payment.transaction.id}`, err)
+        throw err
+      }
     }
     if (status === PAYMENT_STATUS.Failure || status === PAYMENT_STATUS.Error) {
       console.error(


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4649

Currently, when the recurring payment job calls await salesApi.processRPResult, we await the response but we don’t do anything with it. We should have some error handling in place so that if one record fails to process, we can log it to be reviewed later, but also not have the whole job fall over.