### PR TITLE
GAFL: DEV - Handle Postcodes with >100 Results via Pagination (Offset) Before Filtering

### DIFF
--- a/packages/gafl-webapp-service/README.md
+++ b/packages/gafl-webapp-service/README.md
@@ -24,6 +24,7 @@ To run from this directory:
 | ADDRESS_LOOKUP_URL                | OS Places API endpoint URL                                       |    no    | https://api.os.uk/search/places/v1/postcode               |                               |
 | ADDRESS_LOOKUP_KEY                | The API key required by OS places                                |    no    |                                                           |                               |
 | ADDRESS_LOOKUP_TIMEOUT_MS         | The timeout in milliseconds for the lookup                       |    no    | 10000                                                     |                               |
+| ADDRESS_LOOKUP_MAX_RESULTS        | Maximum results to fetch from OS API (pagination cap)            |    no    | 5000                                                      |                               |
 | SALES_API_URL                     | The address of the sales api                                     |    no    | http://0.0.0.0:4000                                       |                               |
 | SALES_API_TIMEOUT_MS              | The timeout in milliseconds requests to the api                  |    no    | 10000                                                     |                               |
 | GOV_PAY_API_URL                   | The GOV.UK Pay API base url                                      |    no    | Yes                                                       |                               |

--- a/packages/gafl-webapp-service/src/constants.js
+++ b/packages/gafl-webapp-service/src/constants.js
@@ -2,6 +2,7 @@
  * System constants and defaults
  */
 export const ADDRESS_LOOKUP_TIMEOUT_MS_DEFAULT = 10000
+export const ADDRESS_LOOKUP_MAX_RESULTS_DEFAULT = 5000
 export const SESSION_TTL_MS_DEFAULT = 3 * 60 * 60 * 1000
 export const PORT_DEFAULT = 3000
 export const REDIS_PORT_DEFAULT = 6379

--- a/packages/gafl-webapp-service/src/services/address-lookup/__mocks__/data/search-results-many.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/__mocks__/data/search-results-many.js
@@ -20,7 +20,7 @@ export default {
         BUILDING_NAME: '1 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -30,7 +30,7 @@ export default {
         BUILDING_NAME: '10 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -40,7 +40,7 @@ export default {
         BUILDING_NAME: '11 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -50,7 +50,7 @@ export default {
         BUILDING_NAME: '12 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -60,7 +60,7 @@ export default {
         BUILDING_NAME: '13 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -70,7 +70,7 @@ export default {
         BUILDING_NAME: '14 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -79,7 +79,7 @@ export default {
         ADDRESS: '15 HOWECROFT COURT, EASTMEAD LANE, BRISTOL, BS9 1HJ',
         BUILDING_NAME: '15 HOWECROFT COURT',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -90,7 +90,7 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         DEPENDENT_LOCALITY: 'Sneyd Park',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -100,7 +100,7 @@ export default {
         BUILDING_NAME: '17 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -110,7 +110,7 @@ export default {
         BUILDING_NAME: '18 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -120,7 +120,7 @@ export default {
         BUILDING_NAME: '19 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -130,7 +130,7 @@ export default {
         BUILDING_NAME: '2 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -140,7 +140,7 @@ export default {
         BUILDING_NAME: '20 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -150,7 +150,7 @@ export default {
         BUILDING_NAME: '21 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -160,7 +160,7 @@ export default {
         BUILDING_NAME: '22 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -170,7 +170,7 @@ export default {
         BUILDING_NAME: '23 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -180,7 +180,7 @@ export default {
         BUILDING_NAME: '24 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -190,7 +190,7 @@ export default {
         BUILDING_NAME: '25 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -200,7 +200,7 @@ export default {
         BUILDING_NAME: '26 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -210,7 +210,7 @@ export default {
         BUILDING_NAME: '27 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -220,7 +220,7 @@ export default {
         BUILDING_NAME: '28 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -230,7 +230,7 @@ export default {
         BUILDING_NAME: '29 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -240,7 +240,7 @@ export default {
         BUILDING_NAME: '3 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -250,7 +250,7 @@ export default {
         BUILDING_NAME: '30 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -260,7 +260,7 @@ export default {
         BUILDING_NAME: '4 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -270,7 +270,7 @@ export default {
         BUILDING_NAME: '5 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -280,7 +280,7 @@ export default {
         BUILDING_NAME: '6 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -290,7 +290,7 @@ export default {
         BUILDING_NAME: '7 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -300,7 +300,7 @@ export default {
         BUILDING_NAME: '8 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     },
     {
@@ -310,7 +310,7 @@ export default {
         BUILDING_NAME: '9 HOWECROFT COURT',
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
-        POSTCODE: 'BS9 1HJ',
+        POSTCODE: 'BS9 1HJ'
       }
     }
   ]

--- a/packages/gafl-webapp-service/src/services/address-lookup/__mocks__/data/search-results-many.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/__mocks__/data/search-results-many.js
@@ -21,7 +21,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -32,7 +31,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -43,7 +41,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -54,7 +51,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -65,7 +61,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -76,7 +71,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -86,7 +80,6 @@ export default {
         BUILDING_NAME: '15 HOWECROFT COURT',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -98,7 +91,6 @@ export default {
         DEPENDENT_LOCALITY: 'Sneyd Park',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -109,7 +101,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -120,7 +111,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -131,7 +121,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -142,7 +131,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -153,7 +141,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -164,7 +151,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -175,7 +161,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -186,7 +171,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -197,7 +181,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -208,7 +191,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -219,7 +201,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -230,7 +211,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -241,7 +221,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -252,7 +231,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -263,7 +241,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -274,7 +251,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -285,7 +261,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -296,7 +271,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -307,7 +281,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -318,7 +291,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -329,7 +301,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     },
     {
@@ -340,7 +311,6 @@ export default {
         THOROUGHFARE_NAME: 'EASTMEAD LANE',
         POST_TOWN: 'BRISTOL',
         POSTCODE: 'BS9 1HJ',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England'
       }
     }
   ]

--- a/packages/gafl-webapp-service/src/services/address-lookup/__mocks__/data/search-results-one.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/__mocks__/data/search-results-one.js
@@ -32,7 +32,6 @@ export default {
         LOCAL_CUSTODIAN_CODE: 1234,
         LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'BRISTOL CITY COUNCIL',
         COUNTRY_CODE: 'E',
-        COUNTRY_CODE_DESCRIPTION: 'This record is within England',
         POSTAL_ADDRESS_CODE: 'D',
         POSTAL_ADDRESS_CODE_DESCRIPTION: 'A record which is linked to PAF',
         BLPU_STATE_CODE: '2',

--- a/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
@@ -48,8 +48,8 @@ describe('address-lookup-service', () => {
                   BUILDING_NAME: buildingName,
                   THOROUGHFARE_NAME: thoroughfare,
                   DEPENDENT_LOCALITY: locality,
-                  POST_TOWN: town,
-              }
+                  POST_TOWN: town
+                }
               }
             ]
           })
