### PR TITLE
Address lookup is not populating premises field

### DIFF
--- a/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/__tests__/address-lookup-service.spec.js
@@ -66,6 +66,68 @@ describe('address-lookup-service', () => {
         })
       }
     )
+
+    it('maps BUILDING_NUMBER to premises when BUILDING_NAME is absent', async () => {
+      fetch.mockResolvedValue({
+        json: () => ({
+          results: [
+            {
+              DPA: {
+                ADDRESS: '19, CRABTREE AVENUE, WEMBLEY, HA0 1LW',
+                POSTCODE: 'HA0 1LW',
+                BUILDING_NUMBER: '19',
+                THOROUGHFARE_NAME: 'CRABTREE AVENUE',
+                POST_TOWN: 'WEMBLEY'
+              }
+            }
+          ]
+        })
+      })
+      const results = await addressLookupService()
+      expect(results[0].premises).toBe('19')
+    })
+
+    it('maps BUILDING_NAME to premises in preference to BUILDING_NUMBER when both exist', async () => {
+      fetch.mockResolvedValue({
+        json: () => ({
+          results: [
+            {
+              DPA: {
+                ADDRESS: 'THE LODGE, 5, CHURCH LANE, BRISTOL, BS1 1AA',
+                POSTCODE: 'BS1 1AA',
+                BUILDING_NAME: 'THE LODGE',
+                BUILDING_NUMBER: '5',
+                THOROUGHFARE_NAME: 'CHURCH LANE',
+                POST_TOWN: 'BRISTOL'
+              }
+            }
+          ]
+        })
+      })
+      const results = await addressLookupService()
+      expect(results[0].premises).toBe('THE LODGE')
+    })
+
+    it('maps SUB_BUILDING_NAME combined with BUILDING_NUMBER to premises when BUILDING_NAME is absent', async () => {
+      fetch.mockResolvedValue({
+        json: () => ({
+          results: [
+            {
+              DPA: {
+                ADDRESS: 'FLAT 1, 19, CRABTREE AVENUE, WEMBLEY, HA0 1LW',
+                POSTCODE: 'HA0 1LW',
+                SUB_BUILDING_NAME: 'FLAT 1',
+                BUILDING_NUMBER: '19',
+                THOROUGHFARE_NAME: 'CRABTREE AVENUE',
+                POST_TOWN: 'WEMBLEY'
+              }
+            }
+          ]
+        })
+      })
+      const results = await addressLookupService()
+      expect(results[0].premises).not.toBe('')
+    })
   })
 
   describe('filtering by premises', () => {
@@ -185,7 +247,7 @@ describe('address-lookup-service', () => {
         {
           id: 0,
           address: '14, church street, york, YO1 8BE',
-          premises: '',
+          premises: '14',
           street: 'CHURCH STREET',
           locality: '',
           town: 'YORK',

--- a/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
+++ b/packages/gafl-webapp-service/src/services/address-lookup/address-lookup-service.js
@@ -70,7 +70,7 @@ const mapResults = results => {
   return results.map((r, idx) => ({
     id: idx,
     address: `${r.DPA.ADDRESS.replace(r.DPA.POSTCODE, '').toLowerCase()}${r.DPA.POSTCODE}`,
-    premises: r.DPA.BUILDING_NAME || '',
+    premises: r.DPA.BUILDING_NAME || r.DPA.BUILDING_NUMBER || '',
     street: r.DPA.THOROUGHFARE_NAME || '',
     locality: r.DPA.DEPENDENT_LOCALITY || '',
     town: r.DPA.POST_TOWN || '',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-5100

This bug is not on production yet, but must be fixed before we can do a release.

When we use the address lookup to find an address, we can select an address by its house number or premises, but this field is then not being saved to the permission. This means that when we try to create a transaction in DynamoDb before taking payment, the permission fails validation and the journey cannot be continued.

We need to make sure the premises field is being set correctly, and test that the full journey works afterwards and the full address is being saved to the CRM. Unit tests should also be written to cover this.