### PR TITLE
SEMVER-PATCH : Release v1.70.1, RELEASE_TYPE=minor

### DIFF
--- a/packages/sales-api-service/src/services/renewals/__tests__/renewals.service.spec.js
+++ b/packages/sales-api-service/src/services/renewals/__tests__/renewals.service.spec.js
@@ -162,12 +162,12 @@ describe('preparePermissionDataForRenewal', () => {
     })
 
     it("doesn't add senior concession if the licensee turns 66 during the licence period but is 65 at the start", async () => {
-      const startDate = moment()
-      const birthDate = moment(startDate).subtract(65, 'years').subtract(6, 'months').format('YYYY-MM-DD')
+      const endDate = moment('2026-05-11')
       const almostSeniorPermission = existingPermission({
+        endDate,
         licensee: {
           ...existingPermission().licensee,
-          birthDate
+          birthDate: '1960-09-01'
         }
       })
       const permission = await preparePermissionDataForRenewal(almostSeniorPermission)

--- a/packages/sales-api-service/src/services/renewals/__tests__/renewals.service.spec.js
+++ b/packages/sales-api-service/src/services/renewals/__tests__/renewals.service.spec.js
@@ -161,6 +161,19 @@ describe('preparePermissionDataForRenewal', () => {
       expect(permission.concessions).toEqual([])
     })
 
+    it("doesn't add senior concession if the licensee turns 66 during the licence period but is 65 at the start", async () => {
+      const startDate = moment()
+      const birthDate = moment(startDate).subtract(65, 'years').subtract(6, 'months').format('YYYY-MM-DD')
+      const almostSeniorPermission = existingPermission({
+        licensee: {
+          ...existingPermission().licensee,
+          birthDate
+        }
+      })
+      const permission = await preparePermissionDataForRenewal(almostSeniorPermission)
+      expect(permission.concessions).toEqual([])
+    })
+
     it('should remove noLicenceRequired from licensee', async () => {
       const permission = existingPermission()
       permission.licensee.noLicenceRequired = true

--- a/packages/sales-api-service/src/services/renewals/__tests__/renewals.service.spec.js
+++ b/packages/sales-api-service/src/services/renewals/__tests__/renewals.service.spec.js
@@ -161,13 +161,17 @@ describe('preparePermissionDataForRenewal', () => {
       expect(permission.concessions).toEqual([])
     })
 
-    it("doesn't add senior concession if the licensee turns 66 during the licence period but is 65 at the start", async () => {
+    it.each([
+      ['1960-09-01', 'turns 66 in < 6 months'],
+      ['1960-05-13', 'turns 66 the day after licence start'],
+      ['1960-12-25', 'turns 66 in > 6 months']
+    ])("doesn't add senior concession if the licensee is 65 at licence start (DOB: %s, %s)", async birthDate => {
       const endDate = moment('2026-05-11')
       const almostSeniorPermission = existingPermission({
         endDate,
         licensee: {
           ...existingPermission().licensee,
-          birthDate: '1960-09-01'
+          birthDate
         }
       })
       const permission = await preparePermissionDataForRenewal(almostSeniorPermission)

--- a/packages/sales-api-service/src/services/renewals/renewals.service.js
+++ b/packages/sales-api-service/src/services/renewals/renewals.service.js
@@ -97,9 +97,7 @@ const preparePermit = async existingPermission => {
 
 const prepareConcessionsData = async (existingPermission, dateData) => {
   delete existingPermission.licensee.noLicenceRequired
-  const ageAtLicenceStartDate = moment(dateData.licenceStartDate)
-    .add(1, 'year')
-    .diff(moment(existingPermission.licensee.birthDate), 'years')
+  const ageAtLicenceStartDate = moment(dateData.licenceStartDate).diff(moment(existingPermission.licensee.birthDate), 'years')
 
   if (isSenior(ageAtLicenceStartDate)) {
     await addSenior(existingPermission)


### PR DESCRIPTION
Users reaching close to senior status are incorrectly being labelled as senior when renewing their licence.