@@ -79,7 +79,7 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '1 SARK TOWER',
                 THOROUGHFARE_NAME: 'EREBUS DRIVE',
-                POST_TOWN: 'LONDON',
+                POST_TOWN: 'LONDON'
               }
             },
             {
@@ -88,7 +88,7 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '10 SARK TOWER',
                 THOROUGHFARE_NAME: 'EREBUS DRIVE',
-                POST_TOWN: 'LONDON',
+                POST_TOWN: 'LONDON'
               }
             }
           ]
@@ -121,7 +121,7 @@ describe('address-lookup-service', () => {
                 SUB_BUILDING_NAME: 'FLAT 1-1 LOWRY 1',
                 BUILDING_NAME: 'PEEL PARK QUARTER',
                 THOROUGHFARE_NAME: 'UNIVERSITY ROAD',
-                POST_TOWN: 'SALFORD',
+                POST_TOWN: 'SALFORD'
               }
             },
             {
@@ -131,7 +131,7 @@ describe('address-lookup-service', () => {
                 SUB_BUILDING_NAME: 'FLAT 1-2 LOWRY 1',
                 BUILDING_NAME: 'PEEL PARK QUARTER',
                 THOROUGHFARE_NAME: 'UNIVERSITY ROAD',
-                POST_TOWN: 'SALFORD',
+                POST_TOWN: 'SALFORD'
               }
             }
           ]
@@ -163,7 +163,7 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'YO1 8BE',
                 BUILDING_NUMBER: '14',
                 THOROUGHFARE_NAME: 'CHURCH STREET',
-                POST_TOWN: 'YORK',
+                POST_TOWN: 'YORK'
               }
             },
             {
@@ -172,7 +172,7 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'YO1 8BE',
                 BUILDING_NUMBER: '15',
                 THOROUGHFARE_NAME: 'CHURCH STREET',
-                POST_TOWN: 'YORK',
+                POST_TOWN: 'YORK'
               }
             }
           ]
@@ -204,7 +204,7 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: 'THE BARN',
                 ORGANISATION_NAME: 'ROSE FARM',
-                POST_TOWN: 'YORK',
+                POST_TOWN: 'YORK'
               }
             },
             {
@@ -213,7 +213,7 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: 'STABLE COTTAGE',
                 ORGANISATION_NAME: 'BLUE MEADOW',
-                POST_TOWN: 'YORK',
+                POST_TOWN: 'YORK'
               }
             }
           ]
@@ -244,7 +244,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: 'THE BARN, YORK, YO60 7PD',
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: 'THE BARN',
-                POST_TOWN: 'YORK',
+                POST_TOWN: 'YORK'
               }
             }
           ]
@@ -265,7 +265,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '10 SARK TOWER, LONDON, SE28 0GG',
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '10 SARK TOWER',
-                POST_TOWN: 'LONDON',
+                POST_TOWN: 'LONDON'
               }
             }
           ]
@@ -289,7 +289,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '1 SARK TOWER, LONDON, SE28 0GG',
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '1 SARK TOWER',
-                POST_TOWN: 'LONDON',
+                POST_TOWN: 'LONDON'
               }
             },
             {
@@ -297,7 +297,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '10 SARK TOWER, LONDON, SE28 0GG',
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '10 SARK TOWER',
-                POST_TOWN: 'LONDON',
+                POST_TOWN: 'LONDON'
               }
             }
           ]
@@ -337,7 +337,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '1 SARK TOWER, LONDON, SE28 0GG',
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '1 SARK TOWER',
-                POST_TOWN: 'LONDON',
+                POST_TOWN: 'LONDON'
               }
             }
           ]
@@ -358,7 +358,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '1 ROSE FARM COTTAGES, YORK, YO60 7PD',
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: '1 ROSE FARM COTTAGES',
-                POST_TOWN: 'YORK',
+                POST_TOWN: 'YORK'
               }
             },
             {
@@ -366,7 +366,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '1 SOUTH VIEW, YORK, YO60 7PD',
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: '1 SOUTH VIEW',
-                POST_TOWN: 'YORK',
+                POST_TOWN: 'YORK'
               }
             },
             {
@@ -374,7 +374,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '2 ROSE FARM COTTAGES, YORK, YO60 7PD',
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: '2 ROSE FARM COTTAGES',
-                POST_TOWN: 'YORK',
+                POST_TOWN: 'YORK'
               }
             }
           ]
@@ -414,7 +414,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: 'THE BARN, MAIN STREET, BRISTOL, BS1 1AA',
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: 'THE BARN',
-                POST_TOWN: 'BRISTOL',
+                POST_TOWN: 'BRISTOL'
               }
             }
           ]
@@ -445,7 +445,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: 'THE  BARN, MAIN STREET, BRISTOL, BS1 1AA',
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: 'THE  BARN',
-                POST_TOWN: 'BRISTOL',
+                POST_TOWN: 'BRISTOL'
               }
             }
           ]
@@ -476,7 +476,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: 'THE   OLD   BARN, MAIN STREET, BRISTOL, BS1 1AA',
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: 'THE   OLD   BARN',
-                POST_TOWN: 'BRISTOL',
+                POST_TOWN: 'BRISTOL'
               }
             }
           ]
@@ -519,7 +519,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '1 TEST STREET, BRISTOL, BS1 1AA',
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: '1 TEST STREET',
-                POST_TOWN: 'BRISTOL',
+                POST_TOWN: 'BRISTOL'
               }
             }
           ]
@@ -550,7 +550,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '1 TEST STREET, BRISTOL, BS1 1AA',
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: '1 TEST STREET',
-                POST_TOWN: 'BRISTOL',
+                POST_TOWN: 'BRISTOL'
               }
             },
             {
@@ -558,7 +558,7 @@ describe('address-lookup-service', () => {
                 ADDRESS: '2 TEST STREET, BRISTOL, BS1 1AA',
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: '2 TEST STREET',
-                POST_TOWN: 'BRISTOL',
+                POST_TOWN: 'BRISTOL'
               }
             }
           ]
