### PR TITLE
RP cancellation journey allows same agreement to be cancelled twice

### DIFF
--- a/packages/gafl-webapp-service/src/handlers/__tests__/cancel-recurring-payment-authentication-handler.spec.js
+++ b/packages/gafl-webapp-service/src/handlers/__tests__/cancel-recurring-payment-authentication-handler.spec.js
@@ -193,10 +193,13 @@ describe('Cancel RP Authentication Handler', () => {
     })
   })
 
-  describe('Unsuccessful authentication - RCP already cancelled', () => {
+  describe.each([
+    ['cancelledDate', { cancelledDate: '2024-01-01' }],
+    ['cancelledReason', { cancelledReason: { label: 'User Cancelled' } }]
+  ])('Unsuccessful authentication - RCP has a %s', (_field, data) => {
     it('redirects to the CANCEL_RP_ALREADY_CANCELLED.uri', async () => {
       const { h } = await invokeHandlerWithMocks({
-        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, cancelledDate: '2024-01-01' } }
+        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, ...data } }
       })
       expect(h.redirectWithLanguageCode).toHaveBeenCalledWith(CANCEL_RP_ALREADY_CANCELLED.uri)
     })
@@ -207,14 +210,14 @@ describe('Cancel RP Authentication Handler', () => {
       h.redirectWithLanguageCode.mockReturnValueOnce(redirectResult)
       const { result } = await invokeHandlerWithMocks({
         h,
-        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, cancelledDate: '2024-01-01' } }
+        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, ...data } }
       })
       expect(result).toBe(redirectResult)
     })
 
     it('sets page cache for RCP already cancelled', async () => {
       const { request } = await invokeHandlerWithMocks({
-        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, cancelledDate: '2024-01-01' } }
+        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, ...data } }
       })
       expect(request.cache().helpers.page.setCurrentPermission).toHaveBeenCalledWith(
         CANCEL_RP_IDENTIFY.page,
@@ -227,7 +230,7 @@ describe('Cancel RP Authentication Handler', () => {
 
     it('marks status as unauthorised', async () => {
       const { request } = await invokeHandlerWithMocks({
-        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, cancelledDate: '2024-01-01' } }
+        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, ...data } }
       })
       expect(request.cache().helpers.status.setCurrentPermission).toHaveBeenCalledWith(
         expect.objectContaining({ authentication: { authorised: false } })
@@ -236,7 +239,7 @@ describe('Cancel RP Authentication Handler', () => {
 
     it('sets currentPage to error page name', async () => {
       const { request } = await invokeHandlerWithMocks({
-        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, cancelledDate: '2024-01-01' } }
+        salesApiResponse: { permission: { id: 'perm-id' }, recurringPayment: { id: 'rcp-id', status: 1, ...data } }
       })
       expect(request.cache().helpers.status.setCurrentPermission).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/gafl-webapp-service/src/handlers/cancel-recurring-payment-authentication-handler.js
+++ b/packages/gafl-webapp-service/src/handlers/cancel-recurring-payment-authentication-handler.js
@@ -48,7 +48,7 @@ const cancelRecurringPaymentAuthenticationHandler = async (request, h) => {
     context.pageData.errorRedirect = true
     context.redirectUri = CANCEL_RP_AGREEMENT_NOT_FOUND.uri
     context.errorPageName = CANCEL_RP_AGREEMENT_NOT_FOUND.page
-  } else if (authenticationResult.recurringPayment.cancelledDate) {
+  } else if (recurringPaymentAlreadyCancelled(authenticationResult.recurringPayment)) {
     context.pageData.errorRedirect = true
     context.redirectUri = CANCEL_RP_ALREADY_CANCELLED.uri
     context.errorPageName = CANCEL_RP_ALREADY_CANCELLED.page
@@ -70,5 +70,7 @@ const cancelRecurringPaymentAuthenticationHandler = async (request, h) => {
 
   return h.redirectWithLanguageCode(CANCEL_RP_DETAILS.uri)
 }
+
+const recurringPaymentAlreadyCancelled = rp => rp.cancelledDate || rp.cancelledReason
 
 export default cancelRecurringPaymentAuthenticationHandler


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-5124

Currently the recurring payments cancellation journey lets you cancel an agreement that has already been cancelled. This could cause confusion for the user as to whether their agreement was actually cancelled or not. Instead we should display a message telling them the agreement has previously been cancelled.