### PR TITLE
Corrected link colours in RCP journey

### DIFF
--- a/packages/gafl-webapp-service/src/pages/recurring-payments/cancel/already-cancelled/cancel-rp-already-cancelled.njk
+++ b/packages/gafl-webapp-service/src/pages/recurring-payments/cancel/already-cancelled/cancel-rp-already-cancelled.njk
@@ -14,9 +14,9 @@
     </p>
     <p class="govuk-body">
       {{ mssgs.rp_licence_already_cancelled_body_2_1 }}
-      <a href="mailto:enquiries@environment-agency.gov.uk"> {{ mssgs.rp_licence_already_cancelled_body_ea_link }}</a>
+      <a class="govuk-link" href="mailto:enquiries@environment-agency.gov.uk"> {{ mssgs.rp_licence_already_cancelled_body_ea_link }}</a>
       {{ mssgs.rp_licence_already_cancelled_body_2_2 }}
-      <a href="https://www.gov.uk/call-charges" target="_blank" rel="noopener"> {{ mssgs.licence_not_found_rp_body_call_charges_link }}</a>{{ mssgs.full_stop }}
+      <a class="govuk-link" href="https://www.gov.uk/call-charges" target="_blank" rel="noopener"> {{ mssgs.licence_not_found_rp_body_call_charges_link }}</a>{{ mssgs.full_stop }}
     </p>
     <p class="govuk-body">
       <a class="govuk-link" href="{{ backRef }}"> {{ mssgs.rp_licence_already_cancelled_body_3_1 }}

--- a/packages/gafl-webapp-service/src/pages/recurring-payments/cancel/complete/cancel-rp-complete.njk
+++ b/packages/gafl-webapp-service/src/pages/recurring-payments/cancel/complete/cancel-rp-complete.njk
@@ -15,7 +15,7 @@
       <p class="govuk-body">{{ mssgs.rp_cancel_complete_body_1 }}{{ data.preferredMethodOfContact }}</p>
       <p class="govuk-body">
         {{ mssgs.rp_cancel_complete_body_2_1 }} {{ data.licenceExpiry }} {{ mssgs.rp_cancel_complete_body_2_2 }}
-        <a href="https://www.gov.uk/fishing-licences/buy-a-fishing-licence" target="_blank" rel="noopener">{{ mssgs.rp_cancel_complete_body_2_link }}</a>.
+        <a class="govuk-link" href="https://www.gov.uk/fishing-licences/buy-a-fishing-licence" target="_blank" rel="noopener">{{ mssgs.rp_cancel_complete_body_2_link }}</a>.
       </p>
       <h2 class="govuk-heading-m">{{ mssgs.rp_cancel_complete_body_3_header }}</h2>
       <p class="govuk-body">
@@ -26,7 +26,7 @@
           <a href="https://www.smartsurvey.co.uk/s/1IB0U5/" class="govuk-link" target="_blank" rel="noopener">{{ mssgs.rp_cancel_complete_body_3_bulletpoint_1_link }}</a>
           - {{ mssgs.rp_cancel_complete_body_3_bulletpoint_1 }}</li>
         <li>
-          <a href="https://www.gov.uk/government/collections/fisheries-annual-reports" target="_blank" rel="noopener">{{ mssgs.rp_cancel_complete_body_3_bulletpoint_2_link }}</a>
+          <a class="govuk-link" href="https://www.gov.uk/government/collections/fisheries-annual-reports" target="_blank" rel="noopener">{{ mssgs.rp_cancel_complete_body_3_bulletpoint_2_link }}</a>
           {{ mssgs.rp_cancel_complete_body_3_bulletpoint_2 }}</li>
       </ul>
     </div>

--- a/packages/gafl-webapp-service/src/pages/recurring-payments/cancel/licence-not-found/cancel-rp-licence-not-found.njk
+++ b/packages/gafl-webapp-service/src/pages/recurring-payments/cancel/licence-not-found/cancel-rp-licence-not-found.njk
@@ -15,10 +15,10 @@
       {{ mssgs.licence_not_found_rp_body_2 }}
       </p>
       <ul class="govuk-list govuk-list--bullet">
-        <li> {{ mssgs.licence_not_found_rp_bullet_point_1 }} <a href="mailto:enquiries@environment-agency.gov.uk"> {{ mssgs.licence_not_found_rp_body_ea_link }}
+        <li> {{ mssgs.licence_not_found_rp_bullet_point_1 }} <a class="govuk-link" href="mailto:enquiries@environment-agency.gov.uk"> {{ mssgs.licence_not_found_rp_body_ea_link }}
         </a> {{ mssgs.licence_not_found_rp_bullet_point_1_2 }} </li>
 
-        <li> {{ mssgs.licence_not_found_rp_bullet_point_2 }} <a href="https://www.gov.uk/call-charges" target="_blank" rel="noopener"> {{ mssgs.licence_not_found_rp_body_call_charges_link }}
+        <li> {{ mssgs.licence_not_found_rp_bullet_point_2 }} <a class="govuk-link" href="https://www.gov.uk/call-charges" target="_blank" rel="noopener"> {{ mssgs.licence_not_found_rp_body_call_charges_link }}
         </a>{{ mssgs.full_stop }} </li>
       </ul>
     


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-5123

Links in various pages of the cancellation journey are not in the correct colours per the Design System. This is in both the English and Welsh journeys. The bright blue below is not correct.