@@ -592,11 +592,7 @@ describe('address-lookup-service', () => {
 
   describe('handles missing optional fields', () => {
     it.each([
-      [
-        'DEPENDENT_LOCALITY',
-        'locality',
-        { BUILDING_NAME: '1 MAIN STREET', POST_TOWN: 'BRISTOL' }
-      ],
+      ['DEPENDENT_LOCALITY', 'locality', { BUILDING_NAME: '1 MAIN STREET', POST_TOWN: 'BRISTOL' }],
       ['POST_TOWN', 'town', { BUILDING_NAME: '1 MAIN STREET' }]
     ])('returns empty string when %s is missing', async (missingField, resultProperty, dpaData) => {
       fetch.mockResolvedValueOnce({

--- a/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
@@ -517,6 +517,18 @@ describe('address-lookup-service', () => {
         }
       ])
     })
+
+    it('returns empty array when results is null but premises filter provided', async () => {
+      fetch.mockResolvedValueOnce({
+        json: () => ({
+          results: null
+        })
+      })
+
+      const results = await addressLookupService('test', 'BS1 1AA')
+
+      expect(results).toEqual([])
+    })
   })
 
   describe('handles missing optional fields', () => {
@@ -576,6 +588,220 @@ describe('address-lookup-service', () => {
 
       expect(consoleErrorSpy).toHaveBeenCalledWith('Unable to connect to address lookup service', testError)
       consoleErrorSpy.mockRestore()
+    })
+  })
+
+  describe('pagination', () => {
+    const createMockAddress = idx => ({
+      DPA: {
+        ADDRESS: `${idx} TEST STREET, BRISTOL, BS1 1AA`,
+        POSTCODE: 'BS1 1AA',
+        BUILDING_NAME: `${idx} TEST STREET`,
+        THOROUGHFARE_NAME: 'TEST STREET',
+        POST_TOWN: 'BRISTOL'
+      }
+    })
+
+    const createMockResponse = (totalresults, maxresults, offset = 0, count = maxresults) => ({
+      json: () => ({
+        header: { totalresults, maxresults },
+        results: Array.from({ length: count }, (_, i) => createMockAddress(offset + i))
+      })
+    })
+
+    describe('when totalresults exceeds maxresults', () => {
+      it.each([
+        { totalresults: 250, maxresults: 100, expectedCalls: 3 },
+        { totalresults: 150, maxresults: 100, expectedCalls: 2 },
+        { totalresults: 301, maxresults: 100, expectedCalls: 4 }
+      ])(
+        'fetches all pages when totalresults=$totalresults maxresults=$maxresults',
+        async ({ totalresults, maxresults, expectedCalls }) => {
+          fetch.mockResolvedValueOnce(createMockResponse(totalresults, maxresults, 0, maxresults))
+          for (let i = 1; i < expectedCalls; i++) {
+            fetch.mockResolvedValueOnce(createMockResponse(totalresults, maxresults, i * maxresults, maxresults))
+          }
+
+          await addressLookupService('test', 'BS1 1AA')
+
+          expect(fetch).toHaveBeenCalledTimes(expectedCalls)
+        }
+      )
+
+      it('fetches second page with correct offset parameter', async () => {
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 100, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        await addressLookupService('test', 'BS1 1AA')
+
+        expect(fetch).toHaveBeenNthCalledWith(2, expect.stringContaining('offset=100'), expect.any(Object))
+      })
+
+      it('fetches third page with correct offset parameter', async () => {
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 100, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        await addressLookupService('test', 'BS1 1AA')
+
+        expect(fetch).toHaveBeenNthCalledWith(3, expect.stringContaining('offset=200'), expect.any(Object))
+      })
+
+      it('aggregates results from all pages', async () => {
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 100, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        const results = await addressLookupService(null, 'BS1 1AA')
+
+        expect(results).toHaveLength(250)
+      })
+
+      it('applies premises filter to aggregated results', async () => {
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 100, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        const results = await addressLookupService('150', 'BS1 1AA')
+
+        expect(results).toHaveLength(1)
+      })
+    })
+
+    describe('when totalresults does not exceed maxresults', () => {
+      it.each([
+        { totalresults: 100, maxresults: 100, description: 'equal to maxresults' },
+        { totalresults: 50, maxresults: 100, description: 'less than maxresults' }
+      ])('does not fetch additional pages when $description', async ({ totalresults, maxresults }) => {
+        fetch.mockResolvedValueOnce(createMockResponse(totalresults, maxresults, 0, totalresults))
+
+        await addressLookupService('test', 'BS1 1AA')
+
+        expect(fetch).toHaveBeenCalledTimes(1)
+      })
+
+      it('does not fetch additional pages when header is missing', async () => {
+        fetch.mockResolvedValueOnce({
+          json: () => ({
+            results: [createMockAddress(0)]
+          })
+        })
+
+        await addressLookupService('test', 'BS1 1AA')
+
+        expect(fetch).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('cap functionality', () => {
+      beforeAll(() => {
+        process.env.ADDRESS_LOOKUP_MAX_RESULTS = '5000'
+      })
+
+      afterAll(() => {
+        delete process.env.ADDRESS_LOOKUP_MAX_RESULTS
+      })
+
+      it('limits fetching to cap when totalresults exceeds cap', async () => {
+        fetch.mockResolvedValueOnce(createMockResponse(10000, 100, 0, 100))
+        // Cap at 5000 = 50 pages, so 1 + 49 additional = 50 total
+        for (let i = 1; i < 50; i++) {
+          fetch.mockResolvedValueOnce(createMockResponse(10000, 100, i * 100, 100))
+        }
+
+        await addressLookupService('test', 'BS1 1AA')
+
+        expect(fetch).toHaveBeenCalledTimes(50)
+      })
+
+      it('logs warning when cap is reached', async () => {
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
+        fetch.mockResolvedValueOnce(createMockResponse(10000, 100, 0, 100))
+        for (let i = 1; i < 50; i++) {
+          fetch.mockResolvedValueOnce(createMockResponse(10000, 100, i * 100, 100))
+        }
+
+        await addressLookupService('test', 'BS1 1AA')
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('totalresults 10000 exceeds cap 5000'))
+        consoleWarnSpy.mockRestore()
+      })
+
+      it('does not log warning when totalresults within cap', async () => {
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 100, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        await addressLookupService('test', 'BS1 1AA')
+
+        expect(consoleWarnSpy).not.toHaveBeenCalled()
+        consoleWarnSpy.mockRestore()
+      })
+    })
+
+    describe('partial failure handling', () => {
+      it('returns successful pages even when some pages fail', async () => {
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockRejectedValueOnce(new Error('Network error'))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        const results = await addressLookupService(null, 'BS1 1AA')
+
+        expect(results).toHaveLength(150)
+      })
+
+      it('logs failed pages to console.error', async () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockRejectedValueOnce(new Error('Network error'))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        await addressLookupService(null, 'BS1 1AA')
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to fetch 1 pages'),
+          expect.objectContaining({ offsets: [100] })
+        )
+        consoleErrorSpy.mockRestore()
+      })
+
+      it('logs error messages for failed pages', async () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockRejectedValueOnce(new Error('Network error'))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        await addressLookupService(null, 'BS1 1AA')
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ errors: ['Network error'] }))
+        consoleErrorSpy.mockRestore()
+      })
+
+      it('does not log error when all pages succeed', async () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 100, 100))
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        await addressLookupService(null, 'BS1 1AA')
+
+        expect(consoleErrorSpy).not.toHaveBeenCalled()
+        consoleErrorSpy.mockRestore()
+      })
+
+      it('logs "Unknown error" when failed page has no error message', async () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 0, 100))
+        fetch.mockRejectedValueOnce({ status: 500 })
+        fetch.mockResolvedValueOnce(createMockResponse(250, 100, 200, 50))
+
+        await addressLookupService(null, 'BS1 1AA')
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ errors: ['Unknown error'] }))
+        consoleErrorSpy.mockRestore()
+      })
     })
   })
 })

