### PR TITLE
GAFL: DEV - Switch from rmdir to rm

### DIFF
--- a/packages/pocl-job/src/io/__tests__/file.spec.js
+++ b/packages/pocl-job/src/io/__tests__/file.spec.js
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmdirSync } from 'fs'
+import { mkdtempSync, mkdirSync, rmSync } from 'fs'
 import mockPath from 'path'
 import os from 'os'
 import * as file from '../file.js'
@@ -6,7 +6,7 @@ import * as file from '../file.js'
 jest.mock('fs', () => ({
   mkdtempSync: jest.fn(prefix => mockPath.join(`${prefix}${String(Math.random()).slice(-6)}`)),
   mkdirSync: jest.fn(val => val),
-  rmdirSync: jest.fn()
+  rmSync: jest.fn()
 }))
 
 describe('file operations', () => {
@@ -45,7 +45,7 @@ describe('file operations', () => {
       const file = require('../file.js')
       const tmpDir = file.getTempDir()
       file.removeTemp()
-      expect(rmdirSync).toHaveBeenCalledWith(tmpDir, { recursive: true })
+      expect(rmSync).toHaveBeenCalledWith(tmpDir, { recursive: true })
     })
   })
 })

--- a/packages/pocl-job/src/io/file.js
+++ b/packages/pocl-job/src/io/file.js
@@ -19,6 +19,6 @@ export function getTempDir (...subfolders) {
 
 export function removeTemp () {
   if (processTemp) {
-    fs.rmdirSync(processTemp, { recursive: true })
+    fs.rmSync(processTemp, { recursive: true })
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4694

When running the POCL job using Node v20, we get a warning:
 In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
The call is made in file.js to rmDirSync. Tests (in file.spec.js) will also have to be updated.
This is Done when - warning no longer appears.