--- a/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
@@ -529,6 +529,59 @@ describe('address-lookup-service', () => {
 
       expect(results).toEqual([])
     })
+
+    it('returns all results when premises parameter is null', async () => {
+      fetch.mockResolvedValueOnce({
+        json: () => ({
+          results: [
+            {
+              DPA: {
+                ADDRESS: '1 TEST STREET, BRISTOL, BS1 1AA',
+                POSTCODE: 'BS1 1AA',
+                BUILDING_NAME: '1 TEST STREET',
+                POST_TOWN: 'BRISTOL',
+                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
+              }
+            }
+          ]
+        })
+      })
+
+      const results = await addressLookupService(null, 'BS1 1AA')
+
+      expect(results).toHaveLength(1)
+    })
+
+    it('returns all results when premises parameter is undefined', async () => {
+      fetch.mockResolvedValueOnce({
+        json: () => ({
+          results: [
+            {
+              DPA: {
+                ADDRESS: '1 TEST STREET, BRISTOL, BS1 1AA',
+                POSTCODE: 'BS1 1AA',
+                BUILDING_NAME: '1 TEST STREET',
+                POST_TOWN: 'BRISTOL',
+                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
+              }
+            },
+            {
+              DPA: {
+                ADDRESS: '2 TEST STREET, BRISTOL, BS1 1AA',
+                POSTCODE: 'BS1 1AA',
+                BUILDING_NAME: '2 TEST STREET',
+                POST_TOWN: 'BRISTOL',
+                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
+              }
+            }
+          ]
+        })
+      })
+
+      const results = await addressLookupService(undefined, 'BS1 1AA')
+
+      expect(results).toHaveLength(2)
+    })
   })
 
   describe('handles missing optional fields', () => {
@@ -738,6 +791,26 @@ describe('address-lookup-service', () => {
 
         expect(consoleWarnSpy).not.toHaveBeenCalled()
         consoleWarnSpy.mockRestore()
+      })
+
+      it('returns only first page results when cap is less than maxresults', async () => {
+        process.env.ADDRESS_LOOKUP_MAX_RESULTS = '50'
+        fetch.mockResolvedValueOnce(createMockResponse(200, 100, 0, 100))
+
+        const results = await addressLookupService('test', 'BS1 1AA')
+
+        expect(results).toHaveLength(100)
+        delete process.env.ADDRESS_LOOKUP_MAX_RESULTS
+      })
+
+      it('does not fetch additional pages when cap is less than maxresults', async () => {
+        process.env.ADDRESS_LOOKUP_MAX_RESULTS = '50'
+        fetch.mockResolvedValueOnce(createMockResponse(200, 100, 0, 100))
+
+        await addressLookupService('test', 'BS1 1AA')
+
+        expect(fetch).toHaveBeenCalledTimes(1)
+        delete process.env.ADDRESS_LOOKUP_MAX_RESULTS
       })
     })
 

--- a/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
@@ -49,8 +49,7 @@ describe('address-lookup-service', () => {
                   THOROUGHFARE_NAME: thoroughfare,
                   DEPENDENT_LOCALITY: locality,
                   POST_TOWN: town,
-                  COUNTRY_CODE_DESCRIPTION: country
-                }
+              }
               }
             ]
           })
@@ -81,7 +80,6 @@ describe('address-lookup-service', () => {
                 BUILDING_NAME: '1 SARK TOWER',
                 THOROUGHFARE_NAME: 'EREBUS DRIVE',
                 POST_TOWN: 'LONDON',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             },
             {
@@ -91,7 +89,6 @@ describe('address-lookup-service', () => {
                 BUILDING_NAME: '10 SARK TOWER',
                 THOROUGHFARE_NAME: 'EREBUS DRIVE',
                 POST_TOWN: 'LONDON',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -125,7 +122,6 @@ describe('address-lookup-service', () => {
                 BUILDING_NAME: 'PEEL PARK QUARTER',
                 THOROUGHFARE_NAME: 'UNIVERSITY ROAD',
                 POST_TOWN: 'SALFORD',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             },
             {
@@ -136,7 +132,6 @@ describe('address-lookup-service', () => {
                 BUILDING_NAME: 'PEEL PARK QUARTER',
                 THOROUGHFARE_NAME: 'UNIVERSITY ROAD',
                 POST_TOWN: 'SALFORD',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -169,7 +164,6 @@ describe('address-lookup-service', () => {
                 BUILDING_NUMBER: '14',
                 THOROUGHFARE_NAME: 'CHURCH STREET',
                 POST_TOWN: 'YORK',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             },
             {
@@ -179,7 +173,6 @@ describe('address-lookup-service', () => {
                 BUILDING_NUMBER: '15',
                 THOROUGHFARE_NAME: 'CHURCH STREET',
                 POST_TOWN: 'YORK',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -212,7 +205,6 @@ describe('address-lookup-service', () => {
                 BUILDING_NAME: 'THE BARN',
                 ORGANISATION_NAME: 'ROSE FARM',
                 POST_TOWN: 'YORK',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             },
             {
@@ -222,7 +214,6 @@ describe('address-lookup-service', () => {
                 BUILDING_NAME: 'STABLE COTTAGE',
                 ORGANISATION_NAME: 'BLUE MEADOW',
                 POST_TOWN: 'YORK',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -254,7 +245,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: 'THE BARN',
                 POST_TOWN: 'YORK',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -276,7 +266,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '10 SARK TOWER',
                 POST_TOWN: 'LONDON',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -301,7 +290,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '1 SARK TOWER',
                 POST_TOWN: 'LONDON',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             },
             {
@@ -310,7 +298,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '10 SARK TOWER',
                 POST_TOWN: 'LONDON',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -351,7 +338,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'SE28 0GG',
                 BUILDING_NAME: '1 SARK TOWER',
                 POST_TOWN: 'LONDON',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -373,7 +359,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: '1 ROSE FARM COTTAGES',
                 POST_TOWN: 'YORK',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             },
             {
@@ -382,7 +367,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: '1 SOUTH VIEW',
                 POST_TOWN: 'YORK',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             },
             {
@@ -391,7 +375,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'YO60 7PD',
                 BUILDING_NAME: '2 ROSE FARM COTTAGES',
                 POST_TOWN: 'YORK',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -432,7 +415,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: 'THE BARN',
                 POST_TOWN: 'BRISTOL',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -464,7 +446,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: 'THE  BARN',
                 POST_TOWN: 'BRISTOL',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -496,7 +477,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: 'THE   OLD   BARN',
                 POST_TOWN: 'BRISTOL',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -540,7 +520,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: '1 TEST STREET',
                 POST_TOWN: 'BRISTOL',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -549,7 +528,17 @@ describe('address-lookup-service', () => {
 
       const results = await addressLookupService(null, 'BS1 1AA')
 
-      expect(results).toHaveLength(1)
+      expect(results).toEqual([
+        {
+          id: 0,
+          address: '1 test street, bristol, BS1 1AA',
+          premises: '1 TEST STREET',
+          street: '',
+          locality: '',
+          town: 'BRISTOL',
+          postcode: 'BS1 1AA'
+        }
+      ])
     })
 
     it('returns all results when premises parameter is undefined', async () => {
@@ -562,7 +551,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: '1 TEST STREET',
                 POST_TOWN: 'BRISTOL',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             },
             {
@@ -571,7 +559,6 @@ describe('address-lookup-service', () => {
                 POSTCODE: 'BS1 1AA',
                 BUILDING_NAME: '2 TEST STREET',
                 POST_TOWN: 'BRISTOL',
-                COUNTRY_CODE_DESCRIPTION: 'This record is within England'
               }
             }
           ]
@@ -580,7 +567,26 @@ describe('address-lookup-service', () => {
 
       const results = await addressLookupService(undefined, 'BS1 1AA')
 
-      expect(results).toHaveLength(2)
+      expect(results).toEqual([
+        {
+          id: 0,
+          address: '1 test street, bristol, BS1 1AA',
+          premises: '1 TEST STREET',
+          street: '',
+          locality: '',
+          town: 'BRISTOL',
+          postcode: 'BS1 1AA'
+        },
+        {
+          id: 1,
+          address: '2 test street, bristol, BS1 1AA',
+          premises: '2 TEST STREET',
+          street: '',
+          locality: '',
+          town: 'BRISTOL',
+          postcode: 'BS1 1AA'
+        }
+      ])
     })
   })
 
@@ -589,9 +595,9 @@ describe('address-lookup-service', () => {
       [
         'DEPENDENT_LOCALITY',
         'locality',
-        { BUILDING_NAME: '1 MAIN STREET', POST_TOWN: 'BRISTOL', COUNTRY_CODE_DESCRIPTION: 'This record is within England' }
+        { BUILDING_NAME: '1 MAIN STREET', POST_TOWN: 'BRISTOL' }
       ],
-      ['POST_TOWN', 'town', { BUILDING_NAME: '1 MAIN STREET', COUNTRY_CODE_DESCRIPTION: 'This record is within England' }]
+      ['POST_TOWN', 'town', { BUILDING_NAME: '1 MAIN STREET' }]
     ])('returns empty string when %s is missing', async (missingField, resultProperty, dpaData) => {
       fetch.mockResolvedValueOnce({
         json: () => ({

--- a/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
@@ -118,6 +118,42 @@ const fetchAdditionalPages = async (postcode, totalresults, maxresults, cap) => 
 }
 
 /**
+ * Get the maximum results cap from environment or default
+ * @returns {number} Maximum results cap
+ */
+const getMaximumResultsCap = () => {
+  return Number.parseInt(process.env.ADDRESS_LOOKUP_MAX_RESULTS) || ADDRESS_LOOKUP_MAX_RESULTS_DEFAULT
+}
+
+/**
+ * Check if pagination is needed based on total results and page size
+ * @param {number} totalresults - Total results available
+ * @param {number} maxresults - Maximum results per page
+ * @returns {boolean} Whether pagination is needed
+ */
+const checkNeedsPagination = (totalresults, maxresults) => {
+  return totalresults && maxresults && totalresults > maxresults
+}
+
+/**
+ * Fetch the first page of results
+ * @param {string} postcode - The postcode to search
+ * @returns {Promise<object|null>} First page response or null on error
+ */
+const fetchFirstPage = async postcode => {
+  const firstUrl = buildUrl(postcode, 0)
+  debug({ url: firstUrl })
+
+  const firstPage = await fetchPage(firstUrl).catch(err => {
+    // On a failure to connect do not stop the user journey
+    console.error('Unable to connect to address lookup service', err)
+    return null
+  })
+
+  return firstPage
+}
+
+/**
  * Process and aggregate results from multiple pages
  * @param {object} firstPage - First page response
  * @param {Array} additionalResults - Results from additional pages
@@ -162,26 +198,18 @@ const processResults = (firstPage, additionalResults, failedPages, additionalPag
 
 export default async (premises, postcode) => {
   const startTime = Date.now()
-  const cap = Number.parseInt(process.env.ADDRESS_LOOKUP_MAX_RESULTS) || ADDRESS_LOOKUP_MAX_RESULTS_DEFAULT
 
-  // Fetch first page
-  const firstUrl = buildUrl(postcode, 0)
-  debug({ url: firstUrl })
-
-  const firstPage = await fetchPage(firstUrl).catch(err => {
-    // On a failure to connect do not stop the user journey
-    console.error('Unable to connect to address lookup service', err)
-    return null
-  })
+  const firstPage = await fetchFirstPage(postcode)
 
   if (!firstPage) {
     return []
   }
 
   const { totalresults, maxresults } = firstPage.header || {}
-  const needsPagination = totalresults && maxresults && totalresults > maxresults
+  const needsPagination = checkNeedsPagination(totalresults, maxresults)
 
   // Fetch additional pages if needed
+  const cap = getMaximumResultsCap()
   const {
     results: additionalResults,
     failedPages,

--- a/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
@@ -1,66 +1,159 @@
 import fetch from 'node-fetch'
-import { ADDRESS_LOOKUP_TIMEOUT_MS_DEFAULT } from '../../constants.js'
+import { ADDRESS_LOOKUP_TIMEOUT_MS_DEFAULT, ADDRESS_LOOKUP_MAX_RESULTS_DEFAULT } from '../../constants.js'
 import db from 'debug'
 const debug = db('webapp:address-lookup-service')
 
-export default async (premises, postcode) => {
+/**
+ * Build URL for OS Places API with optional offset
+ * @param {string} postcode - The postcode to search
+ * @param {number} offset - Optional offset for pagination
+ * @returns {string} The complete URL
+ */
+const buildUrl = (postcode, offset = 0) => {
   const url = new URL(process.env.ADDRESS_LOOKUP_URL)
-
   const params = new URLSearchParams({
     postcode: postcode,
     key: process.env.ADDRESS_LOOKUP_KEY
   })
 
+  if (offset > 0) {
+    params.append('offset', offset)
+  }
+
   url.search = params.toString()
+  return url.href
+}
 
-  debug({ url })
+/**
+ * Fetch a single page from the OS Places API
+ * @param {string} url - The URL to fetch
+ * @returns {Promise<object>} The API response
+ */
+const fetchPage = async url => {
+  const response = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: process.env.ADDRESS_LOOKUP_MS || ADDRESS_LOOKUP_TIMEOUT_MS_DEFAULT
+  })
+  return response.json()
+}
 
-  const { results } = await (async () => {
-    try {
-      const response = await fetch(url.href, {
-        headers: { 'Content-Type': 'application/json' },
-        timeout: process.env.ADDRESS_LOOKUP_MS || ADDRESS_LOOKUP_TIMEOUT_MS_DEFAULT
-      })
-      return response.json()
-    } catch (err) {
-      // On a failure to connect do not stop the user journey
-      console.error('Unable to connect to address lookup service', err)
-      return { results: [] }
-    }
-  })()
+/**
+ * Filter results by premises search term
+ * @param {Array} results - Array of address results
+ * @param {string} premises - Optional premises search term
+ * @returns {Array} Filtered results
+ */
+const filterByPremises = (results, premises) => {
+  if (!results || !premises) return results || []
 
-  // Filter results by premises if provided
-  const filteredResults =
-    results && premises
-      ? results.filter(r => {
-        const normalizedPremises = premises.trim().replaceAll(/\s+/g, ' ').toLowerCase()
-        const searchText = [r.DPA.SUB_BUILDING_NAME, r.DPA.BUILDING_NUMBER, r.DPA.BUILDING_NAME, r.DPA.ORGANISATION_NAME]
-          .filter(Boolean)
-          .join(' ')
-          .replaceAll(/\s+/g, ' ')
-          .toLowerCase()
+  const normalizedPremises = premises.trim().replaceAll(/\s+/g, ' ').toLowerCase()
 
-        return searchText.includes(normalizedPremises)
-      })
-      : results
+  return results.filter(r => {
+    const searchText = [r.DPA.SUB_BUILDING_NAME, r.DPA.BUILDING_NUMBER, r.DPA.BUILDING_NAME, r.DPA.ORGANISATION_NAME]
+      .filter(Boolean)
+      .join(' ')
+      .replaceAll(/\s+/g, ' ')
+      .toLowerCase()
 
+    return searchText.includes(normalizedPremises)
+  })
+}
+
+/**
+ * Map API results to application format
+ * @param {Array} results - Array of address results
+ * @returns {Array} Mapped results
+ */
+const mapResults = results => {
+  return results.map((r, idx) => ({
+    id: idx,
+    address: `${r.DPA.ADDRESS.replace(r.DPA.POSTCODE, '').toLowerCase()}${r.DPA.POSTCODE}`,
+    premises: r.DPA.BUILDING_NAME || '',
+    street: r.DPA.THOROUGHFARE_NAME || '',
+    locality: r.DPA.DEPENDENT_LOCALITY || '',
+    town: r.DPA.POST_TOWN || '',
+    postcode: r.DPA.POSTCODE
+  }))
+}
+
+export default async (premises, postcode) => {
+  const startTime = Date.now()
+  const cap = parseInt(process.env.ADDRESS_LOOKUP_MAX_RESULTS) || ADDRESS_LOOKUP_MAX_RESULTS_DEFAULT
+
+  // Fetch first page
+  const firstUrl = buildUrl(postcode, 0)
+  debug({ url: firstUrl })
+
+  const firstPage = await fetchPage(firstUrl).catch(err => {
+    // On a failure to connect do not stop the user journey
+    console.error('Unable to connect to address lookup service', err)
+    return null
+  })
+
+  if (!firstPage) return []
+
+  const { totalresults, maxresults } = firstPage.header || {}
+  const needsPagination = totalresults && maxresults && totalresults > maxresults
+
+  // Calculate offsets for additional pages
+  const effectiveTotal = needsPagination ? Math.min(totalresults, cap) : 0
+  const offsets = needsPagination
+    ? Array.from({ length: Math.ceil((effectiveTotal - maxresults) / maxresults) }, (_, i) => maxresults + i * maxresults).filter(
+      offset => offset < effectiveTotal
+    )
+    : []
+
+  // Fetch all additional pages in parallel
+  const pageResults = offsets.length > 0 ? await Promise.allSettled(offsets.map(offset => fetchPage(buildUrl(postcode, offset)))) : []
+
+  // Extract successful page results
+  const additionalResults = pageResults.filter(r => r.status === 'fulfilled' && r.value.results).flatMap(r => r.value.results)
+
+  // Extract failed pages
+  const failedPages = pageResults
+    .map((result, idx) => ({ result, offset: offsets[idx] }))
+    .filter(({ result }) => result.status === 'rejected')
+    .map(({ result, offset }) => ({
+      offset,
+      error: result.reason?.message || 'Unknown error'
+    }))
+
+  // Aggregate all results
+  const allResults = [...(firstPage.results || []), ...additionalResults]
+  const pagesFetched = 1 + pageResults.filter(r => r.status === 'fulfilled').length
+
+  // Log partial failures
+  if (failedPages.length > 0) {
+    console.error(`Failed to fetch ${failedPages.length} pages for postcode ${postcode}`, {
+      offsets: failedPages.map(f => f.offset),
+      errors: failedPages.map(f => f.error)
+    })
+  }
+
+  // Log if cap was reached
+  if (totalresults > cap) {
+    console.warn(
+      `Postcode ${postcode}: totalresults ${totalresults} exceeds cap ${cap}, retrieved ${pagesFetched} pages (${allResults.length} addresses)`
+    )
+  }
+
+  // Filter aggregated results
+  const filteredResults = filterByPremises(allResults, premises)
+
+  // Telemetry logging
+  const duration = Date.now() - startTime
   debug({
     postcode,
     premises: premises || null,
-    receivedCount: results?.length || 0,
-    filteredCount: filteredResults?.length || 0
+    totalresults: totalresults || allResults.length,
+    maxresults: maxresults || 100,
+    pagesFetched,
+    aggregatedCount: allResults.length,
+    filteredCount: filteredResults.length,
+    failedPages: failedPages.length,
+    duration: `${duration}ms`
   })
 
-  // Map and enumerate the results
-  return filteredResults
-    ? filteredResults.map((r, idx) => ({
-      id: idx,
-      address: `${r.DPA.ADDRESS.replace(r.DPA.POSTCODE, '').toLowerCase()}${r.DPA.POSTCODE}`,
-      premises: r.DPA.BUILDING_NAME || '',
-      street: r.DPA.THOROUGHFARE_NAME || '',
-      locality: r.DPA.DEPENDENT_LOCALITY || '',
-      town: r.DPA.POST_TOWN || '',
-      postcode: r.DPA.POSTCODE
-    }))
-    : []
+  // Map and return results
+  return mapResults(filteredResults)
 }

--- a/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
@@ -44,7 +44,9 @@ const fetchPage = async url => {
  * @returns {Array} Filtered results
  */
 const filterByPremises = (results, premises) => {
-  if (!results || !premises) return results || []
+  if (!results || !premises) {
+    return results || []
+  }
 
   const normalizedPremises = premises.trim().replaceAll(/\s+/g, ' ').toLowerCase()
 
@@ -76,6 +78,42 @@ const mapResults = results => {
   }))
 }
 
+/**
+ * Fetch additional pages when pagination is needed
+ * @param {string} postcode - The postcode being searched
+ * @param {number} totalresults - Total results available from API
+ * @param {number} maxresults - Maximum results per page
+ * @param {number} cap - Maximum results to fetch (configurable limit)
+ * @returns {Promise<object>} Object containing additional results, failed pages, and page count
+ */
+const fetchAdditionalPages = async (postcode, totalresults, maxresults, cap) => {
+  const effectiveTotal = Math.min(totalresults, cap)
+  const offsets = Array.from(
+    { length: Math.ceil((effectiveTotal - maxresults) / maxresults) },
+    (_, i) => maxresults + i * maxresults
+  ).filter(offset => offset < effectiveTotal)
+
+  if (offsets.length === 0) {
+    return { results: [], failedPages: [], pagesFetched: 0 }
+  }
+
+  const pageResults = await Promise.allSettled(offsets.map(offset => fetchPage(buildUrl(postcode, offset))))
+
+  const additionalResults = pageResults.filter(r => r.status === 'fulfilled' && r.value.results).flatMap(r => r.value.results)
+
+  const failedPages = pageResults
+    .map((result, idx) => ({ result, offset: offsets[idx] }))
+    .filter(({ result }) => result.status === 'rejected')
+    .map(({ result, offset }) => ({
+      offset,
+      error: result.reason?.message || 'Unknown error'
+    }))
+
+  const pagesFetched = pageResults.filter(r => r.status === 'fulfilled').length
+
+  return { results: additionalResults, failedPages, pagesFetched }
+}
+
 export default async (premises, postcode) => {
   const startTime = Date.now()
   const cap = parseInt(process.env.ADDRESS_LOOKUP_MAX_RESULTS) || ADDRESS_LOOKUP_MAX_RESULTS_DEFAULT
@@ -90,37 +128,25 @@ export default async (premises, postcode) => {
     return null
   })
 
-  if (!firstPage) return []
+  if (!firstPage) {
+    return []
+  }
 
   const { totalresults, maxresults } = firstPage.header || {}
   const needsPagination = totalresults && maxresults && totalresults > maxresults
 
-  // Calculate offsets for additional pages
-  const effectiveTotal = needsPagination ? Math.min(totalresults, cap) : 0
-  const offsets = needsPagination
-    ? Array.from({ length: Math.ceil((effectiveTotal - maxresults) / maxresults) }, (_, i) => maxresults + i * maxresults).filter(
-      offset => offset < effectiveTotal
-    )
-    : []
-
-  // Fetch all additional pages in parallel
-  const pageResults = offsets.length > 0 ? await Promise.allSettled(offsets.map(offset => fetchPage(buildUrl(postcode, offset)))) : []
-
-  // Extract successful page results
-  const additionalResults = pageResults.filter(r => r.status === 'fulfilled' && r.value.results).flatMap(r => r.value.results)
-
-  // Extract failed pages
-  const failedPages = pageResults
-    .map((result, idx) => ({ result, offset: offsets[idx] }))
-    .filter(({ result }) => result.status === 'rejected')
-    .map(({ result, offset }) => ({
-      offset,
-      error: result.reason?.message || 'Unknown error'
-    }))
+  // Fetch additional pages if needed
+  const {
+    results: additionalResults,
+    failedPages,
+    pagesFetched: additionalPagesFetched
+  } = needsPagination
+    ? await fetchAdditionalPages(postcode, totalresults, maxresults, cap)
+    : { results: [], failedPages: [], pagesFetched: 0 }
 
   // Aggregate all results
   const allResults = [...(firstPage.results || []), ...additionalResults]
-  const pagesFetched = 1 + pageResults.filter(r => r.status === 'fulfilled').length
+  const pagesFetched = 1 + additionalPagesFetched
 
   // Log partial failures
   if (failedPages.length > 0) {

--- a/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
@@ -6,10 +6,10 @@ const debug = db('webapp:address-lookup-service')
 /**
  * Build URL for OS Places API with optional offset
  * @param {string} postcode - The postcode to search
- * @param {number} offset - Optional offset for pagination
+ * @param {number} offset - Offset for pagination
  * @returns {string} The complete URL
  */
-const buildUrl = (postcode, offset = 0) => {
+const buildUrl = (postcode, offset) => {
   const url = new URL(process.env.ADDRESS_LOOKUP_URL)
   const params = new URLSearchParams({
     postcode: postcode,
@@ -88,6 +88,9 @@ const mapResults = results => {
  */
 const fetchAdditionalPages = async (postcode, totalresults, maxresults, cap) => {
   const effectiveTotal = Math.min(totalresults, cap)
+  
+  // Calculate offsets for additional pages (first page already fetched at offset 0)
+  // Example: if effectiveTotal=250 and maxresults=100, generates [100, 200] to fetch pages 2 and 3
   const offsets = Array.from(
     { length: Math.ceil((effectiveTotal - maxresults) / maxresults) },
     (_, i) => maxresults + i * maxresults

--- a/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
@@ -114,9 +114,52 @@ const fetchAdditionalPages = async (postcode, totalresults, maxresults, cap) => 
   return { results: additionalResults, failedPages, pagesFetched }
 }
 
+/**
+ * Process and aggregate results from multiple pages
+ * @param {object} firstPage - First page response
+ * @param {Array} additionalResults - Results from additional pages
+ * @param {Array} failedPages - Failed page information
+ * @param {number} additionalPagesFetched - Count of additional pages fetched
+ * @param {string} postcode - Postcode being searched
+ * @param {number} cap - Maximum results cap
+ * @param {number} startTime - Start timestamp for telemetry
+ * @returns {Array} Aggregated results
+ */
+const processResults = (firstPage, additionalResults, failedPages, additionalPagesFetched, postcode, cap, startTime) => {
+  const allResults = [...(firstPage.results || []), ...additionalResults]
+  const pagesFetched = 1 + additionalPagesFetched
+  const { totalresults, maxresults } = firstPage.header || {}
+
+  if (failedPages.length > 0) {
+    console.error(`Failed to fetch ${failedPages.length} pages for postcode ${postcode}`, {
+      offsets: failedPages.map(f => f.offset),
+      errors: failedPages.map(f => f.error)
+    })
+  }
+
+  if (totalresults > cap) {
+    console.warn(
+      `Postcode ${postcode}: totalresults ${totalresults} exceeds cap ${cap}, retrieved ${pagesFetched} pages (${allResults.length} addresses)`
+    )
+  }
+
+  const duration = Date.now() - startTime
+  debug({
+    postcode,
+    totalresults: totalresults || allResults.length,
+    maxresults: maxresults || 100,
+    pagesFetched,
+    aggregatedCount: allResults.length,
+    failedPages: failedPages.length,
+    duration: `${duration}ms`
+  })
+
+  return allResults
+}
+
 export default async (premises, postcode) => {
   const startTime = Date.now()
-  const cap = parseInt(process.env.ADDRESS_LOOKUP_MAX_RESULTS) || ADDRESS_LOOKUP_MAX_RESULTS_DEFAULT
+  const cap = Number.parseInt(process.env.ADDRESS_LOOKUP_MAX_RESULTS) || ADDRESS_LOOKUP_MAX_RESULTS_DEFAULT
 
   // Fetch first page
   const firstUrl = buildUrl(postcode, 0)
@@ -144,42 +187,10 @@ export default async (premises, postcode) => {
     ? await fetchAdditionalPages(postcode, totalresults, maxresults, cap)
     : { results: [], failedPages: [], pagesFetched: 0 }
 
-  // Aggregate all results
-  const allResults = [...(firstPage.results || []), ...additionalResults]
-  const pagesFetched = 1 + additionalPagesFetched
-
-  // Log partial failures
-  if (failedPages.length > 0) {
-    console.error(`Failed to fetch ${failedPages.length} pages for postcode ${postcode}`, {
-      offsets: failedPages.map(f => f.offset),
-      errors: failedPages.map(f => f.error)
-    })
-  }
-
-  // Log if cap was reached
-  if (totalresults > cap) {
-    console.warn(
-      `Postcode ${postcode}: totalresults ${totalresults} exceeds cap ${cap}, retrieved ${pagesFetched} pages (${allResults.length} addresses)`
-    )
-  }
-
-  // Filter aggregated results
+  const allResults = processResults(firstPage, additionalResults, failedPages, additionalPagesFetched, postcode, cap, startTime)
   const filteredResults = filterByPremises(allResults, premises)
 
-  // Telemetry logging
-  const duration = Date.now() - startTime
-  debug({
-    postcode,
-    premises: premises || null,
-    totalresults: totalresults || allResults.length,
-    maxresults: maxresults || 100,
-    pagesFetched,
-    aggregatedCount: allResults.length,
-    filteredCount: filteredResults.length,
-    failedPages: failedPages.length,
-    duration: `${duration}ms`
-  })
+  debug({ premises: premises || null, filteredCount: filteredResults.length })
 
-  // Map and return results
   return mapResults(filteredResults)
 }

--- a/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
@@ -88,7 +88,7 @@ const mapResults = results => {
  */
 const fetchAdditionalPages = async (postcode, totalresults, maxresults, cap) => {
   const effectiveTotal = Math.min(totalresults, cap)
-  
+
   // Calculate offsets for additional pages (first page already fetched at offset 0)
   // Example: if effectiveTotal=250 and maxresults=100, generates [100, 200] to fetch pages 2 and 3
   const offsets = Array.from(

--- a/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
@@ -44,8 +44,8 @@ const fetchPage = async url => {
  * @returns {Array} Filtered results
  */
 const filterByPremises = (results, premises) => {
-  if (!results || !premises) {
-    return results || []
+  if (!premises) {
+    return results
   }
 
   const normalizedPremises = premises.trim().replaceAll(/\s+/g, ' ').toLowerCase()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-5016

As a user entering my address for a dense postcode,
I want the system to fetch all addresses from the OS API (not just the first page),
so that my house name/number can be matched even when there are more than 100 addresses in the postcode.